### PR TITLE
A new holiday for Turkey

### DIFF
--- a/data/countries/TR.yaml
+++ b/data/countries/TR.yaml
@@ -26,6 +26,10 @@ holidays:
         name:
           en: Commemoration of Atatürk, Youth and Sports Day
           tr: Atatürk'ü Anma Gençlik ve Spor Bayramı
+      07-15:
+        name:
+          en: Democracy and National Unity Day
+          tr: Demokrasi ve Millî Birlik Günü
       08-30:
         name:
           en: Victory Day

--- a/data/holidays.json
+++ b/data/holidays.json
@@ -1,5 +1,5 @@
 {
-  "version": "2018-04-14",
+  "version": "2018-07-27",
   "license": "CC-BY-SA-3",
   "holidays": {
     "AD": {
@@ -12123,6 +12123,12 @@
             "tr": "Atatürk'ü Anma Gençlik ve Spor Bayramı"
           }
         },
+        "07-15": {
+          "name": {
+            "en": "Democracy and National Unity Day",
+            "tr": "Demokrasi ve Millî Birlik Günü"
+          }
+        },
         "08-30": {
           "name": {
             "en": "Victory Day",
@@ -15178,7 +15184,7 @@
         "nl": "Suikerfeest (Eid al-Fitr)",
         "mk": "Рамазан Бајрам",
         "sq": "Fitër Bajrami",
-        "tr": "Bayramı",
+        "tr": "Ramazan Bayramı",
         "sr": "Рамазански Бајрам",
         "sw": "Idd-ul-Fitr"
       }

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -635,7 +635,7 @@ names:
       nl: Suikerfeest (Eid al-Fitr)
       mk: Рамазан Бајрам
       sq: Fitër Bajrami
-      tr: Bayramı
+      tr: Ramazan Bayramı
       sr: Рамазански Бајрам
       sw: Idd-ul-Fitr
   10 Dhu al-Hijjah: # Feast of the Sacrifice

--- a/test/fixtures/TR-2015.json
+++ b/test/fixtures/TR-2015.json
@@ -31,11 +31,19 @@
     "type": "public",
     "_weekday": "Tue"
   },
+  { 
+    "date": "2015-07-15 00:00:00",
+    "start": "2015-07-14T21:00:00.000Z",
+    "end": "2015-07-15T21:00:00.000Z",
+    "name": "Demokrasi ve Millî Birlik Günü",
+    "type": "public",
+    "_weekday": "Wed" 
+  },
   {
     "date": "2015-07-17 00:00:00 -0600",
     "start": "2015-07-16T15:00:00.000Z",
     "end": "2015-07-20T09:00:00.000Z",
-    "name": "Bayramı",
+    "name": "Ramazan Bayramı",
     "type": "public",
     "_weekday": "Fri"
   },

--- a/test/fixtures/TR-2016.json
+++ b/test/fixtures/TR-2016.json
@@ -35,9 +35,17 @@
     "date": "2016-07-06 00:00:00 -0600",
     "start": "2016-07-05T15:00:00.000Z",
     "end": "2016-07-09T09:00:00.000Z",
-    "name": "Bayramı",
+    "name": "Ramazan Bayramı",
     "type": "public",
     "_weekday": "Wed"
+  },
+  { 
+    "date": "2016-07-15 00:00:00",
+    "start": "2016-07-14T21:00:00.000Z",
+    "end": "2016-07-15T21:00:00.000Z",
+    "name": "Demokrasi ve Millî Birlik Günü",
+    "type": "public",
+    "_weekday": "Fri" 
   },
   {
     "date": "2016-08-30 00:00:00",

--- a/test/fixtures/TR-2017.json
+++ b/test/fixtures/TR-2017.json
@@ -35,9 +35,17 @@
     "date": "2017-06-25 00:00:00 -0600",
     "start": "2017-06-24T15:00:00.000Z",
     "end": "2017-06-28T09:00:00.000Z",
-    "name": "Bayramı",
+    "name": "Ramazan Bayramı",
     "type": "public",
     "_weekday": "Sun"
+  },
+  { 
+    "date": "2017-07-15 00:00:00",
+    "start": "2017-07-14T21:00:00.000Z",
+    "end": "2017-07-15T21:00:00.000Z",
+    "name": "Demokrasi ve Millî Birlik Günü",
+    "type": "public",
+    "_weekday": "Sat" 
   },
   {
     "date": "2017-08-30 00:00:00",

--- a/test/fixtures/TR-2018.json
+++ b/test/fixtures/TR-2018.json
@@ -35,9 +35,17 @@
     "date": "2018-06-15 00:00:00 -0600",
     "start": "2018-06-14T15:00:00.000Z",
     "end": "2018-06-18T09:00:00.000Z",
-    "name": "Bayramı",
+    "name": "Ramazan Bayramı",
     "type": "public",
     "_weekday": "Fri"
+  },
+  { 
+    "date": "2018-07-15 00:00:00",
+    "start": "2018-07-14T21:00:00.000Z",
+    "end": "2018-07-15T21:00:00.000Z",
+    "name": "Demokrasi ve Millî Birlik Günü",
+    "type": "public",
+    "_weekday": "Sun" 
   },
   {
     "date": "2018-08-21 00:00:00 -0600",

--- a/test/fixtures/TR-2019.json
+++ b/test/fixtures/TR-2019.json
@@ -35,9 +35,17 @@
     "date": "2019-06-04 00:00:00 -0600",
     "start": "2019-06-03T15:00:00.000Z",
     "end": "2019-06-07T09:00:00.000Z",
-    "name": "Bayramı",
+    "name": "Ramazan Bayramı",
     "type": "public",
     "_weekday": "Tue"
+  },
+  { 
+    "date": "2019-07-15 00:00:00",
+    "start": "2019-07-14T21:00:00.000Z",
+    "end": "2019-07-15T21:00:00.000Z",
+    "name": "Demokrasi ve Millî Birlik Günü",
+    "type": "public",
+    "_weekday": "Mon" 
   },
   {
     "date": "2019-08-11 00:00:00 -0600",

--- a/test/fixtures/TR-2020.json
+++ b/test/fixtures/TR-2020.json
@@ -35,9 +35,17 @@
     "date": "2020-05-24 00:00:00 -0600",
     "start": "2020-05-23T15:00:00.000Z",
     "end": "2020-05-27T09:00:00.000Z",
-    "name": "Bayramı",
+    "name": "Ramazan Bayramı",
     "type": "public",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2020-07-15 00:00:00",
+    "start": "2020-07-14T21:00:00.000Z",
+    "end": "2020-07-15T21:00:00.000Z",
+    "name": "Demokrasi ve Millî Birlik Günü",
+    "type": "public",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-07-31 00:00:00 -0600",


### PR DESCRIPTION
A new holiday is added for Turkey after 15.07.2016. You can check at https://en.wikipedia.org/wiki/Public_holidays_in_Turkey .

Also Turkish name of an islamic holiday name was wrong. It is fixed.

Lastly, test fixtures are updated.