### PR TITLE
Update EE Independence Day to be a public holiday

### DIFF
--- a/data/countries/EE.yaml
+++ b/data/countries/EE.yaml
@@ -22,7 +22,7 @@ holidays:
         type: observance
       02-24:
         _name: Independence Day
-        type: observance
+        type: public
       03-14:
         name:
           et: emakeelepäev

--- a/test/fixtures/EE-2015.json
+++ b/test/fixtures/EE-2015.json
@@ -31,7 +31,7 @@
     "start": "2015-02-23T22:00:00.000Z",
     "end": "2015-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Tue"
   },

--- a/test/fixtures/EE-2016.json
+++ b/test/fixtures/EE-2016.json
@@ -31,7 +31,7 @@
     "start": "2016-02-23T22:00:00.000Z",
     "end": "2016-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Wed"
   },

--- a/test/fixtures/EE-2017.json
+++ b/test/fixtures/EE-2017.json
@@ -31,7 +31,7 @@
     "start": "2017-02-23T22:00:00.000Z",
     "end": "2017-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Fri"
   },

--- a/test/fixtures/EE-2018.json
+++ b/test/fixtures/EE-2018.json
@@ -31,7 +31,7 @@
     "start": "2018-02-23T22:00:00.000Z",
     "end": "2018-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Sat"
   },

--- a/test/fixtures/EE-2019.json
+++ b/test/fixtures/EE-2019.json
@@ -31,7 +31,7 @@
     "start": "2019-02-23T22:00:00.000Z",
     "end": "2019-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Sun"
   },

--- a/test/fixtures/EE-2020.json
+++ b/test/fixtures/EE-2020.json
@@ -31,7 +31,7 @@
     "start": "2020-02-23T22:00:00.000Z",
     "end": "2020-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Mon"
   },

--- a/test/fixtures/EE-2021.json
+++ b/test/fixtures/EE-2021.json
@@ -31,7 +31,7 @@
     "start": "2021-02-23T22:00:00.000Z",
     "end": "2021-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Wed"
   },

--- a/test/fixtures/EE-2022.json
+++ b/test/fixtures/EE-2022.json
@@ -31,7 +31,7 @@
     "start": "2022-02-23T22:00:00.000Z",
     "end": "2022-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Thu"
   },

--- a/test/fixtures/EE-2023.json
+++ b/test/fixtures/EE-2023.json
@@ -31,7 +31,7 @@
     "start": "2023-02-23T22:00:00.000Z",
     "end": "2023-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Fri"
   },

--- a/test/fixtures/EE-2024.json
+++ b/test/fixtures/EE-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-02-23T22:00:00.000Z",
     "end": "2024-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Sat"
   },

--- a/test/fixtures/EE-2025.json
+++ b/test/fixtures/EE-2025.json
@@ -31,7 +31,7 @@
     "start": "2025-02-23T22:00:00.000Z",
     "end": "2025-02-24T22:00:00.000Z",
     "name": "iseseisvuspäev",
-    "type": "observance",
+    "type": "public",
     "rule": "02-24",
     "_weekday": "Mon"
   },


### PR DESCRIPTION
Estonia (EE) Indepencence day on the 24th of February is marked as observance but it is a national holiday according to https://en.wikipedia.org/wiki/Independence_Day_(Estonia)