### PR TITLE
Fix for public holidays of the Netherlands

### DIFF
--- a/data/countries/NL.yaml
+++ b/data/countries/NL.yaml
@@ -15,10 +15,8 @@ holidays:
         _name: 01-01
       easter -2:
         _name: easter -2
-        type: observance
       easter:
         _name: easter
-        type: observance
       easter 1:
         _name: easter 1
       04-27 if sunday then previous saturday:
@@ -41,17 +39,12 @@ holidays:
         _name: easter 39
       easter 49:
         _name: easter 49
-        type: observance
       easter 50:
         _name: easter 50
       3rd tuesday in September:
         name:
           nl: Prinsjesdag
         note: Scholen in Den Haag geven meestal 1 dag vrij
-        type: observance
-      10-04:
-        name:
-          nl: Dierendag
         type: observance
       11-11:
         _name: 11-11

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -42,7 +42,7 @@ names:
       mg: Taom-baovao
       mk: Нова Година
       mt: L-Ewwel tas-Sena
-      nl: Nieuwjaar
+      nl: Nieuwjaarsdag
       no: Første nyttårsdag
       pap: Aña Nobo
       pl: Nowy Rok
@@ -86,6 +86,7 @@ names:
     name:
       en: Candlemas
       de: Lichtmess
+      nl: Lichtmis
       vi: Lễ Đức Mẹ dâng Chúa Giêsu trong đền thánh
   02-14:
     name:
@@ -103,6 +104,7 @@ names:
       fr: Journée internationale des femmes
       hu: Nemzetközi nőnap
       hy: Կանանց տոն
+      nl: Internationale Vrouwendag
       ro: Ziua Internationala a Femeii
       ru: Международный женский день
       sl: Mednarodni dan žena
@@ -118,10 +120,12 @@ names:
       es: San José
       it: San Giuseppe
       mt: San Ġużepp
+      nl: Hoogfeest van de Heilige Jozef
       vi: Kính Thánh Giuse
   04-01:
     name:
       en: April Fools' Day
+      nl: 1 April
       sq: Dita e Gënjeshtrave
       vi: Cá tháng tư
   05-01:
@@ -173,6 +177,7 @@ names:
       fr: Saint Pierre et Paul
       it: Santi Pietro e Paolo
       mt: L-Imnarja
+      nl: Hoogfeest van Petrus en Paulus
       vi: Lễ kính Thánh Phêrô
   08-15:
     name:
@@ -252,6 +257,7 @@ names:
       fr: Immaculée Conception
       it: Immacolata Concezione
       mt: Il-Kunċizzjoni
+      nl: Onbevlekte Ontvangenis van Maria
       pt: Imaculada Conceição
   12-24:
     name:
@@ -400,6 +406,7 @@ names:
       de: Faschingsdienstag
       # de: Fastnacht
       hr: Pokladni utorak
+      nl: Vastenavond
       pt: Carnaval
       vi: Thứ ba mập béo
   easter -46: # Ash Wednesday
@@ -410,6 +417,7 @@ names:
       fr: Mercredi des Cendres
       it: Ceneri
       is: Öskudagur
+      nl: Aswoensdag
       pt: Quarta-feira de Cinzas
       sw: Jumatano ya Majivu
       vi: Thứ tư Lễ Tro
@@ -420,6 +428,7 @@ names:
       es: Domingo de Ramos
       it: Domenica delle Palme
       is: Pálmasunnudagur
+      nl: Palmzondag
       no: Palmesøndag
       vi: Chúa nhật Lễ Lá
   easter -3:  # Maundy Thursday
@@ -480,6 +489,7 @@ names:
       fil: Sabado de Gloria
       fr: Samedi saint
       it: Sabado santo
+      nl: Dag voor Pasen
       no: Påskeaften
       vi: Thứ bảy Tuần Thánh
   easter:     # Easter
@@ -539,7 +549,7 @@ names:
       lv: Otrās Lieldienas
       mg: Alatsinain'ny Paska
       mk: вториот ден на Велигден
-      nl: Paasmaandag
+      nl: Tweede paasdag
       no: Andre påskedag
       pap: Di dos Dia Pasco di Resureccion
       pl: Drugi dzień Wielkanocy
@@ -563,7 +573,7 @@ names:
       is: Uppstigningardagur
       kl: qilaliarfik
       mg: Andro niakarana
-      nl: O.L.H. Hemelvaart
+      nl: Hemelvaartsdag
       no: Kristi himmelfartsdag
       pap: Dia di Asuncion
       ro: Ziua Eroilor
@@ -584,7 +594,7 @@ names:
       it: Pentecoste
       is: Hvítasunnudagur
       kl: piinsip ullua
-      nl: Pinksteren
+      nl: Eerste pinksterdag
       no: Første pinsedag
       mk: Духовден
       pl: Zielone Świątki
@@ -606,7 +616,7 @@ names:
       is: Annar í hvítasunnu
       kl: piinsip aappaa
       mg: Alatsinain'ny Pentekosta
-      nl: Pinkstermaandag
+      nl: Tweede pinksterdag
       no: Andre pinsedag
       ro: Două zi de Rusalii
   easter 60:  # Corpus Christi
@@ -617,6 +627,7 @@ names:
       fr: la Fête-Dieu
       it: Corpus Domini
       hr: Tijelovo
+      nl: Sacramentsdag
       pl: Dzień Bożego Ciała
       pt: Corpo de Deus
       vi: Lễ Mình và Máu Thánh Chúa Kitô
@@ -625,11 +636,13 @@ names:
       en: Orthodox New Year
       bs: Pravoslavni novogodišnji dan
       hr: Pravoslavna Nova Godina
+      nl: Orthodox Nieuwjaar
       sq: Viti i Ri Ortodoks
       sr: Православна Нова година
   julian 12-24:
     name:
       en: Orthodox Christmas Eve
+      nl: Orthodox Kerstavond
       mk: Бадник
   julian 12-25:
     name:
@@ -637,6 +650,7 @@ names:
       bs: Pravoslavni Božić
       hr: Pravoslavni Božić
       mk: Прв ден Божик
+      nl: Orthodox Kerstmis
       ro: Craciun pe Rit Vechi
       sq: Krishtlindjet Ortodokse
       sr: Божић
@@ -645,6 +659,7 @@ names:
     name:
       en: Orthodox Good Friday
       mk: Велики Петок
+      nl: Orthodoxe Goede vrijdag
       sr: Велики петак
   orthodox:
     name:
@@ -652,6 +667,7 @@ names:
       bs: Pravoslavni Vaskrs
       hr: Pravoslavni Uskrs
       mk: Прв ден Велигден
+      nl: Orthodox Pasen
       sq: Pashkët Ortodokse
       sr: Васкрс
       uk: Великдень
@@ -659,6 +675,7 @@ names:
     name:
       en: Orthodox Easter Monday
       mk: Втор ден Велигден
+      nl: Orthodoxe Tweede Paasdag
       sr: Васкрсни понедељак
 
   # muslim holidays
@@ -670,12 +687,14 @@ names:
       fil: Unang Araw ng Muharram
       hr: Nova hidžretska godina
       ms: Awal Tahun Hijrah
+      nl: Islamitisch Nieuwjaar
       sq: Viti i Ri hixhri
   10 Muharram: # Day of Ashura
     name:
       en: Day of Ashura
       ar: 'عاشوراء'
       bn: আশুরা
+      nl: Asjoera
   12 Rabi al-awwal: # Birthday of Muhammad (Mawlid)
     name:
       en: Birthday of Muhammad (Mawlid)
@@ -685,6 +704,7 @@ names:
       bs: Mevlud
       fr: Mawlid
       ms: Maulidur Rasul
+      nl: Mawlid an-Nabi
       sq: Mevludi
   27 Rajab:   # Laylat al-Mi'raj (Muhammad's Ascension to Heaven)
     name:
@@ -692,6 +712,7 @@ names:
       ar: 'الإسراء والمعراج'
       bs: Lejletul Mi'radž
       ms: Israk dan Mikraj
+      nl: Laylat al-Miraadj
       sq: Nata e Miraxhit
       tr: Miraç Gecesi
   15 Shaban:  # Laylat al-Bara'at (Bara'at Night)
@@ -699,6 +720,7 @@ names:
       en: Laylat al-Bara'at
       ar: 'ليلة البراءة'
       bs: Lejletul berat
+      nl: Laylat al-Baraat
       sq: Nata e Beratit
   1 Ramadan:  # First day of Ramadan
     name:
@@ -707,12 +729,14 @@ names:
       ar: 'اليوم الأول من رمضان'
       bs: Prvi dan posta
       ms: Hari Pertama Berpuasa
+      nl: Eerste dag van Ramadan
       sq: Dita e parë e agjërimit
   27 Ramadan: # Laylat al-Qadr (Night of Power)
     name:
       en: Laylat al-Qadr
       ar: 'لیلة القدر'
       bs: Lejletul kadr
+      nl: Waardevolle Nacht (Laylat al-Qadr)
       sq: Nata e Kadrit
   1 Shawwal:  # End of Ramadan
     name:
@@ -764,6 +788,7 @@ names:
       bs: Pesah
       de: Pessach
       hr: Pesač
+      nl: Pesach
       sq: Pesach
       sr: Песах
   1 Tishrei: # Rosh Hashanah
@@ -772,6 +797,7 @@ names:
       bs: Roš Hašana
       de: Rosch Haschana
       hr: Roš Hašane
+      nl: Rosj Hasjana
       sq: Rosh Hashanah
       sr: Рош Хашана
   10 Tishrei: # Yom Kippur
@@ -781,6 +807,7 @@ names:
       de: Jom Kippur
       hr: Jom Kipur
       mk: Јом Кипур
+      nl: Jom Kipoer
       sq: Yom Kippur
       sr: Јом Кипур
 
@@ -815,6 +842,7 @@ names:
       hy: Սահմանադրության օր
       jp: 憲法記念日
       ko: 제헌절
+      nl: Dag van de Grondwet
       no: Grunnlovsdagen
       pt: Dia da Constituição
       ro: Ziua Constituției
@@ -861,6 +889,7 @@ names:
   Liberation Day:
     name:
       en: Liberation Day
+      nl: Bevrijdingsdag
       no: Frigjøringsdagen
       sq: Dita e Çlirimit
       vi: Ngày Thống nhất
@@ -903,6 +932,7 @@ names:
     name:
       en: Public Holiday
       fr: Jour férié légaux
+      nl: Wettelijke feestdag
       pt: Feriado Obrigatório
       vi: Nghỉ lễ Toàn Quốc
   Reformation Day:
@@ -910,6 +940,7 @@ names:
       en: Reformation Day
       de: Reformationstag
       es: Día Nacional de las Iglesias Evangélicas y Protestantes
+      nl: Hervormingsdag
       vi: Kháng Cách
   Revolution Day:
     name:

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -42,7 +42,7 @@ names:
       mg: Taom-baovao
       mk: Нова Година
       mt: L-Ewwel tas-Sena
-      nl: Nieuwjaarsdag
+      nl: Nieuwjaar
       no: Første nyttårsdag
       pap: Aña Nobo
       pl: Nowy Rok
@@ -573,7 +573,7 @@ names:
       is: Uppstigningardagur
       kl: qilaliarfik
       mg: Andro niakarana
-      nl: Hemelvaartsdag
+      nl: O.L.H. Hemelvaart
       no: Kristi himmelfartsdag
       pap: Dia di Asuncion
       ro: Ziua Eroilor
@@ -594,7 +594,7 @@ names:
       it: Pentecoste
       is: Hvítasunnudagur
       kl: piinsip ullua
-      nl: Eerste pinksterdag
+      nl: Pinksteren
       no: Første pinsedag
       mk: Духовден
       pl: Zielone Świątki

--- a/test/fixtures/BE-VLG-2015.json
+++ b/test/fixtures/BE-VLG-2015.json
@@ -35,7 +35,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-05T22:00:00.000Z",
     "end": "2015-04-06T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2015-05-25 00:00:00",
     "start": "2015-05-24T22:00:00.000Z",
     "end": "2015-05-25T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BE-VLG-2016.json
+++ b/test/fixtures/BE-VLG-2016.json
@@ -35,7 +35,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-27T22:00:00.000Z",
     "end": "2016-03-28T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2016-05-16 00:00:00",
     "start": "2016-05-15T22:00:00.000Z",
     "end": "2016-05-16T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BE-VLG-2017.json
+++ b/test/fixtures/BE-VLG-2017.json
@@ -35,7 +35,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T22:00:00.000Z",
     "end": "2017-04-17T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2017-06-05 00:00:00",
     "start": "2017-06-04T22:00:00.000Z",
     "end": "2017-06-05T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BE-VLG-2018.json
+++ b/test/fixtures/BE-VLG-2018.json
@@ -35,7 +35,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-01T22:00:00.000Z",
     "end": "2018-04-02T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2018-05-21 00:00:00",
     "start": "2018-05-20T22:00:00.000Z",
     "end": "2018-05-21T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BE-VLG-2019.json
+++ b/test/fixtures/BE-VLG-2019.json
@@ -35,7 +35,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-21T22:00:00.000Z",
     "end": "2019-04-22T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2019-06-10 00:00:00",
     "start": "2019-06-09T22:00:00.000Z",
     "end": "2019-06-10T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BE-VLG-2020.json
+++ b/test/fixtures/BE-VLG-2020.json
@@ -35,7 +35,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-12T22:00:00.000Z",
     "end": "2020-04-13T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2020-06-01 00:00:00",
     "start": "2020-05-31T22:00:00.000Z",
     "end": "2020-06-01T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BE-VLG-2021.json
+++ b/test/fixtures/BE-VLG-2021.json
@@ -35,7 +35,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-04T22:00:00.000Z",
     "end": "2021-04-05T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2021-05-24 00:00:00",
     "start": "2021-05-23T22:00:00.000Z",
     "end": "2021-05-24T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BE-VLG-2022.json
+++ b/test/fixtures/BE-VLG-2022.json
@@ -35,7 +35,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-17T22:00:00.000Z",
     "end": "2022-04-18T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2022-06-06 00:00:00",
     "start": "2022-06-05T22:00:00.000Z",
     "end": "2022-06-06T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BE-VLG-2023.json
+++ b/test/fixtures/BE-VLG-2023.json
@@ -35,7 +35,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-09T22:00:00.000Z",
     "end": "2023-04-10T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2023-05-29 00:00:00",
     "start": "2023-05-28T22:00:00.000Z",
     "end": "2023-05-29T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BE-VLG-2024.json
+++ b/test/fixtures/BE-VLG-2024.json
@@ -35,7 +35,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-03-31T22:00:00.000Z",
     "end": "2024-04-01T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2024-05-20 00:00:00",
     "start": "2024-05-19T22:00:00.000Z",
     "end": "2024-05-20T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BE-VLG-2025.json
+++ b/test/fixtures/BE-VLG-2025.json
@@ -35,7 +35,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T22:00:00.000Z",
     "end": "2025-04-21T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T22:00:00.000Z",
     "end": "2025-06-09T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2015.json
+++ b/test/fixtures/BQ-2015.json
@@ -27,7 +27,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-06T04:00:00.000Z",
     "end": "2015-04-07T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2016.json
+++ b/test/fixtures/BQ-2016.json
@@ -27,7 +27,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-28T04:00:00.000Z",
     "end": "2016-03-29T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2017.json
+++ b/test/fixtures/BQ-2017.json
@@ -27,7 +27,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-17T04:00:00.000Z",
     "end": "2017-04-18T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2018.json
+++ b/test/fixtures/BQ-2018.json
@@ -27,7 +27,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-02T04:00:00.000Z",
     "end": "2018-04-03T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2019.json
+++ b/test/fixtures/BQ-2019.json
@@ -27,7 +27,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-22T04:00:00.000Z",
     "end": "2019-04-23T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2020.json
+++ b/test/fixtures/BQ-2020.json
@@ -27,7 +27,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-13T04:00:00.000Z",
     "end": "2020-04-14T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2021.json
+++ b/test/fixtures/BQ-2021.json
@@ -27,7 +27,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-05T04:00:00.000Z",
     "end": "2021-04-06T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2022.json
+++ b/test/fixtures/BQ-2022.json
@@ -27,7 +27,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-18T04:00:00.000Z",
     "end": "2022-04-19T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2023.json
+++ b/test/fixtures/BQ-2023.json
@@ -27,7 +27,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-10T04:00:00.000Z",
     "end": "2023-04-11T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2024.json
+++ b/test/fixtures/BQ-2024.json
@@ -27,7 +27,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-04-01T04:00:00.000Z",
     "end": "2024-04-02T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-2025.json
+++ b/test/fixtures/BQ-2025.json
@@ -27,7 +27,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-21T04:00:00.000Z",
     "end": "2025-04-22T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2015.json
+++ b/test/fixtures/BQ-BO-2015.json
@@ -35,7 +35,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-06T04:00:00.000Z",
     "end": "2015-04-07T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2016.json
+++ b/test/fixtures/BQ-BO-2016.json
@@ -35,7 +35,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-28T04:00:00.000Z",
     "end": "2016-03-29T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2017.json
+++ b/test/fixtures/BQ-BO-2017.json
@@ -35,7 +35,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-17T04:00:00.000Z",
     "end": "2017-04-18T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2018.json
+++ b/test/fixtures/BQ-BO-2018.json
@@ -35,7 +35,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-02T04:00:00.000Z",
     "end": "2018-04-03T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2019.json
+++ b/test/fixtures/BQ-BO-2019.json
@@ -35,7 +35,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-22T04:00:00.000Z",
     "end": "2019-04-23T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2020.json
+++ b/test/fixtures/BQ-BO-2020.json
@@ -35,7 +35,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-13T04:00:00.000Z",
     "end": "2020-04-14T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2021.json
+++ b/test/fixtures/BQ-BO-2021.json
@@ -35,7 +35,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-05T04:00:00.000Z",
     "end": "2021-04-06T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2022.json
+++ b/test/fixtures/BQ-BO-2022.json
@@ -35,7 +35,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-18T04:00:00.000Z",
     "end": "2022-04-19T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2023.json
+++ b/test/fixtures/BQ-BO-2023.json
@@ -35,7 +35,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-10T04:00:00.000Z",
     "end": "2023-04-11T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2024.json
+++ b/test/fixtures/BQ-BO-2024.json
@@ -35,7 +35,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-04-01T04:00:00.000Z",
     "end": "2024-04-02T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-BO-2025.json
+++ b/test/fixtures/BQ-BO-2025.json
@@ -35,7 +35,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-21T04:00:00.000Z",
     "end": "2025-04-22T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2015.json
+++ b/test/fixtures/BQ-SA-2015.json
@@ -27,7 +27,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-06T04:00:00.000Z",
     "end": "2015-04-07T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2016.json
+++ b/test/fixtures/BQ-SA-2016.json
@@ -27,7 +27,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-28T04:00:00.000Z",
     "end": "2016-03-29T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2017.json
+++ b/test/fixtures/BQ-SA-2017.json
@@ -27,7 +27,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-17T04:00:00.000Z",
     "end": "2017-04-18T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2018.json
+++ b/test/fixtures/BQ-SA-2018.json
@@ -27,7 +27,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-02T04:00:00.000Z",
     "end": "2018-04-03T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2019.json
+++ b/test/fixtures/BQ-SA-2019.json
@@ -27,7 +27,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-22T04:00:00.000Z",
     "end": "2019-04-23T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2020.json
+++ b/test/fixtures/BQ-SA-2020.json
@@ -27,7 +27,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-13T04:00:00.000Z",
     "end": "2020-04-14T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2021.json
+++ b/test/fixtures/BQ-SA-2021.json
@@ -27,7 +27,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-05T04:00:00.000Z",
     "end": "2021-04-06T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2022.json
+++ b/test/fixtures/BQ-SA-2022.json
@@ -27,7 +27,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-18T04:00:00.000Z",
     "end": "2022-04-19T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2023.json
+++ b/test/fixtures/BQ-SA-2023.json
@@ -27,7 +27,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-10T04:00:00.000Z",
     "end": "2023-04-11T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2024.json
+++ b/test/fixtures/BQ-SA-2024.json
@@ -27,7 +27,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-04-01T04:00:00.000Z",
     "end": "2024-04-02T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SA-2025.json
+++ b/test/fixtures/BQ-SA-2025.json
@@ -27,7 +27,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-21T04:00:00.000Z",
     "end": "2025-04-22T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2015.json
+++ b/test/fixtures/BQ-SE-2015.json
@@ -27,7 +27,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-06T04:00:00.000Z",
     "end": "2015-04-07T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2016.json
+++ b/test/fixtures/BQ-SE-2016.json
@@ -27,7 +27,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-28T04:00:00.000Z",
     "end": "2016-03-29T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2017.json
+++ b/test/fixtures/BQ-SE-2017.json
@@ -27,7 +27,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-17T04:00:00.000Z",
     "end": "2017-04-18T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2018.json
+++ b/test/fixtures/BQ-SE-2018.json
@@ -27,7 +27,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-02T04:00:00.000Z",
     "end": "2018-04-03T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2019.json
+++ b/test/fixtures/BQ-SE-2019.json
@@ -27,7 +27,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-22T04:00:00.000Z",
     "end": "2019-04-23T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2020.json
+++ b/test/fixtures/BQ-SE-2020.json
@@ -27,7 +27,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-13T04:00:00.000Z",
     "end": "2020-04-14T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2021.json
+++ b/test/fixtures/BQ-SE-2021.json
@@ -27,7 +27,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-05T04:00:00.000Z",
     "end": "2021-04-06T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2022.json
+++ b/test/fixtures/BQ-SE-2022.json
@@ -27,7 +27,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-18T04:00:00.000Z",
     "end": "2022-04-19T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2023.json
+++ b/test/fixtures/BQ-SE-2023.json
@@ -27,7 +27,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-10T04:00:00.000Z",
     "end": "2023-04-11T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2024.json
+++ b/test/fixtures/BQ-SE-2024.json
@@ -27,7 +27,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-04-01T04:00:00.000Z",
     "end": "2024-04-02T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BQ-SE-2025.json
+++ b/test/fixtures/BQ-SE-2025.json
@@ -27,7 +27,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-21T04:00:00.000Z",
     "end": "2025-04-22T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2015.json
+++ b/test/fixtures/CW-2015.json
@@ -35,7 +35,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-06T04:00:00.000Z",
     "end": "2015-04-07T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2016.json
+++ b/test/fixtures/CW-2016.json
@@ -35,7 +35,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-28T04:00:00.000Z",
     "end": "2016-03-29T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2017.json
+++ b/test/fixtures/CW-2017.json
@@ -35,7 +35,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-17T04:00:00.000Z",
     "end": "2017-04-18T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2018.json
+++ b/test/fixtures/CW-2018.json
@@ -35,7 +35,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-02T04:00:00.000Z",
     "end": "2018-04-03T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2019.json
+++ b/test/fixtures/CW-2019.json
@@ -35,7 +35,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-22T04:00:00.000Z",
     "end": "2019-04-23T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2020.json
+++ b/test/fixtures/CW-2020.json
@@ -35,7 +35,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-13T04:00:00.000Z",
     "end": "2020-04-14T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2021.json
+++ b/test/fixtures/CW-2021.json
@@ -35,7 +35,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-05T04:00:00.000Z",
     "end": "2021-04-06T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2022.json
+++ b/test/fixtures/CW-2022.json
@@ -35,7 +35,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-18T04:00:00.000Z",
     "end": "2022-04-19T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2023.json
+++ b/test/fixtures/CW-2023.json
@@ -35,7 +35,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-10T04:00:00.000Z",
     "end": "2023-04-11T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2024.json
+++ b/test/fixtures/CW-2024.json
@@ -35,7 +35,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-04-01T04:00:00.000Z",
     "end": "2024-04-02T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CW-2025.json
+++ b/test/fixtures/CW-2025.json
@@ -35,7 +35,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-21T04:00:00.000Z",
     "end": "2025-04-22T04:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },

--- a/test/fixtures/NL-2015.json
+++ b/test/fixtures/NL-2015.json
@@ -20,14 +20,14 @@
     "start": "2015-04-04T22:00:00.000Z",
     "end": "2015-04-05T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-05T22:00:00.000Z",
     "end": "2015-04-06T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2015-05-23T22:00:00.000Z",
     "end": "2015-05-24T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2015-05-25 00:00:00",
     "start": "2015-05-24T22:00:00.000Z",
     "end": "2015-05-25T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -103,14 +103,6 @@
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2015-10-04 00:00:00",
-    "start": "2015-10-03T22:00:00.000Z",
-    "end": "2015-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
-    "_weekday": "Sun"
   },
   {
     "date": "2015-11-11 00:00:00",

--- a/test/fixtures/NL-2016.json
+++ b/test/fixtures/NL-2016.json
@@ -12,7 +12,7 @@
     "start": "2016-03-24T23:00:00.000Z",
     "end": "2016-03-25T23:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -20,14 +20,14 @@
     "start": "2016-03-26T23:00:00.000Z",
     "end": "2016-03-27T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-27T22:00:00.000Z",
     "end": "2016-03-28T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2016-05-14T22:00:00.000Z",
     "end": "2016-05-15T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2016-05-16 00:00:00",
     "start": "2016-05-15T22:00:00.000Z",
     "end": "2016-05-16T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -102,14 +102,6 @@
     "name": "Prinsjesdag",
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
-    "_weekday": "Tue"
-  },
-  {
-    "date": "2016-10-04 00:00:00",
-    "start": "2016-10-03T22:00:00.000Z",
-    "end": "2016-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/NL-2017.json
+++ b/test/fixtures/NL-2017.json
@@ -12,7 +12,7 @@
     "start": "2017-04-13T22:00:00.000Z",
     "end": "2017-04-14T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -20,14 +20,14 @@
     "start": "2017-04-15T22:00:00.000Z",
     "end": "2017-04-16T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T22:00:00.000Z",
     "end": "2017-04-17T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2017-06-03T22:00:00.000Z",
     "end": "2017-06-04T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2017-06-05 00:00:00",
     "start": "2017-06-04T22:00:00.000Z",
     "end": "2017-06-05T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -103,14 +103,6 @@
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2017-10-04 00:00:00",
-    "start": "2017-10-03T22:00:00.000Z",
-    "end": "2017-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
-    "_weekday": "Wed"
   },
   {
     "date": "2017-11-11 00:00:00",

--- a/test/fixtures/NL-2018.json
+++ b/test/fixtures/NL-2018.json
@@ -12,7 +12,7 @@
     "start": "2018-03-29T22:00:00.000Z",
     "end": "2018-03-30T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -20,14 +20,14 @@
     "start": "2018-03-31T22:00:00.000Z",
     "end": "2018-04-01T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-01T22:00:00.000Z",
     "end": "2018-04-02T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2018-05-19T22:00:00.000Z",
     "end": "2018-05-20T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2018-05-21 00:00:00",
     "start": "2018-05-20T22:00:00.000Z",
     "end": "2018-05-21T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -103,14 +103,6 @@
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-10-04 00:00:00",
-    "start": "2018-10-03T22:00:00.000Z",
-    "end": "2018-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
-    "_weekday": "Thu"
   },
   {
     "date": "2018-11-11 00:00:00",

--- a/test/fixtures/NL-2019.json
+++ b/test/fixtures/NL-2019.json
@@ -12,7 +12,7 @@
     "start": "2019-04-18T22:00:00.000Z",
     "end": "2019-04-19T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -20,14 +20,14 @@
     "start": "2019-04-20T22:00:00.000Z",
     "end": "2019-04-21T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-21T22:00:00.000Z",
     "end": "2019-04-22T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2019-06-08T22:00:00.000Z",
     "end": "2019-06-09T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2019-06-10 00:00:00",
     "start": "2019-06-09T22:00:00.000Z",
     "end": "2019-06-10T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -103,14 +103,6 @@
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2019-10-04 00:00:00",
-    "start": "2019-10-03T22:00:00.000Z",
-    "end": "2019-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
-    "_weekday": "Fri"
   },
   {
     "date": "2019-11-11 00:00:00",

--- a/test/fixtures/NL-2020.json
+++ b/test/fixtures/NL-2020.json
@@ -12,7 +12,7 @@
     "start": "2020-04-09T22:00:00.000Z",
     "end": "2020-04-10T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -20,14 +20,14 @@
     "start": "2020-04-11T22:00:00.000Z",
     "end": "2020-04-12T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-12T22:00:00.000Z",
     "end": "2020-04-13T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2020-05-30T22:00:00.000Z",
     "end": "2020-05-31T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2020-06-01 00:00:00",
     "start": "2020-05-31T22:00:00.000Z",
     "end": "2020-06-01T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -103,14 +103,6 @@
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2020-10-04 00:00:00",
-    "start": "2020-10-03T22:00:00.000Z",
-    "end": "2020-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
-    "_weekday": "Sun"
   },
   {
     "date": "2020-11-11 00:00:00",

--- a/test/fixtures/NL-2021.json
+++ b/test/fixtures/NL-2021.json
@@ -12,7 +12,7 @@
     "start": "2021-04-01T22:00:00.000Z",
     "end": "2021-04-02T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -20,14 +20,14 @@
     "start": "2021-04-03T22:00:00.000Z",
     "end": "2021-04-04T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-04T22:00:00.000Z",
     "end": "2021-04-05T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2021-05-22T22:00:00.000Z",
     "end": "2021-05-23T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2021-05-24 00:00:00",
     "start": "2021-05-23T22:00:00.000Z",
     "end": "2021-05-24T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -103,14 +103,6 @@
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2021-10-04 00:00:00",
-    "start": "2021-10-03T22:00:00.000Z",
-    "end": "2021-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-11-11 00:00:00",

--- a/test/fixtures/NL-2022.json
+++ b/test/fixtures/NL-2022.json
@@ -12,7 +12,7 @@
     "start": "2022-04-14T22:00:00.000Z",
     "end": "2022-04-15T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -20,14 +20,14 @@
     "start": "2022-04-16T22:00:00.000Z",
     "end": "2022-04-17T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-17T22:00:00.000Z",
     "end": "2022-04-18T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2022-06-04T22:00:00.000Z",
     "end": "2022-06-05T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2022-06-06 00:00:00",
     "start": "2022-06-05T22:00:00.000Z",
     "end": "2022-06-06T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -102,14 +102,6 @@
     "name": "Prinsjesdag",
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
-    "_weekday": "Tue"
-  },
-  {
-    "date": "2022-10-04 00:00:00",
-    "start": "2022-10-03T22:00:00.000Z",
-    "end": "2022-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/NL-2023.json
+++ b/test/fixtures/NL-2023.json
@@ -12,7 +12,7 @@
     "start": "2023-04-06T22:00:00.000Z",
     "end": "2023-04-07T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -20,14 +20,14 @@
     "start": "2023-04-08T22:00:00.000Z",
     "end": "2023-04-09T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-09T22:00:00.000Z",
     "end": "2023-04-10T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2023-05-27T22:00:00.000Z",
     "end": "2023-05-28T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2023-05-29 00:00:00",
     "start": "2023-05-28T22:00:00.000Z",
     "end": "2023-05-29T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -103,14 +103,6 @@
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2023-10-04 00:00:00",
-    "start": "2023-10-03T22:00:00.000Z",
-    "end": "2023-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
-    "_weekday": "Wed"
   },
   {
     "date": "2023-11-11 00:00:00",

--- a/test/fixtures/NL-2024.json
+++ b/test/fixtures/NL-2024.json
@@ -12,7 +12,7 @@
     "start": "2024-03-28T23:00:00.000Z",
     "end": "2024-03-29T23:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -20,14 +20,14 @@
     "start": "2024-03-30T23:00:00.000Z",
     "end": "2024-03-31T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2024-04-01 00:00:00",
     "start": "2024-03-31T22:00:00.000Z",
     "end": "2024-04-01T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2024-05-18T22:00:00.000Z",
     "end": "2024-05-19T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2024-05-20 00:00:00",
     "start": "2024-05-19T22:00:00.000Z",
     "end": "2024-05-20T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -103,14 +103,6 @@
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2024-10-04 00:00:00",
-    "start": "2024-10-03T22:00:00.000Z",
-    "end": "2024-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
-    "_weekday": "Fri"
   },
   {
     "date": "2024-11-11 00:00:00",

--- a/test/fixtures/NL-2025.json
+++ b/test/fixtures/NL-2025.json
@@ -12,7 +12,7 @@
     "start": "2025-04-17T22:00:00.000Z",
     "end": "2025-04-18T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Fri"
   },
   {
@@ -20,14 +20,14 @@
     "start": "2025-04-19T22:00:00.000Z",
     "end": "2025-04-20T22:00:00.000Z",
     "name": "Pasen",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T22:00:00.000Z",
     "end": "2025-04-21T22:00:00.000Z",
-    "name": "Paasmaandag",
+    "name": "Tweede paasdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -76,14 +76,14 @@
     "start": "2025-06-07T22:00:00.000Z",
     "end": "2025-06-08T22:00:00.000Z",
     "name": "Pinksteren",
-    "type": "observance",
+    "type": "public",
     "_weekday": "Sun"
   },
   {
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T22:00:00.000Z",
     "end": "2025-06-09T22:00:00.000Z",
-    "name": "Pinkstermaandag",
+    "name": "Tweede pinksterdag",
     "type": "public",
     "_weekday": "Mon"
   },
@@ -103,14 +103,6 @@
     "type": "observance",
     "note": "Scholen in Den Haag geven meestal 1 dag vrij",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2025-10-04 00:00:00",
-    "start": "2025-10-03T22:00:00.000Z",
-    "end": "2025-10-04T22:00:00.000Z",
-    "name": "Dierendag",
-    "type": "observance",
-    "_weekday": "Sat"
   },
   {
     "date": "2025-11-11 00:00:00",


### PR DESCRIPTION
Changed to reflect public holidays to what the government says.

Good Friday, Easter, Day after Easter, Pentecost and day after Pentecost are all official holidays in the Netherlands.

Dierendag (Animals day) is not a holiday at all and should be removed.


Source
[Dutch Government](https://www.rijksoverheid.nl/onderwerpen/arbeidsovereenkomst-en-cao/vraag-en-antwoord/officiele-feestdagen)
[Dutch Government but in English](https://www.government.nl/topics/school-holidays/question-and-answer/on-which-public-holidays-are-schools-closed-in-the-netherlands)