### PR TITLE
adds christmas eve to list of US holidays

### DIFF
--- a/data/holidays.json
+++ b/data/holidays.json
@@ -8851,6 +8851,10 @@
           },
           "type": "observance"
         },
+        "12-24": {
+            "_name": "12-24",
+            "type": "optional"
+        },
         "12-25 and if sunday then next monday if saturday then previous friday": {
           "substitute": true,
           "_name": "12-25"

--- a/data/holidays.yaml
+++ b/data/holidays.yaml
@@ -6243,6 +6243,9 @@ holidays:
         name:
           en: Day after Thanksgiving Day
         type: observance
+      12-24:
+        _name: 12-24
+        type: optional
       12-25 and if sunday then next monday if saturday then previous friday:
         substitute: true
         _name: 12-25


### PR DESCRIPTION
This PR adds Christmas eve as an optional holiday for the US.