### PR TITLE
Australia/Brisbane add partial Christmas Eve

### DIFF
--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -131,6 +131,9 @@ holidays:
               en: Queen's Birthday
             active:
               - from: '2016-01-01'
+          12-24 18:00:
+            _name: 12-24
+            type: public
       # @source http://www.safework.sa.gov.au/show_page.jsp?id=2483
       SA:
         name: South Australia


### PR DESCRIPTION
Partial Christmas Eve holiday for all of Queensland, Australia
as per https://www.qld.gov.au/recreation/travel/holidays/public