### PR TITLE
Update Czech Easter Sunday

### DIFF
--- a/data/countries/CZ.yaml
+++ b/data/countries/CZ.yaml
@@ -28,6 +28,7 @@ holidays:
         type: observance
       easter:
         _name: easter
+        type: observance
       easter 1:
         _name: easter 1
       05-01:

--- a/test/fixtures/CZ-2015.json
+++ b/test/fixtures/CZ-2015.json
@@ -49,7 +49,7 @@
     "start": "2015-04-04T22:00:00.000Z",
     "end": "2015-04-05T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CZ-2016.json
+++ b/test/fixtures/CZ-2016.json
@@ -49,7 +49,7 @@
     "start": "2016-03-26T23:00:00.000Z",
     "end": "2016-03-27T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CZ-2017.json
+++ b/test/fixtures/CZ-2017.json
@@ -49,7 +49,7 @@
     "start": "2017-04-15T22:00:00.000Z",
     "end": "2017-04-16T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CZ-2018.json
+++ b/test/fixtures/CZ-2018.json
@@ -49,7 +49,7 @@
     "start": "2018-03-31T22:00:00.000Z",
     "end": "2018-04-01T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CZ-2019.json
+++ b/test/fixtures/CZ-2019.json
@@ -49,7 +49,7 @@
     "start": "2019-04-20T22:00:00.000Z",
     "end": "2019-04-21T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CZ-2020.json
+++ b/test/fixtures/CZ-2020.json
@@ -49,7 +49,7 @@
     "start": "2020-04-11T22:00:00.000Z",
     "end": "2020-04-12T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CZ-2021.json
+++ b/test/fixtures/CZ-2021.json
@@ -49,7 +49,7 @@
     "start": "2021-04-03T22:00:00.000Z",
     "end": "2021-04-04T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CZ-2022.json
+++ b/test/fixtures/CZ-2022.json
@@ -49,7 +49,7 @@
     "start": "2022-04-16T22:00:00.000Z",
     "end": "2022-04-17T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CZ-2023.json
+++ b/test/fixtures/CZ-2023.json
@@ -49,7 +49,7 @@
     "start": "2023-04-08T22:00:00.000Z",
     "end": "2023-04-09T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CZ-2024.json
+++ b/test/fixtures/CZ-2024.json
@@ -49,7 +49,7 @@
     "start": "2024-03-30T23:00:00.000Z",
     "end": "2024-03-31T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CZ-2025.json
+++ b/test/fixtures/CZ-2025.json
@@ -49,7 +49,7 @@
     "start": "2025-04-19T22:00:00.000Z",
     "end": "2025-04-20T22:00:00.000Z",
     "name": "Velikonoční neděle",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },


### PR DESCRIPTION
Change Czech Easter Sunday type to "observance", because it is not listed as a public holiday on [wikipedia](https://en.wikipedia.org/wiki/Public_holidays_in_the_Czech_Republic).