### PR TITLE
Update HR with 2020 change and add types

### DIFF
--- a/data/countries/HR.yaml
+++ b/data/countries/HR.yaml
@@ -28,7 +28,7 @@ holidays:
         _name: easter 60
         type: public
       03-08:
-        _name: 05-01
+        _name: 03-08
         type: observance
       05-01:
         _name: 05-01
@@ -38,6 +38,8 @@ holidays:
           hr: Dan državnosti
           en: National Day
         type: public
+        active:
+          - from: '2020-01-01'
       2nd sunday in May:
         _name: Mothers Day
         type: observance
@@ -46,32 +48,59 @@ holidays:
           hr: Dan antifašističke borbe
           en: Anti-Fascist Struggle Day
         type: public
+      '06-25 #1':
+        name:
+          hr: Dan državnosti
+          en: Statehood Day
+        type: public
+        active:
+          - to: '2020-01-01'
       06-25:
         name:
           hr: Dan neovisnosti
-          en: Independence Day	
+          en: Independence Day
         type: observance
+        active:
+          - from: '2020-01-01'
       08-05:
         name:
-          hr: Dan pobjede i domovinske zahvalnosti
+          hr: Dan pobjede i domovinske zahvalnosti i Dan hrvatskih branitelja
           en: Victory and Homeland Thanksgiving Day and the Day of Croatian defenders
         type: public
       08-15:
         _name: 08-15
         type: public
+      '10-08 #1':
+        name:
+          hr: Dan neovisnosti
+          en: Independence Day
+        type: public
+        active:
+          - to: '2020-01-01'
       10-08:
         name:
-          hr: Dan Hrvatskoga sabora.
+          hr: Dan Hrvatskoga sabora
           en: Day of the Croatian Parliament
         type: observence
+        active:
+          - from: '2020-01-01'
       11-01:
         _name: 11-01
         type: public
+      '11-18 #1':
+        name:
+          hr: Dan sjećanja na žrtvu Vukovara i Škabrnje
+          en: Remembrance Day
+        type: observance
+        active:
+          - to: '2020-01-01'
       11-18:
         name:
-          hr: Dan sjećanja na žrtve Domovinskog rata
+          hr: Dan sjećanja na žrtve Domovinskog rata i Dan sjećanja na žrtvu Vukovara i Škabrnje
           en: Remembrance Day
         type: public
+        active:
+          - from: '2020-01-01'
       12-25:
         _name: 12-25
         type: public

--- a/data/countries/HR.yaml
+++ b/data/countries/HR.yaml
@@ -112,15 +112,15 @@ holidays:
       orthodox:
         _name: orthodox
         type: optional
-        note: Othhodox believers (legally defined as Christians who follow the Julian Calender)
+        note: Orthodox believers (legally defined as Christians who follow the Julian Calender)
       orthodox 1:
         _name: orthodox 1
         type: optional
-        note: Othhodox believers (legally defined as Christians who follow the Julian Calender)
+        note: Orthodox believers (legally defined as Christians who follow the Julian Calender)
       julian 12-25:
         _name: julian 12-25
         type: optional
-        note: Othhodox believers (legally defined as Christians who follow the Julian Calender)
+        note: Orthodox believers (legally defined as Christians who follow the Julian Calender)
       10 Dhu al-Hijjah:
         _name: 10 Dhu al-Hijjah
         type: optional

--- a/data/countries/HR.yaml
+++ b/data/countries/HR.yaml
@@ -106,7 +106,37 @@ holidays:
         type: public
       12-26:
         _name: 12-26
-        type: public
+        type: public      
+      # Religius holidays
+      # optional holidays for religious minorities
+      orthodox:
+        _name: orthodox
+        type: optional
+        note: Othhodox believers (legally defined as Christians who follow the Julian Calender)
+      orthodox 1:
+        _name: orthodox 1
+        type: optional
+        note: Othhodox believers (legally defined as Christians who follow the Julian Calender)
+      julian 12-25:
+        _name: julian 12-25
+        type: optional
+        note: Othhodox believers (legally defined as Christians who follow the Julian Calender)
+      10 Dhu al-Hijjah:
+        _name: 10 Dhu al-Hijjah
+        type: optional
+        note: Muslim believers
+      1 Shawwal:
+        _name: 1 Shawwal
+        type: optional
+        note: Muslim believers
+      1 Tishrei:
+        _name: 10 Tishrei
+        type: optional
+        note: Jewish believers
+      10 Tishrei:
+        _name: 10 Tishrei
+        type: optional
+        note: Jewish believers
     regions:
       '17':
         name: Split-Dalmatia

--- a/data/countries/HR.yaml
+++ b/data/countries/HR.yaml
@@ -66,6 +66,7 @@ holidays:
         type: observence
       11-01:
         _name: 11-01
+        type: public
       11-18:
         name:
           hr: Dan sjećanja na žrtve Domovinskog rata

--- a/data/countries/HR.yaml
+++ b/data/countries/HR.yaml
@@ -11,19 +11,33 @@ holidays:
     days:
       01-01:
         _name: 01-01
+        type: public
       01-06:
         _name: 01-06
+        type: public
       easter -47:
         _name: easter -47
         type: observance
       easter:
         _name: easter
+        type: public
       easter 1:
         _name: easter 1
+        type: public
       easter 60:
         _name: easter 60
+        type: public
+      03-08:
+        _name: 05-01
+        type: observance
       05-01:
         _name: 05-01
+        type: public
+      05-30:
+        name:
+          hr: Dan državnosti
+          en: National Day
+        type: public
       2nd sunday in May:
         _name: Mothers Day
         type: observance
@@ -31,24 +45,38 @@ holidays:
         name:
           hr: Dan antifašističke borbe
           en: Anti-Fascist Struggle Day
+        type: public
       06-25:
         name:
-          hr: Dan državnosti
-          en: Statehood Day
+          hr: Dan neovisnosti
+          en: Independence Day	
+        type: observance
       08-05:
         name:
           hr: Dan pobjede i domovinske zahvalnosti
           en: Victory and Homeland Thanksgiving Day and the Day of Croatian defenders
+        type: public
       08-15:
         _name: 08-15
+        type: public
       10-08:
-        _name: Independence Day
+        name:
+          hr: Dan Hrvatskoga sabora.
+          en: Day of the Croatian Parliament
+        type: observence
       11-01:
         _name: 11-01
+      11-18:
+        name:
+          hr: Dan sjećanja na žrtve Domovinskog rata
+          en: Remembrance Day
+        type: public
       12-25:
         _name: 12-25
+        type: public
       12-26:
         _name: 12-26
+        type: public
     regions:
       '17':
         name: Split-Dalmatia
@@ -57,6 +85,7 @@ holidays:
             name:
               hr: Sveti Duje
               en: Saint Domnius
+            type: optional
       '19':
         name: Dubrovnik-Neretva
         days:
@@ -64,3 +93,4 @@ holidays:
             name:
               hr: Sveti Vlaho
               en: Saint Blaise
+            type: optional


### PR DESCRIPTION
In 2020 there has been a change in Holidays in Croatia, more info at: https://en.wikipedia.org/wiki/Public_holidays_in_Croatia - Updated data to reflect that change

Additionally added the types of the holidays along with the widely observed International Women's day .

Marked the regional holidays as optional because they don't cover the entire county (just the municipal areas of Split and Dubrovnik respectively) and do not necessarily include all types of business and services as public holidays do.