### PR TITLE
Fixing an attribution typo for Vatican City.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -103,6 +103,7 @@ https://en.wikipedia.org/wiki/Public_holidays_in_Togo
 https://en.wikipedia.org/wiki/Public_holidays_in_Turkey
 https://en.wikipedia.org/wiki/Public_holidays_in_Uganda
 https://en.wikipedia.org/wiki/Public_holidays_in_Ukraine
+https://en.wikipedia.org/wiki/Public_holidays_in_Vatican_City
 https://en.wikipedia.org/wiki/Public_holidays_in_Venezuela
 https://en.wikipedia.org/wiki/Public_holidays_in_Vietnam
 https://en.wikipedia.org/wiki/Public_holidays_in_Zambia

--- a/data/countries/VA.yaml
+++ b/data/countries/VA.yaml
@@ -1,4 +1,4 @@
-# @attric https://en.wikipedia.org/wiki/Public_holidays_in_Vatican_City
+# @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Vatican_City
 holidays:
   VA:
     names:


### PR DESCRIPTION
I also regenerated the LICENSE by running scripts/attributions.js .

I somewhat randomly came across this and wanted to fix it.