### PR TITLE
Fix Guam holidays

### DIFF
--- a/data/countries/GU.yaml
+++ b/data/countries/GU.yaml
@@ -2,6 +2,8 @@ holidays:
   # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_the_United_States#Guam
   # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Guam
   # @source https://www.guamtax.com/help/holidays.html
+  # @source http://www.guamcourts.org/CompilerofLaws/GCA/01gca/1gc010.PDF
+  # @source http://www.guamcourts.org/Holidays-and-Hours/JOG-Holidays-and-Hours.html
   GU:
     names:
       en: Guam
@@ -17,17 +19,17 @@ holidays:
     # additional holidays
     days:
       3rd monday in February: false
-      03-05:
+      1st monday in March:
         name:
-          en: Guam Discovery Day
+          en: Guam History and Chamorro Heritage Day
       easter -2:
         _name: easter -2
-      07-21:
+        type: observance
+      07-21 if sunday then next monday:
         name:
           en: Liberation Day
       11-02:
         _name: 11-02
-      12-08:
+      12-08 if sunday then next monday:
         name:
-          en: Lady of Camarin Day
-
+          en: Our Lady of Camarin Day

--- a/test/fixtures/GU-2015.json
+++ b/test/fixtures/GU-2015.json
@@ -24,19 +24,19 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2015-03-05 00:00:00",
-    "start": "2015-03-04T14:00:00.000Z",
-    "end": "2015-03-05T14:00:00.000Z",
-    "name": "Guam Discovery Day",
+    "date": "2015-03-02 00:00:00",
+    "start": "2015-03-01T14:00:00.000Z",
+    "end": "2015-03-02T14:00:00.000Z",
+    "name": "Guam History and Chamorro Heritage Day",
     "type": "public",
-    "_weekday": "Thu"
+    "_weekday": "Mon"
   },
   {
     "date": "2015-04-03 00:00:00",
     "start": "2015-04-02T14:00:00.000Z",
     "end": "2015-04-03T14:00:00.000Z",
     "name": "Good Friday",
-    "type": "public",
+    "type": "observance",
     "_weekday": "Fri"
   },
   {
@@ -164,7 +164,7 @@
     "date": "2015-12-08 00:00:00",
     "start": "2015-12-07T14:00:00.000Z",
     "end": "2015-12-08T14:00:00.000Z",
-    "name": "Lady of Camarin Day",
+    "name": "Our Lady of Camarin Day",
     "type": "public",
     "_weekday": "Tue"
   },

--- a/test/fixtures/GU-2016.json
+++ b/test/fixtures/GU-2016.json
@@ -24,19 +24,19 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2016-03-05 00:00:00",
-    "start": "2016-03-04T14:00:00.000Z",
-    "end": "2016-03-05T14:00:00.000Z",
-    "name": "Guam Discovery Day",
+    "date": "2016-03-07 00:00:00",
+    "start": "2016-03-06T14:00:00.000Z",
+    "end": "2016-03-07T14:00:00.000Z",
+    "name": "Guam History and Chamorro Heritage Day",
     "type": "public",
-    "_weekday": "Sat"
+    "_weekday": "Mon"
   },
   {
     "date": "2016-03-25 00:00:00",
     "start": "2016-03-24T14:00:00.000Z",
     "end": "2016-03-25T14:00:00.000Z",
     "name": "Good Friday",
-    "type": "public",
+    "type": "observance",
     "_weekday": "Fri"
   },
   {
@@ -163,7 +163,7 @@
     "date": "2016-12-08 00:00:00",
     "start": "2016-12-07T14:00:00.000Z",
     "end": "2016-12-08T14:00:00.000Z",
-    "name": "Lady of Camarin Day",
+    "name": "Our Lady of Camarin Day",
     "type": "public",
     "_weekday": "Thu"
   },

--- a/test/fixtures/GU-2017.json
+++ b/test/fixtures/GU-2017.json
@@ -33,19 +33,19 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2017-03-05 00:00:00",
-    "start": "2017-03-04T14:00:00.000Z",
-    "end": "2017-03-05T14:00:00.000Z",
-    "name": "Guam Discovery Day",
+    "date": "2017-03-06 00:00:00",
+    "start": "2017-03-05T14:00:00.000Z",
+    "end": "2017-03-06T14:00:00.000Z",
+    "name": "Guam History and Chamorro Heritage Day",
     "type": "public",
-    "_weekday": "Sun"
+    "_weekday": "Mon"
   },
   {
     "date": "2017-04-14 00:00:00",
     "start": "2017-04-13T14:00:00.000Z",
     "end": "2017-04-14T14:00:00.000Z",
     "name": "Good Friday",
-    "type": "public",
+    "type": "observance",
     "_weekday": "Fri"
   },
   {
@@ -174,7 +174,7 @@
     "date": "2017-12-08 00:00:00",
     "start": "2017-12-07T14:00:00.000Z",
     "end": "2017-12-08T14:00:00.000Z",
-    "name": "Lady of Camarin Day",
+    "name": "Our Lady of Camarin Day",
     "type": "public",
     "_weekday": "Fri"
   },

--- a/test/fixtures/GU-2018.json
+++ b/test/fixtures/GU-2018.json
@@ -27,7 +27,7 @@
     "date": "2018-03-05 00:00:00",
     "start": "2018-03-04T14:00:00.000Z",
     "end": "2018-03-05T14:00:00.000Z",
-    "name": "Guam Discovery Day",
+    "name": "Guam History and Chamorro Heritage Day",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -36,7 +36,7 @@
     "start": "2018-03-29T14:00:00.000Z",
     "end": "2018-03-30T14:00:00.000Z",
     "name": "Good Friday",
-    "type": "public",
+    "type": "observance",
     "_weekday": "Fri"
   },
   {
@@ -166,7 +166,7 @@
     "date": "2018-12-08 00:00:00",
     "start": "2018-12-07T14:00:00.000Z",
     "end": "2018-12-08T14:00:00.000Z",
-    "name": "Lady of Camarin Day",
+    "name": "Our Lady of Camarin Day",
     "type": "public",
     "_weekday": "Sat"
   },

--- a/test/fixtures/GU-2019.json
+++ b/test/fixtures/GU-2019.json
@@ -24,12 +24,12 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2019-03-05 00:00:00",
-    "start": "2019-03-04T14:00:00.000Z",
-    "end": "2019-03-05T14:00:00.000Z",
-    "name": "Guam Discovery Day",
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-03T14:00:00.000Z",
+    "end": "2019-03-04T14:00:00.000Z",
+    "name": "Guam History and Chamorro Heritage Day",
     "type": "public",
-    "_weekday": "Tue"
+    "_weekday": "Mon"
   },
   {
     "date": "2019-04-15 00:00:00",
@@ -44,7 +44,7 @@
     "start": "2019-04-18T14:00:00.000Z",
     "end": "2019-04-19T14:00:00.000Z",
     "name": "Good Friday",
-    "type": "public",
+    "type": "observance",
     "_weekday": "Fri"
   },
   {
@@ -88,12 +88,12 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2019-07-21 00:00:00",
-    "start": "2019-07-20T14:00:00.000Z",
-    "end": "2019-07-21T14:00:00.000Z",
+    "date": "2019-07-22 00:00:00",
+    "start": "2019-07-21T14:00:00.000Z",
+    "end": "2019-07-22T14:00:00.000Z",
     "name": "Liberation Day",
     "type": "public",
-    "_weekday": "Sun"
+    "_weekday": "Mon"
   },
   {
     "date": "2019-09-02 00:00:00",
@@ -153,12 +153,12 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-12-08 00:00:00",
-    "start": "2019-12-07T14:00:00.000Z",
-    "end": "2019-12-08T14:00:00.000Z",
-    "name": "Lady of Camarin Day",
+    "date": "2019-12-09 00:00:00",
+    "start": "2019-12-08T14:00:00.000Z",
+    "end": "2019-12-09T14:00:00.000Z",
+    "name": "Our Lady of Camarin Day",
     "type": "public",
-    "_weekday": "Sun"
+    "_weekday": "Mon"
   },
   {
     "date": "2019-12-24 00:00:00",

--- a/test/fixtures/GU-2020.json
+++ b/test/fixtures/GU-2020.json
@@ -24,19 +24,19 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-03-05 00:00:00",
-    "start": "2020-03-04T14:00:00.000Z",
-    "end": "2020-03-05T14:00:00.000Z",
-    "name": "Guam Discovery Day",
+    "date": "2020-03-02 00:00:00",
+    "start": "2020-03-01T14:00:00.000Z",
+    "end": "2020-03-02T14:00:00.000Z",
+    "name": "Guam History and Chamorro Heritage Day",
     "type": "public",
-    "_weekday": "Thu"
+    "_weekday": "Mon"
   },
   {
     "date": "2020-04-10 00:00:00",
     "start": "2020-04-09T14:00:00.000Z",
     "end": "2020-04-10T14:00:00.000Z",
     "name": "Good Friday",
-    "type": "public",
+    "type": "observance",
     "_weekday": "Fri"
   },
   {
@@ -172,7 +172,7 @@
     "date": "2020-12-08 00:00:00",
     "start": "2020-12-07T14:00:00.000Z",
     "end": "2020-12-08T14:00:00.000Z",
-    "name": "Lady of Camarin Day",
+    "name": "Our Lady of Camarin Day",
     "type": "public",
     "_weekday": "Tue"
   },


### PR DESCRIPTION
While fixing #80 it was noticed that Presidents' Day is not observed in Guam hence based on the data-set found all have been corrected. 
