### PR TITLE
Fixes and more consistency for Norwegian holidays

### DIFF
--- a/data/countries/NO.yaml
+++ b/data/countries/NO.yaml
@@ -27,6 +27,8 @@ holidays:
         _name: easter -3
       easter -2:
         _name: easter -2
+      easter -1:
+        _name: easter -1
       easter:
         _name: easter
       easter 1:
@@ -35,11 +37,12 @@ holidays:
         _name: 05-01
       05-08:
         name:
-          no: Frigjøringsdag 1945
+          no: Frigjøringsdagen
           en: Liberation Day
-        type: observance
       05-17:
-        _name: Constitution Day
+        name:
+          no: 17. mai
+          en: Constitution Day
       easter 39:
         _name: easter 39
       easter 49:
@@ -51,9 +54,28 @@ holidays:
           no: Sankthansaften
           en: Midsummar Eve
         type: observance
+      2nd sunday in November:
+        _name: Fathers Day
+        type: observance
       4th sunday before 12-24:
         name:
           no: Første søndag i advent
+          en: First Sunday of Advent
+        type: observance
+      3rd sunday before 12-24:
+        name:
+          no: Andre søndag i advent
+          en: Second Sunday of Advent
+        type: observance
+      2nd sunday before 12-24:
+        name:
+          no: Tredje søndag i advent
+          en: Third Sunday of Advent
+        type: observance
+      1st sunday before 12-24:
+        name:
+          no: Fjerde søndag i advent
+          en: Fourth Sunday of Advent
         type: observance
       12-24:
         _name: 12-24

--- a/data/holidays.json
+++ b/data/holidays.json
@@ -1,5 +1,5 @@
 {
-  "version": "2018-07-28",
+  "version": "2018-08-27",
   "license": "CC-BY-SA-3",
   "holidays": {
     "AD": {
@@ -10205,6 +10205,9 @@
         "easter -2": {
           "_name": "easter -2"
         },
+        "easter -1": {
+          "_name": "easter -1"
+        },
         "easter": {
           "_name": "easter"
         },
@@ -10212,17 +10215,22 @@
           "_name": "easter 1"
         },
         "05-01": {
-          "_name": "05-01"
+          "name": {
+            "no": "Arbeidernes dag",
+            "en": "Labour Day"
+          }
         },
         "05-08": {
           "name": {
-            "no": "Frigjøringsdag 1945",
+            "no": "Frigjøringsdagen",
             "en": "Liberation Day"
-          },
-          "type": "observance"
+          }
         },
         "05-17": {
-          "_name": "Constitution Day"
+          "name": {
+            "no": "17.mai",
+            "en": "Constitution Day"
+          }
         },
         "easter 39": {
           "_name": "easter 39"
@@ -10240,9 +10248,35 @@
           },
           "type": "observance"
         },
+        "2nd sunday in November": {
+          "_name": "Fathers Day",
+          "type": "observance"
+        },
         "4th sunday before 12-24": {
           "name": {
-            "no": "Første søndag i advent"
+            "no": "Første søndag i advent",
+            "en": "First Sunday of Advent"
+          },
+          "type": "observance"
+        },
+        "3rd sunday before 12-24": {
+          "name": {
+            "no": "Andre søndag i advent",
+            "en": "Second Sunday of Advent"
+          },
+          "type": "observance"
+        },
+        "2nd sunday before 12-24": {
+          "name": {
+            "no": "Tredje søndag i advent",
+            "en": "Third Sunday of Advent"
+          },
+          "type": "observance"
+        },
+        "1st sunday before 12-24": {
+          "name": {
+            "no": "Fjerde søndag i advent",
+            "en": "Fourth Sunday of Advent"
           },
           "type": "observance"
         },
@@ -14957,7 +14991,8 @@
         "de": "Karsamstag",
         "es": "Sabado Santo",
         "fr": "Samedi saint",
-        "it": "Sabado santo"
+        "it": "Sabado santo",
+        "no": "Påskeaften"
       }
     },
     "easter": {
@@ -15319,7 +15354,8 @@
         "et": "isadepäev",
         "lt": "Tėvo diena",
         "nl": "Vaderdag",
-        "pt": "Dia dos Pais"
+        "pt": "Dia dos Pais",
+        "no": "Farsdag"
       }
     },
     "Independence Day": {

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -138,7 +138,7 @@ names:
       lt: Tarptautinė darbo diena
       lv: Darba svētki
       nl: Dag van de Arbeid
-      no: Første mai
+      no: Arbeidernes dag
       mg: Fetin'ny asa
       mk: Ден на трудот
       mt: Jum il-Ħaddiem
@@ -436,6 +436,7 @@ names:
       es: Sabado Santo
       fr: Samedi saint
       it: Sabado santo
+      no: Påskeaften
   easter:     # Easter
     name:
       en: Easter Sunday
@@ -749,6 +750,7 @@ names:
       lt: Tėvo diena
       nl: Vaderdag
       pt: Dia dos Pais
+      no: Farsdag
   Independence Day:
     name:
       en: Independence Day

--- a/test/fixtures/NO-2015.json
+++ b/test/fixtures/NO-2015.json
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2015-04-04 00:00:00",
+    "start": "2015-04-03T22:00:00.000Z",
+    "end": "2015-04-04T22:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-05 00:00:00",
     "start": "2015-04-04T22:00:00.000Z",
     "end": "2015-04-05T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Fri"
   },
@@ -75,8 +83,8 @@
     "date": "2015-05-08 00:00:00",
     "start": "2015-05-07T22:00:00.000Z",
     "end": "2015-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -91,7 +99,7 @@
     "date": "2015-05-17 00:00:00",
     "start": "2015-05-16T22:00:00.000Z",
     "end": "2015-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Sun"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2015-11-08 00:00:00",
+    "start": "2015-11-07T23:00:00.000Z",
+    "end": "2015-11-08T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-11-29 00:00:00",
     "start": "2015-11-28T23:00:00.000Z",
     "end": "2015-11-29T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-06 00:00:00",
+    "start": "2015-12-05T23:00:00.000Z",
+    "end": "2015-12-06T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-13 00:00:00",
+    "start": "2015-12-12T23:00:00.000Z",
+    "end": "2015-12-13T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-20 00:00:00",
+    "start": "2015-12-19T23:00:00.000Z",
+    "end": "2015-12-20T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/NO-2016.json
+++ b/test/fixtures/NO-2016.json
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2016-03-26 00:00:00",
+    "start": "2016-03-25T23:00:00.000Z",
+    "end": "2016-03-26T23:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-03-27 00:00:00",
     "start": "2016-03-26T23:00:00.000Z",
     "end": "2016-03-27T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Sun"
   },
@@ -83,8 +91,8 @@
     "date": "2016-05-08 00:00:00",
     "start": "2016-05-07T22:00:00.000Z",
     "end": "2016-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
@@ -107,7 +115,7 @@
     "date": "2016-05-17 00:00:00",
     "start": "2016-05-16T22:00:00.000Z",
     "end": "2016-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Tue"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2016-11-13 00:00:00",
+    "start": "2016-11-12T23:00:00.000Z",
+    "end": "2016-11-13T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-11-27 00:00:00",
     "start": "2016-11-26T23:00:00.000Z",
     "end": "2016-11-27T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-04 00:00:00",
+    "start": "2016-12-03T23:00:00.000Z",
+    "end": "2016-12-04T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-11 00:00:00",
+    "start": "2016-12-10T23:00:00.000Z",
+    "end": "2016-12-11T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-18 00:00:00",
+    "start": "2016-12-17T23:00:00.000Z",
+    "end": "2016-12-18T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/NO-2017.json
+++ b/test/fixtures/NO-2017.json
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2017-04-15 00:00:00",
+    "start": "2017-04-14T22:00:00.000Z",
+    "end": "2017-04-15T22:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2017-04-16 00:00:00",
     "start": "2017-04-15T22:00:00.000Z",
     "end": "2017-04-16T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,15 +83,15 @@
     "date": "2017-05-08 00:00:00",
     "start": "2017-05-07T22:00:00.000Z",
     "end": "2017-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Mon"
   },
   {
     "date": "2017-05-17 00:00:00",
     "start": "2017-05-16T22:00:00.000Z",
     "end": "2017-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Wed"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2017-11-12 00:00:00",
+    "start": "2017-11-11T23:00:00.000Z",
+    "end": "2017-11-12T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-11-26 00:00:00",
     "start": "2017-11-25T23:00:00.000Z",
     "end": "2017-11-26T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-12-03 00:00:00",
+    "start": "2017-12-02T23:00:00.000Z",
+    "end": "2017-12-03T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-12-10 00:00:00",
+    "start": "2017-12-09T23:00:00.000Z",
+    "end": "2017-12-10T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-12-17 00:00:00",
+    "start": "2017-12-16T23:00:00.000Z",
+    "end": "2017-12-17T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/NO-2018.json
+++ b/test/fixtures/NO-2018.json
@@ -11,7 +11,7 @@
     "date": "2018-02-11 00:00:00",
     "start": "2018-02-10T23:00:00.000Z",
     "end": "2018-02-11T23:00:00.000Z",
-    "name": "Fastelavn",
+    "name": "Morsdag",
     "type": "observance",
     "_weekday": "Sun"
   },
@@ -19,7 +19,7 @@
     "date": "2018-02-11 00:00:00",
     "start": "2018-02-10T23:00:00.000Z",
     "end": "2018-02-11T23:00:00.000Z",
-    "name": "Morsdag",
+    "name": "Fastelavn",
     "type": "observance",
     "_weekday": "Sun"
   },
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2018-03-31 00:00:00",
+    "start": "2018-03-30T22:00:00.000Z",
+    "end": "2018-03-31T22:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2018-04-01 00:00:00",
     "start": "2018-03-31T22:00:00.000Z",
     "end": "2018-04-01T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Tue"
   },
@@ -75,8 +83,8 @@
     "date": "2018-05-08 00:00:00",
     "start": "2018-05-07T22:00:00.000Z",
     "end": "2018-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Tue"
   },
   {
@@ -91,7 +99,7 @@
     "date": "2018-05-17 00:00:00",
     "start": "2018-05-16T22:00:00.000Z",
     "end": "2018-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Thu"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2018-11-11 00:00:00",
+    "start": "2018-11-10T23:00:00.000Z",
+    "end": "2018-11-11T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-12-02 00:00:00",
     "start": "2018-12-01T23:00:00.000Z",
     "end": "2018-12-02T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-12-09 00:00:00",
+    "start": "2018-12-08T23:00:00.000Z",
+    "end": "2018-12-09T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-12-16 00:00:00",
+    "start": "2018-12-15T23:00:00.000Z",
+    "end": "2018-12-16T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-12-23 00:00:00",
+    "start": "2018-12-22T23:00:00.000Z",
+    "end": "2018-12-23T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/NO-2019.json
+++ b/test/fixtures/NO-2019.json
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2019-04-20 00:00:00",
+    "start": "2019-04-19T22:00:00.000Z",
+    "end": "2019-04-20T22:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2019-04-21 00:00:00",
     "start": "2019-04-20T22:00:00.000Z",
     "end": "2019-04-21T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Wed"
   },
@@ -75,15 +83,15 @@
     "date": "2019-05-08 00:00:00",
     "start": "2019-05-07T22:00:00.000Z",
     "end": "2019-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Wed"
   },
   {
     "date": "2019-05-17 00:00:00",
     "start": "2019-05-16T22:00:00.000Z",
     "end": "2019-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Fri"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2019-11-10 00:00:00",
+    "start": "2019-11-09T23:00:00.000Z",
+    "end": "2019-11-10T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-12-01 00:00:00",
     "start": "2019-11-30T23:00:00.000Z",
     "end": "2019-12-01T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-12-08 00:00:00",
+    "start": "2019-12-07T23:00:00.000Z",
+    "end": "2019-12-08T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-12-15 00:00:00",
+    "start": "2019-12-14T23:00:00.000Z",
+    "end": "2019-12-15T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-12-22 00:00:00",
+    "start": "2019-12-21T23:00:00.000Z",
+    "end": "2019-12-22T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/NO-2020.json
+++ b/test/fixtures/NO-2020.json
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2020-04-11 00:00:00",
+    "start": "2020-04-10T22:00:00.000Z",
+    "end": "2020-04-11T22:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-12 00:00:00",
     "start": "2020-04-11T22:00:00.000Z",
     "end": "2020-04-12T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Fri"
   },
@@ -75,15 +83,15 @@
     "date": "2020-05-08 00:00:00",
     "start": "2020-05-07T22:00:00.000Z",
     "end": "2020-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
     "date": "2020-05-17 00:00:00",
     "start": "2020-05-16T22:00:00.000Z",
     "end": "2020-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Sun"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2020-11-08 00:00:00",
+    "start": "2020-11-07T23:00:00.000Z",
+    "end": "2020-11-08T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-11-29 00:00:00",
     "start": "2020-11-28T23:00:00.000Z",
     "end": "2020-11-29T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-06 00:00:00",
+    "start": "2020-12-05T23:00:00.000Z",
+    "end": "2020-12-06T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-13 00:00:00",
+    "start": "2020-12-12T23:00:00.000Z",
+    "end": "2020-12-13T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-20 00:00:00",
+    "start": "2020-12-19T23:00:00.000Z",
+    "end": "2020-12-20T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SJ-2015.json
+++ b/test/fixtures/SJ-2015.json
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2015-04-04 00:00:00",
+    "start": "2015-04-03T22:00:00.000Z",
+    "end": "2015-04-04T22:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-05 00:00:00",
     "start": "2015-04-04T22:00:00.000Z",
     "end": "2015-04-05T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Fri"
   },
@@ -75,8 +83,8 @@
     "date": "2015-05-08 00:00:00",
     "start": "2015-05-07T22:00:00.000Z",
     "end": "2015-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -91,7 +99,7 @@
     "date": "2015-05-17 00:00:00",
     "start": "2015-05-16T22:00:00.000Z",
     "end": "2015-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Sun"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2015-11-08 00:00:00",
+    "start": "2015-11-07T23:00:00.000Z",
+    "end": "2015-11-08T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-11-29 00:00:00",
     "start": "2015-11-28T23:00:00.000Z",
     "end": "2015-11-29T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-06 00:00:00",
+    "start": "2015-12-05T23:00:00.000Z",
+    "end": "2015-12-06T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-13 00:00:00",
+    "start": "2015-12-12T23:00:00.000Z",
+    "end": "2015-12-13T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-20 00:00:00",
+    "start": "2015-12-19T23:00:00.000Z",
+    "end": "2015-12-20T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SJ-2016.json
+++ b/test/fixtures/SJ-2016.json
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2016-03-26 00:00:00",
+    "start": "2016-03-25T23:00:00.000Z",
+    "end": "2016-03-26T23:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-03-27 00:00:00",
     "start": "2016-03-26T23:00:00.000Z",
     "end": "2016-03-27T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Sun"
   },
@@ -83,8 +91,8 @@
     "date": "2016-05-08 00:00:00",
     "start": "2016-05-07T22:00:00.000Z",
     "end": "2016-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
@@ -107,7 +115,7 @@
     "date": "2016-05-17 00:00:00",
     "start": "2016-05-16T22:00:00.000Z",
     "end": "2016-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Tue"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2016-11-13 00:00:00",
+    "start": "2016-11-12T23:00:00.000Z",
+    "end": "2016-11-13T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-11-27 00:00:00",
     "start": "2016-11-26T23:00:00.000Z",
     "end": "2016-11-27T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-04 00:00:00",
+    "start": "2016-12-03T23:00:00.000Z",
+    "end": "2016-12-04T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-11 00:00:00",
+    "start": "2016-12-10T23:00:00.000Z",
+    "end": "2016-12-11T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-18 00:00:00",
+    "start": "2016-12-17T23:00:00.000Z",
+    "end": "2016-12-18T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SJ-2017.json
+++ b/test/fixtures/SJ-2017.json
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2017-04-15 00:00:00",
+    "start": "2017-04-14T22:00:00.000Z",
+    "end": "2017-04-15T22:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2017-04-16 00:00:00",
     "start": "2017-04-15T22:00:00.000Z",
     "end": "2017-04-16T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,15 +83,15 @@
     "date": "2017-05-08 00:00:00",
     "start": "2017-05-07T22:00:00.000Z",
     "end": "2017-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Mon"
   },
   {
     "date": "2017-05-17 00:00:00",
     "start": "2017-05-16T22:00:00.000Z",
     "end": "2017-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Wed"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2017-11-12 00:00:00",
+    "start": "2017-11-11T23:00:00.000Z",
+    "end": "2017-11-12T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-11-26 00:00:00",
     "start": "2017-11-25T23:00:00.000Z",
     "end": "2017-11-26T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-12-03 00:00:00",
+    "start": "2017-12-02T23:00:00.000Z",
+    "end": "2017-12-03T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-12-10 00:00:00",
+    "start": "2017-12-09T23:00:00.000Z",
+    "end": "2017-12-10T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-12-17 00:00:00",
+    "start": "2017-12-16T23:00:00.000Z",
+    "end": "2017-12-17T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SJ-2018.json
+++ b/test/fixtures/SJ-2018.json
@@ -11,7 +11,7 @@
     "date": "2018-02-11 00:00:00",
     "start": "2018-02-10T23:00:00.000Z",
     "end": "2018-02-11T23:00:00.000Z",
-    "name": "Fastelavn",
+    "name": "Morsdag",
     "type": "observance",
     "_weekday": "Sun"
   },
@@ -19,7 +19,7 @@
     "date": "2018-02-11 00:00:00",
     "start": "2018-02-10T23:00:00.000Z",
     "end": "2018-02-11T23:00:00.000Z",
-    "name": "Morsdag",
+    "name": "Fastelavn",
     "type": "observance",
     "_weekday": "Sun"
   },
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2018-03-31 00:00:00",
+    "start": "2018-03-30T22:00:00.000Z",
+    "end": "2018-03-31T22:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2018-04-01 00:00:00",
     "start": "2018-03-31T22:00:00.000Z",
     "end": "2018-04-01T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Tue"
   },
@@ -75,8 +83,8 @@
     "date": "2018-05-08 00:00:00",
     "start": "2018-05-07T22:00:00.000Z",
     "end": "2018-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Tue"
   },
   {
@@ -91,7 +99,7 @@
     "date": "2018-05-17 00:00:00",
     "start": "2018-05-16T22:00:00.000Z",
     "end": "2018-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Thu"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2018-11-11 00:00:00",
+    "start": "2018-11-10T23:00:00.000Z",
+    "end": "2018-11-11T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-12-02 00:00:00",
     "start": "2018-12-01T23:00:00.000Z",
     "end": "2018-12-02T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-12-09 00:00:00",
+    "start": "2018-12-08T23:00:00.000Z",
+    "end": "2018-12-09T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-12-16 00:00:00",
+    "start": "2018-12-15T23:00:00.000Z",
+    "end": "2018-12-16T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-12-23 00:00:00",
+    "start": "2018-12-22T23:00:00.000Z",
+    "end": "2018-12-23T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SJ-2019.json
+++ b/test/fixtures/SJ-2019.json
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2019-04-20 00:00:00",
+    "start": "2019-04-19T22:00:00.000Z",
+    "end": "2019-04-20T22:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2019-04-21 00:00:00",
     "start": "2019-04-20T22:00:00.000Z",
     "end": "2019-04-21T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Wed"
   },
@@ -75,15 +83,15 @@
     "date": "2019-05-08 00:00:00",
     "start": "2019-05-07T22:00:00.000Z",
     "end": "2019-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Wed"
   },
   {
     "date": "2019-05-17 00:00:00",
     "start": "2019-05-16T22:00:00.000Z",
     "end": "2019-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Fri"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2019-11-10 00:00:00",
+    "start": "2019-11-09T23:00:00.000Z",
+    "end": "2019-11-10T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-12-01 00:00:00",
     "start": "2019-11-30T23:00:00.000Z",
     "end": "2019-12-01T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-12-08 00:00:00",
+    "start": "2019-12-07T23:00:00.000Z",
+    "end": "2019-12-08T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-12-15 00:00:00",
+    "start": "2019-12-14T23:00:00.000Z",
+    "end": "2019-12-15T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-12-22 00:00:00",
+    "start": "2019-12-21T23:00:00.000Z",
+    "end": "2019-12-22T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SJ-2020.json
+++ b/test/fixtures/SJ-2020.json
@@ -48,6 +48,14 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2020-04-11 00:00:00",
+    "start": "2020-04-10T22:00:00.000Z",
+    "end": "2020-04-11T22:00:00.000Z",
+    "name": "Påskeaften",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-12 00:00:00",
     "start": "2020-04-11T22:00:00.000Z",
     "end": "2020-04-12T22:00:00.000Z",
@@ -67,7 +75,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Første mai",
+    "name": "Arbeidernes dag",
     "type": "public",
     "_weekday": "Fri"
   },
@@ -75,15 +83,15 @@
     "date": "2020-05-08 00:00:00",
     "start": "2020-05-07T22:00:00.000Z",
     "end": "2020-05-08T22:00:00.000Z",
-    "name": "Frigjøringsdag 1945",
-    "type": "observance",
+    "name": "Frigjøringsdagen",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
     "date": "2020-05-17 00:00:00",
     "start": "2020-05-16T22:00:00.000Z",
     "end": "2020-05-17T22:00:00.000Z",
-    "name": "Grunnlovsdagen",
+    "name": "17.mai",
     "type": "public",
     "_weekday": "Sun"
   },
@@ -120,10 +128,42 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2020-11-08 00:00:00",
+    "start": "2020-11-07T23:00:00.000Z",
+    "end": "2020-11-08T23:00:00.000Z",
+    "name": "Farsdag",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-11-29 00:00:00",
     "start": "2020-11-28T23:00:00.000Z",
     "end": "2020-11-29T23:00:00.000Z",
     "name": "Første søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-06 00:00:00",
+    "start": "2020-12-05T23:00:00.000Z",
+    "end": "2020-12-06T23:00:00.000Z",
+    "name": "Andre søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-13 00:00:00",
+    "start": "2020-12-12T23:00:00.000Z",
+    "end": "2020-12-13T23:00:00.000Z",
+    "name": "Tredje søndag i advent",
+    "type": "observance",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-20 00:00:00",
+    "start": "2020-12-19T23:00:00.000Z",
+    "end": "2020-12-20T23:00:00.000Z",
+    "name": "Fjerde søndag i advent",
     "type": "observance",
     "_weekday": "Sun"
   },


### PR DESCRIPTION
Notes:

"Første mai" -> "Arbeidernes dag". This is this day is generally known as; and it's also the translation provided by Google. 

`Frigjøringsdag 1945` -> `Frigjøringsdagen`. We don't actually call it with '1945'.

I've decoupled `Constitution Day` from the internal use of it and said that the Norwegian translation of it is `17. mai`, because that is what we call ours, and not everybody else's.
For example, an other country's `Constitution Day` should still be `Grunnlovsdagen` which is provided in the `data/names.yaml`-file.

I've added `Fathers Day`.

I've added 2nd, 3rd and 4th Sunday of Advent to align consistency. None of these are actually holidays, other than normally noted in calendars, but carry some christian values with them.


Let me know if there's anything that should be changed.

Edit:

Also, I've added `Easter Day` -> `Påskeaften`.

Sources:
- [https://no.wikipedia.org/wiki/Arbeidernes_internasjonale_kampdag](https://no.wikipedia.org/wiki/Arbeidernes_internasjonale_kampdag)
- [https://no.wikipedia.org/wiki/17._mai_(grunnlovsdag)](https://no.wikipedia.org/wiki/17._mai_(grunnlovsdag))
- [https://www.timeanddate.com/holidays/norway/](https://www.timeanddate.com/holidays/norway/)
- [https://no.wikipedia.org/wiki/P%C3%A5skeaften](https://no.wikipedia.org/wiki/P%C3%A5skeaften)