### PR TITLE
Typings that match module export implementation

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,74 +1,91 @@
-// TypeScript Version: 2.2
+// TypeScript Version: 3.3
 
 declare module 'date-holidays' {
-    export interface Country {
-        country: string;
-        state?: string;
-        region?: string;
+    namespace Holidays {
+        export interface Country {
+            country: string;
+            state?: string;
+            region?: string;
+        }
+
+        export type HolidayType = 'public' | 'bank' | 'school' | 'observance';
+
+        export interface Options {
+            languages?: string | string[];
+            timezone?: string;
+            types?: HolidayType[];
+        }
+
+        export interface HolidayOptions {
+            name: { [key: string]: string; };
+            type: HolidayType;
+        }
+
+        export interface Holiday {
+            date: string;
+            start: Date;
+            end: Date;
+            name: string;
+            type: HolidayType;
+            substitute?: boolean;
+        }
+
+        export interface HolidaysInterface {
+            init(country?: Country | string, opts?: Options): void;
+
+            init(country?: string, state?: string, opts?: Options): void;
+
+            init(country?: string, state?: string, region?: string, opts?: Options): void;
+
+            setHoliday(rule: string, opts: HolidayOptions | string): boolean;
+
+            getHolidays(year?: string | number | Date, lang?: string): Holiday[];
+
+            isHoliday(date: Date): Holiday;
+
+            query(country?: string, state?: string, lang?: string): { [key: string]: string; };
+
+            getCountries(lang?: string): { [key: string]: string; };
+
+            getStates(country: string, lang?: string): { [key: string]: string; };
+
+            getRegions(country: string, state: string, lang?: string): { [key: string]: string; };
+
+            getTimezones(): string[];
+
+            setTimezone(timezone: string): void;
+
+            getLanguages(): string[];
+
+            setLanguage(language: string | string[]): string[];
+
+            getDayOff(): string;
+        }
     }
 
-    export type HolidayType = "public" | "bank" | "school" | "observance";
+    class Holidays implements Holidays.HolidaysInterface {
+        constructor(opts?: Holidays.Options);
+        constructor(country: Holidays.Country | string, opts?: Holidays.Options);
+        constructor(country: Holidays.Country | string, state: string, opts?: Holidays.Options);
+        constructor(country: Holidays.Country | string, state: string, region: string, opts?: Holidays.Options);
 
-    export interface Options {
-        languages?: string | ReadonlyArray<string>;
-        timezone?: string;
-        types?: ReadonlyArray<HolidayType>;
-    }
-
-    export interface HolidayOptions {
-        name: { [key: string]: string };
-        type: HolidayType;
-    }
-
-    export interface Holiday {
-        date: string;
-        start: Date;
-        end: Date;
-        name: string;
-        type: HolidayType;
-        substitute?: boolean;
-    }
-
-    export interface HolidaysInterface {
-        init(country?: Country | string, opts?: Options): void;
-
-        init(country?: string, state?: string, opts?: Options): void;
-
-        init(country?: string, state?: string, region?: string, opts?: Options): void;
-
-        setHoliday(rule: string, opts: HolidayOptions | string): boolean;
-
-        getHolidays(year?: string | number | Date, lang?: string): Holiday[];
-
-        isHoliday(date: Date): Holiday;
-
-        query(country?: string, state?: string, lang?: string): { [key: string]: string };
-
-        getCountries(lang?: string): { [key: string]: string };
-
-        getStates(country: string, lang?: string): { [key: string]: string };
-
-        getRegions(country: string, state: string, lang?: string): { [key: string]: string };
-
+        // HolidaysInterface:
+        init(country?: Holidays.Country | string, opts?: Holidays.Options): void;
+        init(country?: string, state?: string, opts?: Holidays.Options): void;
+        init(country?: string, state?: string, region?: string, opts?: Holidays.Options): void;
+        setHoliday(rule: string, opts: Holidays.HolidayOptions | string): boolean;
+        getHolidays(year?: string | number | Date, lang?: string): Holidays.Holiday[];
+        isHoliday(date: Date): Holidays.Holiday;
+        query(country?: string, state?: string, lang?: string): { [key: string]: string; };
+        getCountries(lang?: string): { [key: string]: string; };
+        getStates(country: string, lang?: string): { [key: string]: string; };
+        getRegions(country: string, state: string, lang?: string): { [key: string]: string; };
         getTimezones(): string[];
-
         setTimezone(timezone: string): void;
-
         getLanguages(): string[];
-
         setLanguage(language: string | string[]): string[];
-
         getDayOff(): string;
     }
 
-    interface HolidaysConstructor {
-        new (opts?: Options): HolidaysInterface;
-        new (country: Country | string, opts?: Options): HolidaysInterface;
-        new (country: Country | string, state: string, opts?: Options): HolidaysInterface;
-        new (country: Country | string, state: string, region: string, opts?: Options): HolidaysInterface;
-    }
-
-    let Holidays: HolidaysConstructor;
-
-    export default Holidays;
+    export = Holidays;
 }

--- a/types/typings.test.ts
+++ b/types/typings.test.ts
@@ -1,4 +1,6 @@
-import Holidays, { Holiday } from 'date-holidays';
+import * as Holidays from 'date-holidays';
+
+type Holiday = Holidays.Holiday;
 
 const hd = new Holidays('');
 hd.init('US');


### PR DESCRIPTION
Related to [this comment](https://github.com/commenthol/date-holidays/issues/44#issuecomment-548330984) where I mentioned that form my project I wrote a different typings implementation. This is that typings implementation.

Note that this expects the import to be `import * as Holiday from 'date-holidays'` and requires the tests to be changed as well.