### PR TITLE
fix: Add dependency for watch-run

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "rimraf": "^3.0.2",
     "typescript": "^4.0.3",
     "uglifyjs-webpack-plugin": "^2.2.0",
+    "watch-run": "^1.2.5",
     "webpack": "^4.43.0",
     "webpack-bundle-analyzer": "^3.8.0",
     "webpack-cli": "^3.3.12"


### PR DESCRIPTION
When running `npm run watch` I got an error because the package `watch-run` was not installed. I added it as a `devDependency`.

Simple fix. Please review.