### PR TITLE
fix(ES): Correct Spanish holidays

### DIFF
--- a/data/countries/ES.yaml
+++ b/data/countries/ES.yaml
@@ -14,20 +14,21 @@ holidays:
       01-01:
         _name: 01-01
       substitutes 01-01 if sunday then next monday:
+        type: observance
         substitute: true
         _name: 01-01
       01-06:
         _name: 01-06
       substitutes 01-06 if sunday then next monday:
+        type: observance
         substitute: true
         _name: 01-06
       03-19:
         _name: 03-19
-      substitutes 03-19 if sunday then next monday:
-        substitute: true
-        _name: 03-19
+        type: observance
       easter -3:
         _name: easter -3
+        type: observance
       easter -2:
         _name: easter -2
       easter:
@@ -36,6 +37,7 @@ holidays:
       05-01:
         _name: 05-01
       substitutes 05-01 if sunday then next monday:
+        type: observance
         substitute: true
         _name: 05-01
       1st sunday in May:
@@ -53,26 +55,40 @@ holidays:
         _name: 08-15
       substitutes 08-15 if sunday then next monday:
         substitute: true
+        type: observance
         _name: 08-15
-      10-12 if sunday then next monday:
+      10-12:
+        name:
+          es: Fiesta Nacional de España
+      substitutes 10-12 if sunday then next monday:
+        substitute: true
+        type: observance
         name:
           es: Fiesta Nacional de España
       11-01:
         _name: 11-01
       substitutes 11-01 if sunday then next monday:
         substitute: true
+        type: observance
         _name: 11-01
-      12-06 if sunday then next monday:
+      12-06:
+        name:
+          es: Día de la Constitución Española
+      substitutes 12-06 if sunday then next monday:
+        type: observance
+        substitute: true
         name:
           es: Día de la Constitución Española
       12-08:
         _name: 12-08
       substitutes 12-08 if sunday then next monday:
+        type: observance
         substitute: true
         _name: 12-08
       12-25:
         _name: 12-25
       substitutes 12-25 if sunday then next monday:
+        type: observance
         substitute: true
         _name: 12-25
     states:

--- a/test/fixtures/ES-2015.json
+++ b/test/fixtures/ES-2015.json
@@ -22,7 +22,7 @@
     "start": "2015-03-18T23:00:00.000Z",
     "end": "2015-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Thu"
   },
@@ -31,7 +31,7 @@
     "start": "2015-04-01T22:00:00.000Z",
     "end": "2015-04-02T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -105,7 +105,7 @@
     "end": "2015-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Mon"
   },
   {
@@ -122,18 +122,28 @@
     "start": "2015-11-01T23:00:00.000Z",
     "end": "2015-11-02T23:00:00.000Z",
     "name": "Todos los Santos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 11-01 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
+    "date": "2015-12-06 00:00:00",
+    "start": "2015-12-05T23:00:00.000Z",
+    "end": "2015-12-06T23:00:00.000Z",
+    "name": "Día de la Constitución Española",
+    "type": "public",
+    "rule": "12-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-07 00:00:00",
     "start": "2015-12-06T23:00:00.000Z",
     "end": "2015-12-07T23:00:00.000Z",
-    "name": "Día de la Constitución Española",
-    "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "name": "Día de la Constitución Española (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 12-06 if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-2016.json
+++ b/test/fixtures/ES-2016.json
@@ -22,7 +22,7 @@
     "start": "2016-03-18T23:00:00.000Z",
     "end": "2016-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sat"
   },
@@ -31,7 +31,7 @@
     "start": "2016-03-23T23:00:00.000Z",
     "end": "2016-03-24T23:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -76,7 +76,7 @@
     "start": "2016-05-01T22:00:00.000Z",
     "end": "2016-05-02T22:00:00.000Z",
     "name": "Fiesta del trabajo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 05-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -115,7 +115,7 @@
     "end": "2016-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Wed"
   },
   {
@@ -133,7 +133,7 @@
     "end": "2016-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Tue"
   },
   {
@@ -159,7 +159,7 @@
     "start": "2016-12-25T23:00:00.000Z",
     "end": "2016-12-26T23:00:00.000Z",
     "name": "Navidad (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-25 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-2017.json
+++ b/test/fixtures/ES-2017.json
@@ -13,7 +13,7 @@
     "start": "2017-01-01T23:00:00.000Z",
     "end": "2017-01-02T23:00:00.000Z",
     "name": "Año Nuevo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,26 +32,16 @@
     "start": "2017-03-18T23:00:00.000Z",
     "end": "2017-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2017-03-20 00:00:00",
-    "start": "2017-03-19T23:00:00.000Z",
-    "end": "2017-03-20T23:00:00.000Z",
-    "name": "San José (día sustituto)",
-    "type": "public",
-    "substitute": true,
-    "rule": "substitutes 03-19 if sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2017-04-13 00:00:00",
     "start": "2017-04-12T22:00:00.000Z",
     "end": "2017-04-13T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -125,7 +115,7 @@
     "end": "2017-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Thu"
   },
   {
@@ -143,7 +133,7 @@
     "end": "2017-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/ES-2018.json
+++ b/test/fixtures/ES-2018.json
@@ -22,7 +22,7 @@
     "start": "2018-03-18T23:00:00.000Z",
     "end": "2018-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Mon"
   },
@@ -31,7 +31,7 @@
     "start": "2018-03-28T22:00:00.000Z",
     "end": "2018-03-29T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -105,7 +105,7 @@
     "end": "2018-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Fri"
   },
   {
@@ -123,7 +123,7 @@
     "end": "2018-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/ES-2019.json
+++ b/test/fixtures/ES-2019.json
@@ -22,7 +22,7 @@
     "start": "2019-01-06T23:00:00.000Z",
     "end": "2019-01-07T23:00:00.000Z",
     "name": "Día de los Reyes Magos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-06 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,7 +32,7 @@
     "start": "2019-03-18T23:00:00.000Z",
     "end": "2019-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Tue"
   },
@@ -41,7 +41,7 @@
     "start": "2019-04-17T22:00:00.000Z",
     "end": "2019-04-18T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -115,7 +115,7 @@
     "end": "2019-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Sat"
   },
   {
@@ -133,7 +133,7 @@
     "end": "2019-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Fri"
   },
   {
@@ -150,7 +150,7 @@
     "start": "2019-12-08T23:00:00.000Z",
     "end": "2019-12-09T23:00:00.000Z",
     "name": "La inmaculada concepción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-08 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-2020.json
+++ b/test/fixtures/ES-2020.json
@@ -22,7 +22,7 @@
     "start": "2020-03-18T23:00:00.000Z",
     "end": "2020-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Thu"
   },
@@ -31,7 +31,7 @@
     "start": "2020-04-08T22:00:00.000Z",
     "end": "2020-04-09T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -105,7 +105,7 @@
     "end": "2020-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Mon"
   },
   {
@@ -122,18 +122,28 @@
     "start": "2020-11-01T23:00:00.000Z",
     "end": "2020-11-02T23:00:00.000Z",
     "name": "Todos los Santos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 11-01 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
+    "date": "2020-12-06 00:00:00",
+    "start": "2020-12-05T23:00:00.000Z",
+    "end": "2020-12-06T23:00:00.000Z",
+    "name": "Día de la Constitución Española",
+    "type": "public",
+    "rule": "12-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-07 00:00:00",
     "start": "2020-12-06T23:00:00.000Z",
     "end": "2020-12-07T23:00:00.000Z",
-    "name": "Día de la Constitución Española",
-    "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "name": "Día de la Constitución Española (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 12-06 if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-2021.json
+++ b/test/fixtures/ES-2021.json
@@ -22,7 +22,7 @@
     "start": "2021-03-18T23:00:00.000Z",
     "end": "2021-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Fri"
   },
@@ -31,7 +31,7 @@
     "start": "2021-03-31T22:00:00.000Z",
     "end": "2021-04-01T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -104,7 +104,7 @@
     "start": "2021-08-15T22:00:00.000Z",
     "end": "2021-08-16T22:00:00.000Z",
     "name": "Asunción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 08-15 if sunday then next monday",
     "_weekday": "Mon"
@@ -115,7 +115,7 @@
     "end": "2021-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Tue"
   },
   {
@@ -133,7 +133,7 @@
     "end": "2021-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-2022.json
+++ b/test/fixtures/ES-2022.json
@@ -22,7 +22,7 @@
     "start": "2022-03-18T23:00:00.000Z",
     "end": "2022-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sat"
   },
@@ -31,7 +31,7 @@
     "start": "2022-04-13T22:00:00.000Z",
     "end": "2022-04-14T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -76,7 +76,7 @@
     "start": "2022-05-01T22:00:00.000Z",
     "end": "2022-05-02T22:00:00.000Z",
     "name": "Fiesta del trabajo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 05-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -115,7 +115,7 @@
     "end": "2022-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Wed"
   },
   {
@@ -133,7 +133,7 @@
     "end": "2022-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Tue"
   },
   {
@@ -159,7 +159,7 @@
     "start": "2022-12-25T23:00:00.000Z",
     "end": "2022-12-26T23:00:00.000Z",
     "name": "Navidad (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-25 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-2023.json
+++ b/test/fixtures/ES-2023.json
@@ -13,7 +13,7 @@
     "start": "2023-01-01T23:00:00.000Z",
     "end": "2023-01-02T23:00:00.000Z",
     "name": "Año Nuevo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,26 +32,16 @@
     "start": "2023-03-18T23:00:00.000Z",
     "end": "2023-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2023-03-20 00:00:00",
-    "start": "2023-03-19T23:00:00.000Z",
-    "end": "2023-03-20T23:00:00.000Z",
-    "name": "San José (día sustituto)",
-    "type": "public",
-    "substitute": true,
-    "rule": "substitutes 03-19 if sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-04-06 00:00:00",
     "start": "2023-04-05T22:00:00.000Z",
     "end": "2023-04-06T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -125,7 +115,7 @@
     "end": "2023-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Thu"
   },
   {
@@ -143,7 +133,7 @@
     "end": "2023-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/ES-2024.json
+++ b/test/fixtures/ES-2024.json
@@ -22,7 +22,7 @@
     "start": "2024-03-18T23:00:00.000Z",
     "end": "2024-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Tue"
   },
@@ -31,7 +31,7 @@
     "start": "2024-03-27T23:00:00.000Z",
     "end": "2024-03-28T23:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -105,7 +105,7 @@
     "end": "2024-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Sat"
   },
   {
@@ -123,7 +123,7 @@
     "end": "2024-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Fri"
   },
   {
@@ -140,7 +140,7 @@
     "start": "2024-12-08T23:00:00.000Z",
     "end": "2024-12-09T23:00:00.000Z",
     "name": "La inmaculada concepción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-08 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-2025.json
+++ b/test/fixtures/ES-2025.json
@@ -22,7 +22,7 @@
     "start": "2025-03-18T23:00:00.000Z",
     "end": "2025-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Wed"
   },
@@ -31,7 +31,7 @@
     "start": "2025-04-16T22:00:00.000Z",
     "end": "2025-04-17T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -100,12 +100,22 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-10-12 00:00:00",
+    "start": "2025-10-11T22:00:00.000Z",
+    "end": "2025-10-12T22:00:00.000Z",
+    "name": "Fiesta Nacional de España",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-10-13 00:00:00",
     "start": "2025-10-12T22:00:00.000Z",
     "end": "2025-10-13T22:00:00.000Z",
-    "name": "Fiesta Nacional de España",
-    "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "name": "Fiesta Nacional de España (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 10-12 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -123,7 +133,7 @@
     "end": "2025-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Sat"
   },
   {

--- a/test/fixtures/ES-AN-2015.json
+++ b/test/fixtures/ES-AN-2015.json
@@ -31,7 +31,7 @@
     "start": "2015-03-18T23:00:00.000Z",
     "end": "2015-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Thu"
   },
@@ -40,7 +40,7 @@
     "start": "2015-04-01T22:00:00.000Z",
     "end": "2015-04-02T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2015-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Mon"
   },
   {
@@ -131,18 +131,28 @@
     "start": "2015-11-01T23:00:00.000Z",
     "end": "2015-11-02T23:00:00.000Z",
     "name": "Todos los Santos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 11-01 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
+    "date": "2015-12-06 00:00:00",
+    "start": "2015-12-05T23:00:00.000Z",
+    "end": "2015-12-06T23:00:00.000Z",
+    "name": "Día de la Constitución Española",
+    "type": "public",
+    "rule": "12-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-07 00:00:00",
     "start": "2015-12-06T23:00:00.000Z",
     "end": "2015-12-07T23:00:00.000Z",
-    "name": "Día de la Constitución Española",
-    "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "name": "Día de la Constitución Española (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 12-06 if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-AN-2016.json
+++ b/test/fixtures/ES-AN-2016.json
@@ -31,7 +31,7 @@
     "start": "2016-03-18T23:00:00.000Z",
     "end": "2016-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sat"
   },
@@ -40,7 +40,7 @@
     "start": "2016-03-23T23:00:00.000Z",
     "end": "2016-03-24T23:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -85,7 +85,7 @@
     "start": "2016-05-01T22:00:00.000Z",
     "end": "2016-05-02T22:00:00.000Z",
     "name": "Fiesta del trabajo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 05-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -124,7 +124,7 @@
     "end": "2016-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Wed"
   },
   {
@@ -142,7 +142,7 @@
     "end": "2016-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Tue"
   },
   {
@@ -168,7 +168,7 @@
     "start": "2016-12-25T23:00:00.000Z",
     "end": "2016-12-26T23:00:00.000Z",
     "name": "Navidad (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-25 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-AN-2017.json
+++ b/test/fixtures/ES-AN-2017.json
@@ -13,7 +13,7 @@
     "start": "2017-01-01T23:00:00.000Z",
     "end": "2017-01-02T23:00:00.000Z",
     "name": "Año Nuevo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -41,26 +41,16 @@
     "start": "2017-03-18T23:00:00.000Z",
     "end": "2017-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2017-03-20 00:00:00",
-    "start": "2017-03-19T23:00:00.000Z",
-    "end": "2017-03-20T23:00:00.000Z",
-    "name": "San José (día sustituto)",
-    "type": "public",
-    "substitute": true,
-    "rule": "substitutes 03-19 if sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2017-04-13 00:00:00",
     "start": "2017-04-12T22:00:00.000Z",
     "end": "2017-04-13T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -134,7 +124,7 @@
     "end": "2017-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Thu"
   },
   {
@@ -152,7 +142,7 @@
     "end": "2017-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/ES-AN-2018.json
+++ b/test/fixtures/ES-AN-2018.json
@@ -31,7 +31,7 @@
     "start": "2018-03-18T23:00:00.000Z",
     "end": "2018-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Mon"
   },
@@ -40,7 +40,7 @@
     "start": "2018-03-28T22:00:00.000Z",
     "end": "2018-03-29T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2018-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Fri"
   },
   {
@@ -132,7 +132,7 @@
     "end": "2018-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/ES-AN-2019.json
+++ b/test/fixtures/ES-AN-2019.json
@@ -22,7 +22,7 @@
     "start": "2019-01-06T23:00:00.000Z",
     "end": "2019-01-07T23:00:00.000Z",
     "name": "Día de los Reyes Magos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-06 if sunday then next monday",
     "_weekday": "Mon"
@@ -41,7 +41,7 @@
     "start": "2019-03-18T23:00:00.000Z",
     "end": "2019-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Tue"
   },
@@ -50,7 +50,7 @@
     "start": "2019-04-17T22:00:00.000Z",
     "end": "2019-04-18T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -124,7 +124,7 @@
     "end": "2019-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Sat"
   },
   {
@@ -142,7 +142,7 @@
     "end": "2019-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Fri"
   },
   {
@@ -159,7 +159,7 @@
     "start": "2019-12-08T23:00:00.000Z",
     "end": "2019-12-09T23:00:00.000Z",
     "name": "La inmaculada concepción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-08 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-AN-2020.json
+++ b/test/fixtures/ES-AN-2020.json
@@ -31,7 +31,7 @@
     "start": "2020-03-18T23:00:00.000Z",
     "end": "2020-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Thu"
   },
@@ -40,7 +40,7 @@
     "start": "2020-04-08T22:00:00.000Z",
     "end": "2020-04-09T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2020-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Mon"
   },
   {
@@ -131,18 +131,28 @@
     "start": "2020-11-01T23:00:00.000Z",
     "end": "2020-11-02T23:00:00.000Z",
     "name": "Todos los Santos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 11-01 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
+    "date": "2020-12-06 00:00:00",
+    "start": "2020-12-05T23:00:00.000Z",
+    "end": "2020-12-06T23:00:00.000Z",
+    "name": "Día de la Constitución Española",
+    "type": "public",
+    "rule": "12-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-07 00:00:00",
     "start": "2020-12-06T23:00:00.000Z",
     "end": "2020-12-07T23:00:00.000Z",
-    "name": "Día de la Constitución Española",
-    "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "name": "Día de la Constitución Española (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 12-06 if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-AN-2021.json
+++ b/test/fixtures/ES-AN-2021.json
@@ -31,7 +31,7 @@
     "start": "2021-03-18T23:00:00.000Z",
     "end": "2021-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Fri"
   },
@@ -40,7 +40,7 @@
     "start": "2021-03-31T22:00:00.000Z",
     "end": "2021-04-01T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -113,7 +113,7 @@
     "start": "2021-08-15T22:00:00.000Z",
     "end": "2021-08-16T22:00:00.000Z",
     "name": "Asunción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 08-15 if sunday then next monday",
     "_weekday": "Mon"
@@ -124,7 +124,7 @@
     "end": "2021-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Tue"
   },
   {
@@ -142,7 +142,7 @@
     "end": "2021-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-AN-2022.json
+++ b/test/fixtures/ES-AN-2022.json
@@ -31,7 +31,7 @@
     "start": "2022-03-18T23:00:00.000Z",
     "end": "2022-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sat"
   },
@@ -40,7 +40,7 @@
     "start": "2022-04-13T22:00:00.000Z",
     "end": "2022-04-14T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -85,7 +85,7 @@
     "start": "2022-05-01T22:00:00.000Z",
     "end": "2022-05-02T22:00:00.000Z",
     "name": "Fiesta del trabajo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 05-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -124,7 +124,7 @@
     "end": "2022-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Wed"
   },
   {
@@ -142,7 +142,7 @@
     "end": "2022-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Tue"
   },
   {
@@ -168,7 +168,7 @@
     "start": "2022-12-25T23:00:00.000Z",
     "end": "2022-12-26T23:00:00.000Z",
     "name": "Navidad (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-25 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-AN-2023.json
+++ b/test/fixtures/ES-AN-2023.json
@@ -13,7 +13,7 @@
     "start": "2023-01-01T23:00:00.000Z",
     "end": "2023-01-02T23:00:00.000Z",
     "name": "Año Nuevo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -41,26 +41,16 @@
     "start": "2023-03-18T23:00:00.000Z",
     "end": "2023-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2023-03-20 00:00:00",
-    "start": "2023-03-19T23:00:00.000Z",
-    "end": "2023-03-20T23:00:00.000Z",
-    "name": "San José (día sustituto)",
-    "type": "public",
-    "substitute": true,
-    "rule": "substitutes 03-19 if sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-04-06 00:00:00",
     "start": "2023-04-05T22:00:00.000Z",
     "end": "2023-04-06T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -134,7 +124,7 @@
     "end": "2023-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Thu"
   },
   {
@@ -152,7 +142,7 @@
     "end": "2023-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/ES-AN-2024.json
+++ b/test/fixtures/ES-AN-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-03-18T23:00:00.000Z",
     "end": "2024-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Tue"
   },
@@ -40,7 +40,7 @@
     "start": "2024-03-27T23:00:00.000Z",
     "end": "2024-03-28T23:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2024-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Sat"
   },
   {
@@ -132,7 +132,7 @@
     "end": "2024-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Fri"
   },
   {
@@ -149,7 +149,7 @@
     "start": "2024-12-08T23:00:00.000Z",
     "end": "2024-12-09T23:00:00.000Z",
     "name": "La inmaculada concepción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-08 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-AN-2025.json
+++ b/test/fixtures/ES-AN-2025.json
@@ -31,7 +31,7 @@
     "start": "2025-03-18T23:00:00.000Z",
     "end": "2025-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Wed"
   },
@@ -40,7 +40,7 @@
     "start": "2025-04-16T22:00:00.000Z",
     "end": "2025-04-17T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -109,12 +109,22 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-10-12 00:00:00",
+    "start": "2025-10-11T22:00:00.000Z",
+    "end": "2025-10-12T22:00:00.000Z",
+    "name": "Fiesta Nacional de España",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-10-13 00:00:00",
     "start": "2025-10-12T22:00:00.000Z",
     "end": "2025-10-13T22:00:00.000Z",
-    "name": "Fiesta Nacional de España",
-    "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "name": "Fiesta Nacional de España (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 10-12 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -132,7 +142,7 @@
     "end": "2025-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Sat"
   },
   {

--- a/test/fixtures/ES-AR-2015.json
+++ b/test/fixtures/ES-AR-2015.json
@@ -22,7 +22,7 @@
     "start": "2015-03-18T23:00:00.000Z",
     "end": "2015-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Thu"
   },
@@ -31,7 +31,7 @@
     "start": "2015-04-01T22:00:00.000Z",
     "end": "2015-04-02T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2015-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Mon"
   },
   {
@@ -131,18 +131,28 @@
     "start": "2015-11-01T23:00:00.000Z",
     "end": "2015-11-02T23:00:00.000Z",
     "name": "Todos los Santos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 11-01 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
+    "date": "2015-12-06 00:00:00",
+    "start": "2015-12-05T23:00:00.000Z",
+    "end": "2015-12-06T23:00:00.000Z",
+    "name": "Día de la Constitución Española",
+    "type": "public",
+    "rule": "12-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-07 00:00:00",
     "start": "2015-12-06T23:00:00.000Z",
     "end": "2015-12-07T23:00:00.000Z",
-    "name": "Día de la Constitución Española",
-    "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "name": "Día de la Constitución Española (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 12-06 if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-AR-2016.json
+++ b/test/fixtures/ES-AR-2016.json
@@ -22,7 +22,7 @@
     "start": "2016-03-18T23:00:00.000Z",
     "end": "2016-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sat"
   },
@@ -31,7 +31,7 @@
     "start": "2016-03-23T23:00:00.000Z",
     "end": "2016-03-24T23:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -85,7 +85,7 @@
     "start": "2016-05-01T22:00:00.000Z",
     "end": "2016-05-02T22:00:00.000Z",
     "name": "Fiesta del trabajo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 05-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -124,7 +124,7 @@
     "end": "2016-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Wed"
   },
   {
@@ -142,7 +142,7 @@
     "end": "2016-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Tue"
   },
   {
@@ -168,7 +168,7 @@
     "start": "2016-12-25T23:00:00.000Z",
     "end": "2016-12-26T23:00:00.000Z",
     "name": "Navidad (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-25 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-AR-2017.json
+++ b/test/fixtures/ES-AR-2017.json
@@ -13,7 +13,7 @@
     "start": "2017-01-01T23:00:00.000Z",
     "end": "2017-01-02T23:00:00.000Z",
     "name": "Año Nuevo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,26 +32,16 @@
     "start": "2017-03-18T23:00:00.000Z",
     "end": "2017-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2017-03-20 00:00:00",
-    "start": "2017-03-19T23:00:00.000Z",
-    "end": "2017-03-20T23:00:00.000Z",
-    "name": "San José (día sustituto)",
-    "type": "public",
-    "substitute": true,
-    "rule": "substitutes 03-19 if sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2017-04-13 00:00:00",
     "start": "2017-04-12T22:00:00.000Z",
     "end": "2017-04-13T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -134,7 +124,7 @@
     "end": "2017-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Thu"
   },
   {
@@ -152,7 +142,7 @@
     "end": "2017-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/ES-AR-2018.json
+++ b/test/fixtures/ES-AR-2018.json
@@ -22,7 +22,7 @@
     "start": "2018-03-18T23:00:00.000Z",
     "end": "2018-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Mon"
   },
@@ -31,7 +31,7 @@
     "start": "2018-03-28T22:00:00.000Z",
     "end": "2018-03-29T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2018-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Fri"
   },
   {
@@ -132,7 +132,7 @@
     "end": "2018-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/ES-AR-2019.json
+++ b/test/fixtures/ES-AR-2019.json
@@ -22,7 +22,7 @@
     "start": "2019-01-06T23:00:00.000Z",
     "end": "2019-01-07T23:00:00.000Z",
     "name": "Día de los Reyes Magos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-06 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,7 +32,7 @@
     "start": "2019-03-18T23:00:00.000Z",
     "end": "2019-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Tue"
   },
@@ -41,7 +41,7 @@
     "start": "2019-04-17T22:00:00.000Z",
     "end": "2019-04-18T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -124,7 +124,7 @@
     "end": "2019-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Sat"
   },
   {
@@ -142,7 +142,7 @@
     "end": "2019-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Fri"
   },
   {
@@ -159,7 +159,7 @@
     "start": "2019-12-08T23:00:00.000Z",
     "end": "2019-12-09T23:00:00.000Z",
     "name": "La inmaculada concepción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-08 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-AR-2020.json
+++ b/test/fixtures/ES-AR-2020.json
@@ -22,7 +22,7 @@
     "start": "2020-03-18T23:00:00.000Z",
     "end": "2020-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Thu"
   },
@@ -31,7 +31,7 @@
     "start": "2020-04-08T22:00:00.000Z",
     "end": "2020-04-09T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2020-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Mon"
   },
   {
@@ -131,18 +131,28 @@
     "start": "2020-11-01T23:00:00.000Z",
     "end": "2020-11-02T23:00:00.000Z",
     "name": "Todos los Santos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 11-01 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
+    "date": "2020-12-06 00:00:00",
+    "start": "2020-12-05T23:00:00.000Z",
+    "end": "2020-12-06T23:00:00.000Z",
+    "name": "Día de la Constitución Española",
+    "type": "public",
+    "rule": "12-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-07 00:00:00",
     "start": "2020-12-06T23:00:00.000Z",
     "end": "2020-12-07T23:00:00.000Z",
-    "name": "Día de la Constitución Española",
-    "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "name": "Día de la Constitución Española (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 12-06 if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-AR-2021.json
+++ b/test/fixtures/ES-AR-2021.json
@@ -22,7 +22,7 @@
     "start": "2021-03-18T23:00:00.000Z",
     "end": "2021-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Fri"
   },
@@ -31,7 +31,7 @@
     "start": "2021-03-31T22:00:00.000Z",
     "end": "2021-04-01T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -113,7 +113,7 @@
     "start": "2021-08-15T22:00:00.000Z",
     "end": "2021-08-16T22:00:00.000Z",
     "name": "Asunción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 08-15 if sunday then next monday",
     "_weekday": "Mon"
@@ -124,7 +124,7 @@
     "end": "2021-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Tue"
   },
   {
@@ -142,7 +142,7 @@
     "end": "2021-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-AR-2022.json
+++ b/test/fixtures/ES-AR-2022.json
@@ -22,7 +22,7 @@
     "start": "2022-03-18T23:00:00.000Z",
     "end": "2022-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sat"
   },
@@ -31,7 +31,7 @@
     "start": "2022-04-13T22:00:00.000Z",
     "end": "2022-04-14T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -85,7 +85,7 @@
     "start": "2022-05-01T22:00:00.000Z",
     "end": "2022-05-02T22:00:00.000Z",
     "name": "Fiesta del trabajo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 05-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -124,7 +124,7 @@
     "end": "2022-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Wed"
   },
   {
@@ -142,7 +142,7 @@
     "end": "2022-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Tue"
   },
   {
@@ -168,7 +168,7 @@
     "start": "2022-12-25T23:00:00.000Z",
     "end": "2022-12-26T23:00:00.000Z",
     "name": "Navidad (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-25 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-AR-2023.json
+++ b/test/fixtures/ES-AR-2023.json
@@ -13,7 +13,7 @@
     "start": "2023-01-01T23:00:00.000Z",
     "end": "2023-01-02T23:00:00.000Z",
     "name": "Año Nuevo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,26 +32,16 @@
     "start": "2023-03-18T23:00:00.000Z",
     "end": "2023-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2023-03-20 00:00:00",
-    "start": "2023-03-19T23:00:00.000Z",
-    "end": "2023-03-20T23:00:00.000Z",
-    "name": "San José (día sustituto)",
-    "type": "public",
-    "substitute": true,
-    "rule": "substitutes 03-19 if sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-04-06 00:00:00",
     "start": "2023-04-05T22:00:00.000Z",
     "end": "2023-04-06T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -134,7 +124,7 @@
     "end": "2023-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Thu"
   },
   {
@@ -152,7 +142,7 @@
     "end": "2023-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/ES-AR-2024.json
+++ b/test/fixtures/ES-AR-2024.json
@@ -22,7 +22,7 @@
     "start": "2024-03-18T23:00:00.000Z",
     "end": "2024-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Tue"
   },
@@ -31,7 +31,7 @@
     "start": "2024-03-27T23:00:00.000Z",
     "end": "2024-03-28T23:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2024-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Sat"
   },
   {
@@ -132,7 +132,7 @@
     "end": "2024-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Fri"
   },
   {
@@ -149,7 +149,7 @@
     "start": "2024-12-08T23:00:00.000Z",
     "end": "2024-12-09T23:00:00.000Z",
     "name": "La inmaculada concepción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-08 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-AR-2025.json
+++ b/test/fixtures/ES-AR-2025.json
@@ -22,7 +22,7 @@
     "start": "2025-03-18T23:00:00.000Z",
     "end": "2025-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Wed"
   },
@@ -31,7 +31,7 @@
     "start": "2025-04-16T22:00:00.000Z",
     "end": "2025-04-17T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -109,12 +109,22 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-10-12 00:00:00",
+    "start": "2025-10-11T22:00:00.000Z",
+    "end": "2025-10-12T22:00:00.000Z",
+    "name": "Fiesta Nacional de España",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-10-13 00:00:00",
     "start": "2025-10-12T22:00:00.000Z",
     "end": "2025-10-13T22:00:00.000Z",
-    "name": "Fiesta Nacional de España",
-    "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "name": "Fiesta Nacional de España (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 10-12 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -132,7 +142,7 @@
     "end": "2025-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Sat"
   },
   {

--- a/test/fixtures/ES-CT-2015.json
+++ b/test/fixtures/ES-CT-2015.json
@@ -22,7 +22,7 @@
     "start": "2015-03-18T23:00:00.000Z",
     "end": "2015-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Thu"
   },
@@ -31,7 +31,7 @@
     "start": "2015-04-01T22:00:00.000Z",
     "end": "2015-04-02T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -132,7 +132,7 @@
     "end": "2015-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Mon"
   },
   {
@@ -149,18 +149,28 @@
     "start": "2015-11-01T23:00:00.000Z",
     "end": "2015-11-02T23:00:00.000Z",
     "name": "Todos los Santos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 11-01 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
+    "date": "2015-12-06 00:00:00",
+    "start": "2015-12-05T23:00:00.000Z",
+    "end": "2015-12-06T23:00:00.000Z",
+    "name": "Día de la Constitución Española",
+    "type": "public",
+    "rule": "12-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-07 00:00:00",
     "start": "2015-12-06T23:00:00.000Z",
     "end": "2015-12-07T23:00:00.000Z",
-    "name": "Día de la Constitución Española",
-    "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "name": "Día de la Constitución Española (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 12-06 if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-CT-2016.json
+++ b/test/fixtures/ES-CT-2016.json
@@ -22,7 +22,7 @@
     "start": "2016-03-18T23:00:00.000Z",
     "end": "2016-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sat"
   },
@@ -31,7 +31,7 @@
     "start": "2016-03-23T23:00:00.000Z",
     "end": "2016-03-24T23:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -76,7 +76,7 @@
     "start": "2016-05-01T22:00:00.000Z",
     "end": "2016-05-02T22:00:00.000Z",
     "name": "Fiesta del trabajo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 05-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -142,7 +142,7 @@
     "end": "2016-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Wed"
   },
   {
@@ -160,7 +160,7 @@
     "end": "2016-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Tue"
   },
   {
@@ -186,7 +186,7 @@
     "start": "2016-12-25T23:00:00.000Z",
     "end": "2016-12-26T23:00:00.000Z",
     "name": "Navidad (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-25 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-CT-2017.json
+++ b/test/fixtures/ES-CT-2017.json
@@ -13,7 +13,7 @@
     "start": "2017-01-01T23:00:00.000Z",
     "end": "2017-01-02T23:00:00.000Z",
     "name": "Año Nuevo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,26 +32,16 @@
     "start": "2017-03-18T23:00:00.000Z",
     "end": "2017-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2017-03-20 00:00:00",
-    "start": "2017-03-19T23:00:00.000Z",
-    "end": "2017-03-20T23:00:00.000Z",
-    "name": "San José (día sustituto)",
-    "type": "public",
-    "substitute": true,
-    "rule": "substitutes 03-19 if sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2017-04-13 00:00:00",
     "start": "2017-04-12T22:00:00.000Z",
     "end": "2017-04-13T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -152,7 +142,7 @@
     "end": "2017-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Thu"
   },
   {
@@ -170,7 +160,7 @@
     "end": "2017-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/ES-CT-2018.json
+++ b/test/fixtures/ES-CT-2018.json
@@ -22,7 +22,7 @@
     "start": "2018-03-18T23:00:00.000Z",
     "end": "2018-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Mon"
   },
@@ -31,7 +31,7 @@
     "start": "2018-03-28T22:00:00.000Z",
     "end": "2018-03-29T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -132,7 +132,7 @@
     "end": "2018-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Fri"
   },
   {
@@ -150,7 +150,7 @@
     "end": "2018-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/ES-CT-2019.json
+++ b/test/fixtures/ES-CT-2019.json
@@ -22,7 +22,7 @@
     "start": "2019-01-06T23:00:00.000Z",
     "end": "2019-01-07T23:00:00.000Z",
     "name": "Día de los Reyes Magos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-06 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,7 +32,7 @@
     "start": "2019-03-18T23:00:00.000Z",
     "end": "2019-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Tue"
   },
@@ -41,7 +41,7 @@
     "start": "2019-04-17T22:00:00.000Z",
     "end": "2019-04-18T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -142,7 +142,7 @@
     "end": "2019-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Sat"
   },
   {
@@ -160,7 +160,7 @@
     "end": "2019-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Fri"
   },
   {
@@ -177,7 +177,7 @@
     "start": "2019-12-08T23:00:00.000Z",
     "end": "2019-12-09T23:00:00.000Z",
     "name": "La inmaculada concepción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-08 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-CT-2020.json
+++ b/test/fixtures/ES-CT-2020.json
@@ -22,7 +22,7 @@
     "start": "2020-03-18T23:00:00.000Z",
     "end": "2020-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Thu"
   },
@@ -31,7 +31,7 @@
     "start": "2020-04-08T22:00:00.000Z",
     "end": "2020-04-09T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -132,7 +132,7 @@
     "end": "2020-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Mon"
   },
   {
@@ -149,18 +149,28 @@
     "start": "2020-11-01T23:00:00.000Z",
     "end": "2020-11-02T23:00:00.000Z",
     "name": "Todos los Santos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 11-01 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
+    "date": "2020-12-06 00:00:00",
+    "start": "2020-12-05T23:00:00.000Z",
+    "end": "2020-12-06T23:00:00.000Z",
+    "name": "Día de la Constitución Española",
+    "type": "public",
+    "rule": "12-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-07 00:00:00",
     "start": "2020-12-06T23:00:00.000Z",
     "end": "2020-12-07T23:00:00.000Z",
-    "name": "Día de la Constitución Española",
-    "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "name": "Día de la Constitución Española (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 12-06 if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-CT-2021.json
+++ b/test/fixtures/ES-CT-2021.json
@@ -22,7 +22,7 @@
     "start": "2021-03-18T23:00:00.000Z",
     "end": "2021-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Fri"
   },
@@ -31,7 +31,7 @@
     "start": "2021-03-31T22:00:00.000Z",
     "end": "2021-04-01T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -113,7 +113,7 @@
     "start": "2021-08-15T22:00:00.000Z",
     "end": "2021-08-16T22:00:00.000Z",
     "name": "Asunción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 08-15 if sunday then next monday",
     "_weekday": "Mon"
@@ -142,7 +142,7 @@
     "end": "2021-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Tue"
   },
   {
@@ -160,7 +160,7 @@
     "end": "2021-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-CT-2022.json
+++ b/test/fixtures/ES-CT-2022.json
@@ -22,7 +22,7 @@
     "start": "2022-03-18T23:00:00.000Z",
     "end": "2022-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sat"
   },
@@ -31,7 +31,7 @@
     "start": "2022-04-13T22:00:00.000Z",
     "end": "2022-04-14T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -76,7 +76,7 @@
     "start": "2022-05-01T22:00:00.000Z",
     "end": "2022-05-02T22:00:00.000Z",
     "name": "Fiesta del trabajo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 05-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -142,7 +142,7 @@
     "end": "2022-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Wed"
   },
   {
@@ -160,7 +160,7 @@
     "end": "2022-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Tue"
   },
   {
@@ -186,7 +186,7 @@
     "start": "2022-12-25T23:00:00.000Z",
     "end": "2022-12-26T23:00:00.000Z",
     "name": "Navidad (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-25 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-CT-2023.json
+++ b/test/fixtures/ES-CT-2023.json
@@ -13,7 +13,7 @@
     "start": "2023-01-01T23:00:00.000Z",
     "end": "2023-01-02T23:00:00.000Z",
     "name": "Año Nuevo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,26 +32,16 @@
     "start": "2023-03-18T23:00:00.000Z",
     "end": "2023-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2023-03-20 00:00:00",
-    "start": "2023-03-19T23:00:00.000Z",
-    "end": "2023-03-20T23:00:00.000Z",
-    "name": "San José (día sustituto)",
-    "type": "public",
-    "substitute": true,
-    "rule": "substitutes 03-19 if sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-04-06 00:00:00",
     "start": "2023-04-05T22:00:00.000Z",
     "end": "2023-04-06T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -152,7 +142,7 @@
     "end": "2023-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Thu"
   },
   {
@@ -170,7 +160,7 @@
     "end": "2023-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/ES-CT-2024.json
+++ b/test/fixtures/ES-CT-2024.json
@@ -22,7 +22,7 @@
     "start": "2024-03-18T23:00:00.000Z",
     "end": "2024-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Tue"
   },
@@ -31,7 +31,7 @@
     "start": "2024-03-27T23:00:00.000Z",
     "end": "2024-03-28T23:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -132,7 +132,7 @@
     "end": "2024-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Sat"
   },
   {
@@ -150,7 +150,7 @@
     "end": "2024-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Fri"
   },
   {
@@ -167,7 +167,7 @@
     "start": "2024-12-08T23:00:00.000Z",
     "end": "2024-12-09T23:00:00.000Z",
     "name": "La inmaculada concepción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-08 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-CT-2025.json
+++ b/test/fixtures/ES-CT-2025.json
@@ -22,7 +22,7 @@
     "start": "2025-03-18T23:00:00.000Z",
     "end": "2025-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Wed"
   },
@@ -31,7 +31,7 @@
     "start": "2025-04-16T22:00:00.000Z",
     "end": "2025-04-17T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -127,12 +127,22 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2025-10-12 00:00:00",
+    "start": "2025-10-11T22:00:00.000Z",
+    "end": "2025-10-12T22:00:00.000Z",
+    "name": "Fiesta Nacional de España",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-10-13 00:00:00",
     "start": "2025-10-12T22:00:00.000Z",
     "end": "2025-10-13T22:00:00.000Z",
-    "name": "Fiesta Nacional de España",
-    "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "name": "Fiesta Nacional de España (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 10-12 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -150,7 +160,7 @@
     "end": "2025-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Sat"
   },
   {

--- a/test/fixtures/ES-MD-2015.json
+++ b/test/fixtures/ES-MD-2015.json
@@ -22,7 +22,7 @@
     "start": "2015-03-18T23:00:00.000Z",
     "end": "2015-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Thu"
   },
@@ -31,7 +31,7 @@
     "start": "2015-04-01T22:00:00.000Z",
     "end": "2015-04-02T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2015-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Mon"
   },
   {
@@ -131,7 +131,7 @@
     "start": "2015-11-01T23:00:00.000Z",
     "end": "2015-11-02T23:00:00.000Z",
     "name": "Todos los Santos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 11-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -146,12 +146,22 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-12-06 00:00:00",
+    "start": "2015-12-05T23:00:00.000Z",
+    "end": "2015-12-06T23:00:00.000Z",
+    "name": "Día de la Constitución Española",
+    "type": "public",
+    "rule": "12-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-07 00:00:00",
     "start": "2015-12-06T23:00:00.000Z",
     "end": "2015-12-07T23:00:00.000Z",
-    "name": "Día de la Constitución Española",
-    "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "name": "Día de la Constitución Española (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 12-06 if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-MD-2016.json
+++ b/test/fixtures/ES-MD-2016.json
@@ -22,7 +22,7 @@
     "start": "2016-03-18T23:00:00.000Z",
     "end": "2016-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sat"
   },
@@ -31,7 +31,7 @@
     "start": "2016-03-23T23:00:00.000Z",
     "end": "2016-03-24T23:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -76,7 +76,7 @@
     "start": "2016-05-01T22:00:00.000Z",
     "end": "2016-05-02T22:00:00.000Z",
     "name": "Fiesta del trabajo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 05-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -124,7 +124,7 @@
     "end": "2016-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Wed"
   },
   {
@@ -151,7 +151,7 @@
     "end": "2016-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Tue"
   },
   {
@@ -177,7 +177,7 @@
     "start": "2016-12-25T23:00:00.000Z",
     "end": "2016-12-26T23:00:00.000Z",
     "name": "Navidad (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-25 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-MD-2017.json
+++ b/test/fixtures/ES-MD-2017.json
@@ -13,7 +13,7 @@
     "start": "2017-01-01T23:00:00.000Z",
     "end": "2017-01-02T23:00:00.000Z",
     "name": "Año Nuevo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,26 +32,16 @@
     "start": "2017-03-18T23:00:00.000Z",
     "end": "2017-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2017-03-20 00:00:00",
-    "start": "2017-03-19T23:00:00.000Z",
-    "end": "2017-03-20T23:00:00.000Z",
-    "name": "San José (día sustituto)",
-    "type": "public",
-    "substitute": true,
-    "rule": "substitutes 03-19 if sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2017-04-13 00:00:00",
     "start": "2017-04-12T22:00:00.000Z",
     "end": "2017-04-13T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -134,7 +124,7 @@
     "end": "2017-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Thu"
   },
   {
@@ -161,7 +151,7 @@
     "end": "2017-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/ES-MD-2018.json
+++ b/test/fixtures/ES-MD-2018.json
@@ -22,7 +22,7 @@
     "start": "2018-03-18T23:00:00.000Z",
     "end": "2018-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Mon"
   },
@@ -31,7 +31,7 @@
     "start": "2018-03-28T22:00:00.000Z",
     "end": "2018-03-29T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2018-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Fri"
   },
   {
@@ -141,7 +141,7 @@
     "end": "2018-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/ES-MD-2019.json
+++ b/test/fixtures/ES-MD-2019.json
@@ -22,7 +22,7 @@
     "start": "2019-01-06T23:00:00.000Z",
     "end": "2019-01-07T23:00:00.000Z",
     "name": "Día de los Reyes Magos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-06 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,7 +32,7 @@
     "start": "2019-03-18T23:00:00.000Z",
     "end": "2019-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Tue"
   },
@@ -41,7 +41,7 @@
     "start": "2019-04-17T22:00:00.000Z",
     "end": "2019-04-18T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -124,7 +124,7 @@
     "end": "2019-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Sat"
   },
   {
@@ -151,7 +151,7 @@
     "end": "2019-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Fri"
   },
   {
@@ -168,7 +168,7 @@
     "start": "2019-12-08T23:00:00.000Z",
     "end": "2019-12-09T23:00:00.000Z",
     "name": "La inmaculada concepción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-08 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-MD-2020.json
+++ b/test/fixtures/ES-MD-2020.json
@@ -22,7 +22,7 @@
     "start": "2020-03-18T23:00:00.000Z",
     "end": "2020-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Thu"
   },
@@ -31,7 +31,7 @@
     "start": "2020-04-08T22:00:00.000Z",
     "end": "2020-04-09T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2020-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Mon"
   },
   {
@@ -131,7 +131,7 @@
     "start": "2020-11-01T23:00:00.000Z",
     "end": "2020-11-02T23:00:00.000Z",
     "name": "Todos los Santos (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 11-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -146,12 +146,22 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-12-06 00:00:00",
+    "start": "2020-12-05T23:00:00.000Z",
+    "end": "2020-12-06T23:00:00.000Z",
+    "name": "Día de la Constitución Española",
+    "type": "public",
+    "rule": "12-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-07 00:00:00",
     "start": "2020-12-06T23:00:00.000Z",
     "end": "2020-12-07T23:00:00.000Z",
-    "name": "Día de la Constitución Española",
-    "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "name": "Día de la Constitución Española (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 12-06 if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-MD-2021.json
+++ b/test/fixtures/ES-MD-2021.json
@@ -22,7 +22,7 @@
     "start": "2021-03-18T23:00:00.000Z",
     "end": "2021-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Fri"
   },
@@ -31,7 +31,7 @@
     "start": "2021-03-31T22:00:00.000Z",
     "end": "2021-04-01T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -113,7 +113,7 @@
     "start": "2021-08-15T22:00:00.000Z",
     "end": "2021-08-16T22:00:00.000Z",
     "name": "Asunción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 08-15 if sunday then next monday",
     "_weekday": "Mon"
@@ -124,7 +124,7 @@
     "end": "2021-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Tue"
   },
   {
@@ -151,7 +151,7 @@
     "end": "2021-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ES-MD-2022.json
+++ b/test/fixtures/ES-MD-2022.json
@@ -22,7 +22,7 @@
     "start": "2022-03-18T23:00:00.000Z",
     "end": "2022-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sat"
   },
@@ -31,7 +31,7 @@
     "start": "2022-04-13T22:00:00.000Z",
     "end": "2022-04-14T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -76,7 +76,7 @@
     "start": "2022-05-01T22:00:00.000Z",
     "end": "2022-05-02T22:00:00.000Z",
     "name": "Fiesta del trabajo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 05-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -124,7 +124,7 @@
     "end": "2022-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Wed"
   },
   {
@@ -151,7 +151,7 @@
     "end": "2022-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Tue"
   },
   {
@@ -177,7 +177,7 @@
     "start": "2022-12-25T23:00:00.000Z",
     "end": "2022-12-26T23:00:00.000Z",
     "name": "Navidad (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-25 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-MD-2023.json
+++ b/test/fixtures/ES-MD-2023.json
@@ -13,7 +13,7 @@
     "start": "2023-01-01T23:00:00.000Z",
     "end": "2023-01-02T23:00:00.000Z",
     "name": "Año Nuevo (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 01-01 if sunday then next monday",
     "_weekday": "Mon"
@@ -32,26 +32,16 @@
     "start": "2023-03-18T23:00:00.000Z",
     "end": "2023-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2023-03-20 00:00:00",
-    "start": "2023-03-19T23:00:00.000Z",
-    "end": "2023-03-20T23:00:00.000Z",
-    "name": "San José (día sustituto)",
-    "type": "public",
-    "substitute": true,
-    "rule": "substitutes 03-19 if sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-04-06 00:00:00",
     "start": "2023-04-05T22:00:00.000Z",
     "end": "2023-04-06T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -134,7 +124,7 @@
     "end": "2023-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Thu"
   },
   {
@@ -161,7 +151,7 @@
     "end": "2023-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/ES-MD-2024.json
+++ b/test/fixtures/ES-MD-2024.json
@@ -22,7 +22,7 @@
     "start": "2024-03-18T23:00:00.000Z",
     "end": "2024-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Tue"
   },
@@ -31,7 +31,7 @@
     "start": "2024-03-27T23:00:00.000Z",
     "end": "2024-03-28T23:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -114,7 +114,7 @@
     "end": "2024-10-12T22:00:00.000Z",
     "name": "Fiesta Nacional de España",
     "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "rule": "10-12",
     "_weekday": "Sat"
   },
   {
@@ -141,7 +141,7 @@
     "end": "2024-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Fri"
   },
   {
@@ -158,7 +158,7 @@
     "start": "2024-12-08T23:00:00.000Z",
     "end": "2024-12-09T23:00:00.000Z",
     "name": "La inmaculada concepción (día sustituto)",
-    "type": "public",
+    "type": "observance",
     "substitute": true,
     "rule": "substitutes 12-08 if sunday then next monday",
     "_weekday": "Mon"

--- a/test/fixtures/ES-MD-2025.json
+++ b/test/fixtures/ES-MD-2025.json
@@ -22,7 +22,7 @@
     "start": "2025-03-18T23:00:00.000Z",
     "end": "2025-03-19T23:00:00.000Z",
     "name": "San José",
-    "type": "public",
+    "type": "observance",
     "rule": "03-19",
     "_weekday": "Wed"
   },
@@ -31,7 +31,7 @@
     "start": "2025-04-16T22:00:00.000Z",
     "end": "2025-04-17T22:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -109,12 +109,22 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-10-12 00:00:00",
+    "start": "2025-10-11T22:00:00.000Z",
+    "end": "2025-10-12T22:00:00.000Z",
+    "name": "Fiesta Nacional de España",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-10-13 00:00:00",
     "start": "2025-10-12T22:00:00.000Z",
     "end": "2025-10-13T22:00:00.000Z",
-    "name": "Fiesta Nacional de España",
-    "type": "public",
-    "rule": "10-12 if sunday then next monday",
+    "name": "Fiesta Nacional de España (día sustituto)",
+    "type": "observance",
+    "substitute": true,
+    "rule": "substitutes 10-12 if sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -141,7 +151,7 @@
     "end": "2025-12-06T23:00:00.000Z",
     "name": "Día de la Constitución Española",
     "type": "public",
-    "rule": "12-06 if sunday then next monday",
+    "rule": "12-06",
     "_weekday": "Sat"
   },
   {


### PR DESCRIPTION
Spanish holidays did not yield accurate results according to the official bulletin BOE: holidays that fall on a Sunday are not automatically passed to the next Monday (or any other automatic mechanism), but they are adjusted depending on regional authorities (Comunidad Autónoma). The central government only sets a number of official holidays which are published on the BOE. In this case I have marked them as `type: observance` because they are sometimes respected in certain regions, not in others.

Official BOE records have been checked for [2019](https://www.boe.es/boe/dias/2018/10/20/pdfs/BOE-A-2018-14369.pdf), [2020](https://www.boe.es/boe/dias/2019/10/11/pdfs/BOE-A-2019-14552.pdf) and [2021](https://www.boe.es/boe/dias/2020/11/02/pdfs/BOE-A-2020-13343.pdf); they hold correct.

Tests have been updated and verified manually. Please review.