### PR TITLE
IE: add bank holidays

### DIFF
--- a/data/countries/IE.yaml
+++ b/data/countries/IE.yaml
@@ -1,5 +1,6 @@
 holidays:
   # @source http://www.citizensinformation.ie/en/employment/employment_rights_and_conditions/leave_and_holidays/public_holidays_in_ireland.html
+  # @source https://www.bpfi.ie/wp-content/uploads/2017/10/Bank20Holidays202017-20.pdf
   IE:
     names:
       en: Ireland
@@ -14,12 +15,17 @@ holidays:
       03-17:
         name:
           en: St. Patrick’s Day
+      03-17 and if saturday then next monday if sunday then next monday:
+        name:
+          en: St. Patrick’s Day
+        substitute: true
+        type: bank
       easter -21:
         _name: Mothers Day
         type: observance
       easter -2:
         _name: easter -2
-        type: observance
+        type: bank
       easter:
         _name: easter
       easter 1:
@@ -36,10 +42,10 @@ holidays:
       1st monday before 10-31:
         name:
           en: October Bank Holiday
+          type: bank
       12-25:
         _name: 12-25
       12-26:
         _name: 12-26
         name:
           en: St. Stephen's Day
-

--- a/data/countries/IE.yaml
+++ b/data/countries/IE.yaml
@@ -49,3 +49,16 @@ holidays:
         _name: 12-26
         name:
           en: St. Stephen's Day
+      12-26 and if saturday then next monday if sunday then next monday:
+        _name: 12-26
+        name:
+          en: St. Stephen's Day
+        substitute: true
+        type: bank
+      # Note that this is NOT "12-27 and if saturday..." (no and). This is
+      # becuase this is not a substitute for another holiday but a bank holiday
+      # in its own right which always falls on the work week.
+      12-27 if saturday then next monday if sunday then next tuesday:
+        name:
+          en: Christmas Bank Holiday
+        type: bank

--- a/data/countries/IE.yaml
+++ b/data/countries/IE.yaml
@@ -1,6 +1,10 @@
 holidays:
   # @source http://www.citizensinformation.ie/en/employment/employment_rights_and_conditions/leave_and_holidays/public_holidays_in_ireland.html
   # @source https://www.bpfi.ie/wp-content/uploads/2017/10/Bank20Holidays202017-20.pdf
+  #
+  # Note that the "Bank of Ireland" is not the official national bank playes a
+  # somewhat similar role (https://en.wikipedia.org/wiki/Bank_of_Ireland#Role_as_government_banker).
+  # @source https://personalbanking.bankofireland.com/app/uploads/2018/11/OMI021897-CHRISTMAS-2018-CAMPAIGN-Opening-Hours-A1-Generic_v3.v2-compressed.pdf
   IE:
     names:
       en: Ireland

--- a/data/holidays.json
+++ b/data/holidays.json
@@ -9221,6 +9221,20 @@
           "name": {
             "en": "St. Stephen's Day"
           }
+        },
+        "12-26 and if saturday then next monday if sunday then next monday": {
+          "_name": "12-26",
+          "name": {
+            "en": "St. Stephen's Day"
+          },
+          "substitute": true,
+          "type": "bank"
+        },
+        "12-27 if saturday then next monday if sunday then next tuesday": {
+          "name": {
+            "en": "Christmas Bank Holiday"
+          },
+          "type": "bank"
         }
       }
     },

--- a/data/holidays.json
+++ b/data/holidays.json
@@ -1,5 +1,5 @@
 {
-  "version": "2019-01-07",
+  "version": "2019-01-13",
   "license": "CC-BY-SA-3",
   "holidays": {
     "AD": {
@@ -9171,13 +9171,20 @@
             "en": "St. Patrick’s Day"
           }
         },
+        "03-17 and if saturday then next monday if sunday then next monday": {
+          "name": {
+            "en": "St. Patrick’s Day"
+          },
+          "substitute": true,
+          "type": "bank"
+        },
         "easter -21": {
           "_name": "Mothers Day",
           "type": "observance"
         },
         "easter -2": {
           "_name": "easter -2",
-          "type": "observance"
+          "type": "bank"
         },
         "easter": {
           "_name": "easter"
@@ -9202,7 +9209,8 @@
         },
         "1st monday before 10-31": {
           "name": {
-            "en": "October Bank Holiday"
+            "en": "October Bank Holiday",
+            "type": "bank"
           }
         },
         "12-25": {

--- a/test/fixtures/IE-2015.json
+++ b/test/fixtures/IE-2015.json
@@ -94,5 +94,22 @@
     "name": "St. Stephen's Day",
     "type": "public",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2015-12-28 00:00:00",
+    "start": "2015-12-28T00:00:00.000Z",
+    "end": "2015-12-29T00:00:00.000Z",
+    "name": "St. Stephen's Day (substitute day)",
+    "type": "bank",
+    "substitute": true,
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-12-29 00:00:00",
+    "start": "2015-12-29T00:00:00.000Z",
+    "end": "2015-12-30T00:00:00.000Z",
+    "name": "Christmas Bank Holiday",
+    "type": "bank",
+    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2015.json
+++ b/test/fixtures/IE-2015.json
@@ -28,7 +28,7 @@
     "start": "2015-04-02T23:00:00.000Z",
     "end": "2015-04-03T23:00:00.000Z",
     "name": "Good Friday",
-    "type": "observance",
+    "type": "bank",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/IE-2016.json
+++ b/test/fixtures/IE-2016.json
@@ -28,7 +28,7 @@
     "start": "2016-03-25T00:00:00.000Z",
     "end": "2016-03-26T00:00:00.000Z",
     "name": "Good Friday",
-    "type": "observance",
+    "type": "bank",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/IE-2016.json
+++ b/test/fixtures/IE-2016.json
@@ -94,5 +94,13 @@
     "name": "St. Stephen's Day",
     "type": "public",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2016-12-27 00:00:00",
+    "start": "2016-12-27T00:00:00.000Z",
+    "end": "2016-12-28T00:00:00.000Z",
+    "name": "Christmas Bank Holiday",
+    "type": "bank",
+    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2017.json
+++ b/test/fixtures/IE-2017.json
@@ -28,7 +28,7 @@
     "start": "2017-04-13T23:00:00.000Z",
     "end": "2017-04-14T23:00:00.000Z",
     "name": "Good Friday",
-    "type": "observance",
+    "type": "bank",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/IE-2017.json
+++ b/test/fixtures/IE-2017.json
@@ -94,5 +94,13 @@
     "name": "St. Stephen's Day",
     "type": "public",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2017-12-27 00:00:00",
+    "start": "2017-12-27T00:00:00.000Z",
+    "end": "2017-12-28T00:00:00.000Z",
+    "name": "Christmas Bank Holiday",
+    "type": "bank",
+    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/IE-2018.json
+++ b/test/fixtures/IE-2018.json
@@ -103,5 +103,13 @@
     "name": "St. Stephen's Day",
     "type": "public",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2018-12-27 00:00:00",
+    "start": "2018-12-27T00:00:00.000Z",
+    "end": "2018-12-28T00:00:00.000Z",
+    "name": "Christmas Bank Holiday",
+    "type": "bank",
+    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/IE-2018.json
+++ b/test/fixtures/IE-2018.json
@@ -24,11 +24,20 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T00:00:00.000Z",
+    "end": "2018-03-20T00:00:00.000Z",
+    "name": "St. Patrick’s Day (substitute day)",
+    "type": "bank",
+    "substitute": true,
+    "_weekday": "Mon"
+  },
+  {
     "date": "2018-03-30 00:00:00",
     "start": "2018-03-29T23:00:00.000Z",
     "end": "2018-03-30T23:00:00.000Z",
     "name": "Good Friday",
-    "type": "observance",
+    "type": "bank",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/IE-2019.json
+++ b/test/fixtures/IE-2019.json
@@ -103,5 +103,13 @@
     "name": "St. Stephen's Day",
     "type": "public",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2019-12-27 00:00:00",
+    "start": "2019-12-27T00:00:00.000Z",
+    "end": "2019-12-28T00:00:00.000Z",
+    "name": "Christmas Bank Holiday",
+    "type": "bank",
+    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/IE-2019.json
+++ b/test/fixtures/IE-2019.json
@@ -16,6 +16,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2019-03-18 00:00:00",
+    "start": "2019-03-18T00:00:00.000Z",
+    "end": "2019-03-19T00:00:00.000Z",
+    "name": "St. Patrick’s Day (substitute day)",
+    "type": "bank",
+    "substitute": true,
+    "_weekday": "Mon"
+  },
+  {
     "date": "2019-03-31 00:00:00",
     "start": "2019-03-31T00:00:00.000Z",
     "end": "2019-03-31T23:00:00.000Z",
@@ -28,7 +37,7 @@
     "start": "2019-04-18T23:00:00.000Z",
     "end": "2019-04-19T23:00:00.000Z",
     "name": "Good Friday",
-    "type": "observance",
+    "type": "bank",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/IE-2020.json
+++ b/test/fixtures/IE-2020.json
@@ -94,5 +94,22 @@
     "name": "St. Stephen's Day",
     "type": "public",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2020-12-28 00:00:00",
+    "start": "2020-12-28T00:00:00.000Z",
+    "end": "2020-12-29T00:00:00.000Z",
+    "name": "St. Stephen's Day (substitute day)",
+    "type": "bank",
+    "substitute": true,
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-12-29 00:00:00",
+    "start": "2020-12-29T00:00:00.000Z",
+    "end": "2020-12-30T00:00:00.000Z",
+    "name": "Christmas Bank Holiday",
+    "type": "bank",
+    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2020.json
+++ b/test/fixtures/IE-2020.json
@@ -28,7 +28,7 @@
     "start": "2020-04-09T23:00:00.000Z",
     "end": "2020-04-10T23:00:00.000Z",
     "name": "Good Friday",
-    "type": "observance",
+    "type": "bank",
     "_weekday": "Fri"
   },
   {


### PR DESCRIPTION
This completes the definition of bank holidays in the Republic of Ireland based on a publication form the Banking and Payments Federation of Ireland. The end of year holidays are reinforced by another source I found from the Bank of Ireland.