### PR TITLE
fix wrong type for NYE

### DIFF
--- a/data/holidays.json
+++ b/data/holidays.json
@@ -8857,7 +8857,7 @@
         },
         "12-31 18:00": {
           "_name": "12-31",
-          "type": "observed"
+          "type": "observance"
         }
       },
       "states": {

--- a/data/holidays.yaml
+++ b/data/holidays.yaml
@@ -6248,7 +6248,7 @@ holidays:
         _name: 12-25
       12-31 18:00:
         _name: 12-31
-        type: observed
+        type: observance
     states:
       al:
         name: Alabama


### PR DESCRIPTION
This PR fixes the holiday type for new year's eve. The incorrect value was causing it not to be listed as a holiday.

Two quick questions:

1. Is there a true difference between the optional and observance types?
2. When making a change to `holidays.yaml`, there appeared to be no effect.  However, the change to `holidays.json` did. Is the YAML version unused?

Thanks!