### PR TITLE
fix: correct substitution of NZ holidays

### DIFF
--- a/data/countries/NZ.yaml
+++ b/data/countries/NZ.yaml
@@ -13,11 +13,12 @@ holidays:
       01-01 and if saturday then next monday if sunday then next tuesday:
         substitute: true
         _name: 01-01
-      01-02 and if saturday,sunday then next monday:
+      01-02 and if saturday then next monday if sunday then next tuesday:
         substitute: true
         name:
           en: Day after New Year's Day
-      02-06 if saturday,sunday then next monday:
+      02-06 and if saturday,sunday then next monday:
+        substitute: true
         name:
           en: Waitangi Day
       easter -2:
@@ -27,7 +28,8 @@ holidays:
         type: observance
       easter 1:
         _name: easter 1
-      04-25 if saturday,sunday then next monday:
+      04-25 and if saturday,sunday then next monday:
+        substitute: true
         name:
           en: ANZAC Day
       1st monday in June:

--- a/test/fixtures/NZ-2015.json
+++ b/test/fixtures/NZ-2015.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-2016.json
+++ b/test/fixtures/NZ-2016.json
@@ -25,11 +25,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-2020.json
+++ b/test/fixtures/NZ-2020.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-AUK-2015.json
+++ b/test/fixtures/NZ-AUK-2015.json
@@ -56,11 +56,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-AUK-2016.json
+++ b/test/fixtures/NZ-AUK-2016.json
@@ -33,11 +33,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-AUK-2020.json
+++ b/test/fixtures/NZ-AUK-2020.json
@@ -56,11 +56,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-CAN-2015.json
+++ b/test/fixtures/NZ-CAN-2015.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-CAN-2016.json
+++ b/test/fixtures/NZ-CAN-2016.json
@@ -25,11 +25,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-CAN-2020.json
+++ b/test/fixtures/NZ-CAN-2020.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-CAN-S-2015.json
+++ b/test/fixtures/NZ-CAN-S-2015.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-CAN-S-2016.json
+++ b/test/fixtures/NZ-CAN-S-2016.json
@@ -25,11 +25,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-CAN-S-2020.json
+++ b/test/fixtures/NZ-CAN-S-2020.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-CIT-2015.json
+++ b/test/fixtures/NZ-CIT-2015.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-CIT-2016.json
+++ b/test/fixtures/NZ-CIT-2016.json
@@ -25,11 +25,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-CIT-2020.json
+++ b/test/fixtures/NZ-CIT-2020.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-HKB-2015.json
+++ b/test/fixtures/NZ-HKB-2015.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-HKB-2016.json
+++ b/test/fixtures/NZ-HKB-2016.json
@@ -25,11 +25,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-HKB-2020.json
+++ b/test/fixtures/NZ-HKB-2020.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-MBH-2015.json
+++ b/test/fixtures/NZ-MBH-2015.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-MBH-2016.json
+++ b/test/fixtures/NZ-MBH-2016.json
@@ -25,11 +25,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-MBH-2020.json
+++ b/test/fixtures/NZ-MBH-2020.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-NSN-2015.json
+++ b/test/fixtures/NZ-NSN-2015.json
@@ -56,11 +56,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-NSN-2016.json
+++ b/test/fixtures/NZ-NSN-2016.json
@@ -33,11 +33,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-NSN-2020.json
+++ b/test/fixtures/NZ-NSN-2020.json
@@ -56,11 +56,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-NTL-2015.json
+++ b/test/fixtures/NZ-NTL-2015.json
@@ -56,11 +56,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-NTL-2016.json
+++ b/test/fixtures/NZ-NTL-2016.json
@@ -33,11 +33,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-NTL-2020.json
+++ b/test/fixtures/NZ-NTL-2020.json
@@ -56,11 +56,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-OTA-2015.json
+++ b/test/fixtures/NZ-OTA-2015.json
@@ -57,11 +57,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-OTA-2016.json
+++ b/test/fixtures/NZ-OTA-2016.json
@@ -25,11 +25,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-OTA-2020.json
+++ b/test/fixtures/NZ-OTA-2020.json
@@ -57,11 +57,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-STL-2015.json
+++ b/test/fixtures/NZ-STL-2015.json
@@ -56,11 +56,20 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-STL-2016.json
+++ b/test/fixtures/NZ-STL-2016.json
@@ -25,11 +25,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-STL-2020.json
+++ b/test/fixtures/NZ-STL-2020.json
@@ -56,11 +56,20 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-TKI-2015.json
+++ b/test/fixtures/NZ-TKI-2015.json
@@ -56,11 +56,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-TKI-2016.json
+++ b/test/fixtures/NZ-TKI-2016.json
@@ -25,11 +25,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-TKI-2020.json
+++ b/test/fixtures/NZ-TKI-2020.json
@@ -56,11 +56,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-WGN-2015.json
+++ b/test/fixtures/NZ-WGN-2015.json
@@ -56,11 +56,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-WGN-2016.json
+++ b/test/fixtures/NZ-WGN-2016.json
@@ -33,11 +33,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-WGN-2020.json
+++ b/test/fixtures/NZ-WGN-2020.json
@@ -56,11 +56,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-WTC-2015.json
+++ b/test/fixtures/NZ-WTC-2015.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T12:00:00.000Z",
+    "end": "2015-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T12:00:00.000Z",
     "end": "2015-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-WTC-2016.json
+++ b/test/fixtures/NZ-WTC-2016.json
@@ -25,11 +25,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T11:00:00.000Z",
+    "end": "2016-02-06T11:00:00.000Z",
+    "name": "Waitangi Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-07T11:00:00.000Z",
     "end": "2016-02-08T11:00:00.000Z",
-    "name": "Waitangi Day",
+    "name": "Waitangi Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/NZ-WTC-2020.json
+++ b/test/fixtures/NZ-WTC-2020.json
@@ -48,11 +48,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T12:00:00.000Z",
+    "end": "2020-04-25T12:00:00.000Z",
+    "name": "ANZAC Day",
+    "type": "public",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T12:00:00.000Z",
     "end": "2020-04-27T12:00:00.000Z",
-    "name": "ANZAC Day",
+    "name": "ANZAC Day (substitute day)",
     "type": "public",
+    "substitute": true,
     "_weekday": "Mon"
   },
   {


### PR DESCRIPTION
- ensures that New Years Day and The Day After New Years Day do not fall
on the same day
- adds subtitute days for ANZAC Day and Waitangi Day

[source: https://www.govt.nz/browse/work/public-holidays-and-work/public-holidays-and-anniversary-dates]