### PR TITLE
fix: JP holidays for 2021

### DIFF
--- a/data/countries/JP.yaml
+++ b/data/countries/JP.yaml
@@ -1,6 +1,6 @@
 holidays:
-  # @source http://www8.cao.go.jp/chosei/shukujitsu/gaiyou.html
-  # @source http://eco.mtk.nao.ac.jp/koyomi/yoko/index.html.en
+  # @source https://www8.cao.go.jp/chosei/shukujitsu/gaiyou.html
+  # @source https://eco.mtk.nao.ac.jp/koyomi/yoko/index.html.en
   # @attrib https://ja.wikipedia.org/wiki/%E5%9B%BD%E6%B0%91%E3%81%AE%E7%A5%9D%E6%97%A5
   # Japan
   JP:
@@ -178,17 +178,25 @@ holidays:
           jp: 海の日
         disable:
           - '2020-07-20'
+          - '2021-07-19'
         enable:
           - '2020-07-23'
+          - '2021-07-22'
         active:
           - from: 2003-01-01
-      08-11 and if sunday then next monday:
+      substitutes 2021-08-08 and if sunday then next monday:
+        substitute: true
+        name:
+          en: Mountain Day
+          jp: 山の日
+      substitutes 08-11 and if sunday then next monday:
         substitute: true
         name:
           en: Mountain Day
           jp: 山の日
         disable:
           - '2020-08-11'
+          - '2021-08-11'
         enable:
           - '2020-08-10'
         active:
@@ -259,8 +267,10 @@ holidays:
           jp: スポーツの日
         disable:
           - '2020-10-12'
+          - '2021-10-11'
         enable:
           - '2020-07-24'
+          - '2021-07-23'
         active:
           - from: 2020-01-01
       '2019-10-22':

--- a/test/fixtures/JP-2016.json
+++ b/test/fixtures/JP-2016.json
@@ -114,7 +114,7 @@
     "end": "2016-08-11T15:00:00.000Z",
     "name": "山の日",
     "type": "public",
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/JP-2017.json
+++ b/test/fixtures/JP-2017.json
@@ -114,7 +114,7 @@
     "end": "2017-08-11T15:00:00.000Z",
     "name": "山の日",
     "type": "public",
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/JP-2018.json
+++ b/test/fixtures/JP-2018.json
@@ -124,7 +124,7 @@
     "end": "2018-08-11T15:00:00.000Z",
     "name": "山の日",
     "type": "public",
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Sat"
   },
   {

--- a/test/fixtures/JP-2019.json
+++ b/test/fixtures/JP-2019.json
@@ -141,7 +141,7 @@
     "end": "2019-08-11T15:00:00.000Z",
     "name": "山の日",
     "type": "public",
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -151,7 +151,7 @@
     "name": "山の日 (振替休日)",
     "type": "public",
     "substitute": true,
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/JP-2020.json
+++ b/test/fixtures/JP-2020.json
@@ -142,7 +142,7 @@
     "end": "2020-08-10T15:00:00.000Z",
     "name": "山の日",
     "type": "public",
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/JP-2021.json
+++ b/test/fixtures/JP-2021.json
@@ -99,22 +99,41 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2021-07-19 00:00:00",
-    "start": "2021-07-18T15:00:00.000Z",
-    "end": "2021-07-19T15:00:00.000Z",
+    "date": "2021-07-22 00:00:00",
+    "start": "2021-07-21T15:00:00.000Z",
+    "end": "2021-07-22T15:00:00.000Z",
     "name": "海の日",
     "type": "public",
     "rule": "3rd monday in July",
-    "_weekday": "Mon"
+    "_weekday": "Thu"
   },
   {
-    "date": "2021-08-11 00:00:00",
-    "start": "2021-08-10T15:00:00.000Z",
-    "end": "2021-08-11T15:00:00.000Z",
+    "date": "2021-07-23 00:00:00",
+    "start": "2021-07-22T15:00:00.000Z",
+    "end": "2021-07-23T15:00:00.000Z",
+    "name": "スポーツの日",
+    "type": "public",
+    "rule": "2nd monday in October #2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-08 00:00:00",
+    "start": "2021-08-07T15:00:00.000Z",
+    "end": "2021-08-08T15:00:00.000Z",
     "name": "山の日",
     "type": "public",
-    "rule": "08-11 and if sunday then next monday",
-    "_weekday": "Wed"
+    "rule": "substitutes 2021-08-08 and if sunday then next monday",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-08-09 00:00:00",
+    "start": "2021-08-08T15:00:00.000Z",
+    "end": "2021-08-09T15:00:00.000Z",
+    "name": "山の日 (振替休日)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2021-08-08 and if sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2021-09-20 00:00:00",
@@ -133,15 +152,6 @@
     "type": "public",
     "rule": "september equinox in +09:00",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2021-10-11 00:00:00",
-    "start": "2021-10-10T15:00:00.000Z",
-    "end": "2021-10-11T15:00:00.000Z",
-    "name": "スポーツの日",
-    "type": "public",
-    "rule": "2nd monday in October #2",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-11-03 00:00:00",

--- a/test/fixtures/JP-2022.json
+++ b/test/fixtures/JP-2022.json
@@ -113,7 +113,7 @@
     "end": "2022-08-11T15:00:00.000Z",
     "name": "山の日",
     "type": "public",
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/JP-2023.json
+++ b/test/fixtures/JP-2023.json
@@ -123,7 +123,7 @@
     "end": "2023-08-11T15:00:00.000Z",
     "name": "山の日",
     "type": "public",
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/JP-2024.json
+++ b/test/fixtures/JP-2024.json
@@ -133,7 +133,7 @@
     "end": "2024-08-11T15:00:00.000Z",
     "name": "山の日",
     "type": "public",
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -143,7 +143,7 @@
     "name": "山の日 (振替休日)",
     "type": "public",
     "substitute": true,
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/JP-2025.json
+++ b/test/fixtures/JP-2025.json
@@ -133,7 +133,7 @@
     "end": "2025-08-11T15:00:00.000Z",
     "name": "山の日",
     "type": "public",
-    "rule": "08-11 and if sunday then next monday",
+    "rule": "substitutes 08-11 and if sunday then next monday",
     "_weekday": "Mon"
   },
   {


### PR DESCRIPTION
Fixed JP-2021 holidays announced by Tokyo 2020 Olympic and Paralympic Games, Cabinet Secretariat on December 21, 2020.
https://www8.cao.go.jp/chosei/shukujitsu/gaiyou.html

* 2021-07-19 Marine Day (海の日) to **2021-07-22**
* 2021-08-11 Mountain Day (山の日) to **2021-08-08** and substitutes holiday **2021-08-09**
* 2021-10-11 Sports Day (スポーツの日) to **2021-07-23**



