### PR TITLE
Fixed a typo in Argentina file

### DIFF
--- a/data/countries/AR.yaml
+++ b/data/countries/AR.yaml
@@ -24,7 +24,7 @@ holidays:
       01-01:
         _name: 01-01
       easter -48:
-        _name: easter -47
+        _name: easter -48
       easter -47:
         _name: easter -47
       03-24:


### PR DESCRIPTION
## Description
Argentina has duplicate Shrove Tuesdays (easter -47). This is due to the fact that there is a typo in AR.yaml where Shrove Monday (easter -48) has been incorrectly mapped to Shrove Tuesday (easter -47). This commit fixes the typo by mapping Shrove Monday correctly to easter -48.