### PR TITLE
Changed "Faschingsdienstag" to observance commenthol/date-holidays#144

### DIFF
--- a/data/countries/DE.yaml
+++ b/data/countries/DE.yaml
@@ -27,7 +27,7 @@ holidays:
         type: observance
       'easter -47 14:00':
         _name: easter -47
-        type: bank
+        type: observance
       easter -46:
         _name: easter -46
         type: observance


### PR DESCRIPTION
Changed German holiday "Faschingsdienstag" to type `observance`, based on https://en.wikipedia.org/wiki/Public_holidays_in_Germany.

Solves commenthol/date-holidays#144