### PR TITLE
Added 'midsommarafton' public holiday, old 'midsommar' -> 'midsommardagen'

### DIFF
--- a/data/countries/SE.yaml
+++ b/data/countries/SE.yaml
@@ -29,9 +29,12 @@ holidays:
         name:
           sv: Sveriges nationaldag
           en: National Day
+      friday after 06-19:
+        name:
+          sv: Midsommarafton
       saturday after 06-20:
         name:
-          sv: Midsommar
+          sv: Midsommardagen
       saturday after 10-31:
         name:
           sv: Alla Helgons dag

--- a/test/fixtures/SE-2015.json
+++ b/test/fixtures/SE-2015.json
@@ -126,10 +126,19 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2015-06-19 00:00:00",
+    "start": "2015-06-18T22:00:00.000Z",
+    "end": "2015-06-19T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2015-06-20 00:00:00",
     "start": "2015-06-19T22:00:00.000Z",
     "end": "2015-06-20T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2016.json
+++ b/test/fixtures/SE-2016.json
@@ -126,10 +126,19 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-24 00:00:00",
+    "start": "2016-06-23T22:00:00.000Z",
+    "end": "2016-06-24T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2016-06-25 00:00:00",
     "start": "2016-06-24T22:00:00.000Z",
     "end": "2016-06-25T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2017.json
+++ b/test/fixtures/SE-2017.json
@@ -126,10 +126,19 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2017-06-23 00:00:00",
+    "start": "2017-06-22T22:00:00.000Z",
+    "end": "2017-06-23T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2017-06-24 00:00:00",
     "start": "2017-06-23T22:00:00.000Z",
     "end": "2017-06-24T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2018.json
+++ b/test/fixtures/SE-2018.json
@@ -126,10 +126,19 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2018-06-22 00:00:00",
+    "start": "2018-06-21T22:00:00.000Z",
+    "end": "2018-06-22T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2018-06-23 00:00:00",
     "start": "2018-06-22T22:00:00.000Z",
     "end": "2018-06-23T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2019.json
+++ b/test/fixtures/SE-2019.json
@@ -126,10 +126,19 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-20T22:00:00.000Z",
+    "end": "2019-06-21T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2019-06-22 00:00:00",
     "start": "2019-06-21T22:00:00.000Z",
     "end": "2019-06-22T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2020.json
+++ b/test/fixtures/SE-2020.json
@@ -126,10 +126,19 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2020-06-19 00:00:00",
+    "start": "2020-06-18T22:00:00.000Z",
+    "end": "2020-06-19T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2020-06-20 00:00:00",
     "start": "2020-06-19T22:00:00.000Z",
     "end": "2020-06-20T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2021.json
+++ b/test/fixtures/SE-2021.json
@@ -126,10 +126,19 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-06-25 00:00:00",
+    "start": "2021-06-24T22:00:00.000Z",
+    "end": "2021-06-25T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2021-06-26 00:00:00",
     "start": "2021-06-25T22:00:00.000Z",
     "end": "2021-06-26T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2022.json
+++ b/test/fixtures/SE-2022.json
@@ -126,10 +126,19 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-06-24 00:00:00",
+    "start": "2022-06-23T22:00:00.000Z",
+    "end": "2022-06-24T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2022-06-25 00:00:00",
     "start": "2022-06-24T22:00:00.000Z",
     "end": "2022-06-25T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2023.json
+++ b/test/fixtures/SE-2023.json
@@ -126,10 +126,19 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2023-06-23 00:00:00",
+    "start": "2023-06-22T22:00:00.000Z",
+    "end": "2023-06-23T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2023-06-24 00:00:00",
     "start": "2023-06-23T22:00:00.000Z",
     "end": "2023-06-24T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2024.json
+++ b/test/fixtures/SE-2024.json
@@ -126,10 +126,19 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-20T22:00:00.000Z",
+    "end": "2024-06-21T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2024-06-22 00:00:00",
     "start": "2024-06-21T22:00:00.000Z",
     "end": "2024-06-22T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2025.json
+++ b/test/fixtures/SE-2025.json
@@ -126,10 +126,19 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2025-06-20 00:00:00",
+    "start": "2025-06-19T22:00:00.000Z",
+    "end": "2025-06-20T22:00:00.000Z",
+    "name": "Midsommarafton",
+    "type": "public",
+    "rule": "friday after 06-19",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2025-06-21 00:00:00",
     "start": "2025-06-20T22:00:00.000Z",
     "end": "2025-06-21T22:00:00.000Z",
-    "name": "Midsommar",
+    "name": "Midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"


### PR DESCRIPTION
* Added Swedish public holiday _Midsommarafton_ (Midsummer's eve) to `SE.yaml`
* Refactored Swedish public holiday _Midsommar_ :arrow_right: _Midsommardagen_
* Updated test files to reflect new changes

In Sweden, simply _Midsummer_ is not a holiday per se, but consists of two days (see [Wikipedia](https://en.wikipedia.org/wiki/Midsummer#Sweden)), Midsummer's eve and Midsummer's day. Both of these are holidays.

Thanks for a great library!