### PR TITLE
fix(example): weekdays not shown for some dates

### DIFF
--- a/examples/browser/test.js
+++ b/examples/browser/test.js
@@ -3,14 +3,17 @@
 ;(function () {
   var vcalendar = require('date-holidays-ical/lib/vcalendar')
 
+  var DAY = 86400000
+  var HOUR = 3600000
+
   var WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
   var year = new Date().getFullYear()
   var g = { year: year }
   var n = {}
 
   function duration (ms) {
-    var days = (ms / 86400000) | 0
-    var hours = (ms - (days * 86400000)) / 3600000 | 0
+    var days = (ms / DAY) | 0
+    var hours = (ms - (days * DAY)) / HOUR | 0
     var str = days ? days + 'd ' : ''
     str += hours ? hours + 'h' : ''
     return str
@@ -100,9 +103,10 @@
       '<tbody>',
       Object.keys(holidays).map(function (i) {
         var d = holidays[i]
+        var _date = d.date.replace(/^(\d+-\d+-\d+ \d+:\d+:\d+).*$/, '$1')
         return '<tr><td>' + [
           count++,
-          WEEKDAYS[new Date(d.date).getDay()],
+          WEEKDAYS[new Date(_date).getDay()],
           d.date,
           duration(d.end - d.start),
           d.name,


### PR DESCRIPTION
dates like this '2019-01-01 00:00:00 -06:00' don't show weekdays in the example.