### PR TITLE
fix(AU-SA): New Year's Eve

### DIFF
--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -144,7 +144,7 @@ holidays:
             _name: 12-24
             type: public
           12-31 19:00:
-            _name: 12-24
+            _name: 12-31
             type: public
       # @source http://worksafe.tas.gov.au/laws/public_holidays
       TAS:

--- a/test/fixtures/AU-SA-2015.json
+++ b/test/fixtures/AU-SA-2015.json
@@ -133,7 +133,7 @@
     "date": "2015-12-31 19:00:00",
     "start": "2015-12-31T08:30:00.000Z",
     "end": "2015-12-31T13:30:00.000Z",
-    "name": "Christmas Eve",
+    "name": "New Year's Eve",
     "type": "public",
     "_weekday": "Thu"
   }

--- a/test/fixtures/AU-SA-2016.json
+++ b/test/fixtures/AU-SA-2016.json
@@ -124,7 +124,7 @@
     "date": "2016-12-31 19:00:00",
     "start": "2016-12-31T08:30:00.000Z",
     "end": "2016-12-31T13:30:00.000Z",
-    "name": "Christmas Eve",
+    "name": "New Year's Eve",
     "type": "public",
     "_weekday": "Sat"
   }

--- a/test/fixtures/AU-SA-2017.json
+++ b/test/fixtures/AU-SA-2017.json
@@ -124,7 +124,7 @@
     "date": "2017-12-31 19:00:00",
     "start": "2017-12-31T08:30:00.000Z",
     "end": "2017-12-31T13:30:00.000Z",
-    "name": "Christmas Eve",
+    "name": "New Year's Eve",
     "type": "public",
     "_weekday": "Sun"
   }

--- a/test/fixtures/AU-SA-2018.json
+++ b/test/fixtures/AU-SA-2018.json
@@ -115,7 +115,7 @@
     "date": "2018-12-31 19:00:00",
     "start": "2018-12-31T08:30:00.000Z",
     "end": "2018-12-31T13:30:00.000Z",
-    "name": "Christmas Eve",
+    "name": "New Year's Eve",
     "type": "public",
     "_weekday": "Mon"
   }

--- a/test/fixtures/AU-SA-2019.json
+++ b/test/fixtures/AU-SA-2019.json
@@ -124,7 +124,7 @@
     "date": "2019-12-31 19:00:00",
     "start": "2019-12-31T08:30:00.000Z",
     "end": "2019-12-31T13:30:00.000Z",
-    "name": "Christmas Eve",
+    "name": "New Year's Eve",
     "type": "public",
     "_weekday": "Tue"
   }

--- a/test/fixtures/AU-SA-2020.json
+++ b/test/fixtures/AU-SA-2020.json
@@ -142,7 +142,7 @@
     "date": "2020-12-31 19:00:00",
     "start": "2020-12-31T08:30:00.000Z",
     "end": "2020-12-31T13:30:00.000Z",
-    "name": "Christmas Eve",
+    "name": "New Year's Eve",
     "type": "public",
     "_weekday": "Thu"
   }


### PR DESCRIPTION
fixes issue with wrong holiday name using Christmas Eve instead of New Year's Eve for AU.SA