### PR TITLE
misspelling corrected "Baden Würtemberg" -> "Baden-Württemberg"

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Countries: 142
 ├── DE: Deutschland
 │   ├── BB: Brandenburg
 │   ├── BE: Berlin
-│   ├── BW: Baden Würtemberg
+│   ├── BW: Baden-Württemberg
 │   ├── BY: Bayern
 │   │   ├── A: Stadt Augsburg
 │   │   └── EVANG: Überwiegend evangelische Gemeinden

--- a/data/countries/DE.yaml
+++ b/data/countries/DE.yaml
@@ -130,7 +130,7 @@ holidays:
             _name: easter 49
             type: observance
       BW:
-        name: Baden Würtemberg
+        name: Baden-Württemberg
         days:
           01-06:
             _name: 01-06

--- a/data/holidays.json
+++ b/data/holidays.json
@@ -6652,7 +6652,7 @@
           }
         },
         "BW": {
-          "name": "Baden Würtemberg",
+          "name": "Baden-Württemberg",
           "days": {
             "01-06": {
               "_name": "01-06"


### PR DESCRIPTION
See https://de.wikipedia.org/wiki/Baden-W%C3%BCrttemberg