### PR TITLE
You should export this Interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ declare module 'date-holidays' {
         type: HolidayType;
     }
 
-    interface HolidaysInterface {
+    export interface HolidaysInterface {
         init(country?: Country | string, opts?: Options): void;
 
         init(country?: string, state?: string, opts?: Options): void;


### PR DESCRIPTION
For external usage, you should export this interface as using like this would have correct types:
```ts
const brazilianHolidays = new Holidays()
const isBrazilianHoliday (date: Date, holidays: HolidaysInterface) {
    return holidays.isHoliday(date)
}
isBrazilianHoliday(new Date(), holidays)
```