### PR TITLE
Fix import and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,11 +635,19 @@ Please take a look at `./webpack.config.js`. To further reduce size consider cus
 ```js
 ...
   plugins: [
-    // ---- do not bundle moment locales
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-    // ---- do not bundle astronomia vsop planet data
-    new webpack.IgnorePlugin(/^\.\/vsop87B.*$/)
-    ...
+    new webpack.IgnorePlugin({
+      checkResource (resource, context) {
+        // ---- do not bundle astronomia vsop planet data
+        if (/\/astronomia\/data$/.test(context)) {
+          return !['./deltat.js', './vsop87Bearth.js'].includes(resource)
+        }
+        // ---- do not bundle moment locales
+        if (/\/moment\/locale$/.test(context)) {
+          return true
+        }
+        return false
+      }
+    })
 ```
 
 ## Browser

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "./package.json": "./package.json"
   },
   "main": "./lib/index.cjs",
+  "module": "./src/index.js",
   "typings": "./types",
   "bin": {
     "holidays2json": "scripts/holidays2json.cjs"
@@ -177,8 +178,8 @@
     "prepin": "^1.0.3"
   },
   "devDependencies": {
-    "@babel/cli": "^7.13.16",
-    "@babel/core": "^7.14.2",
+    "@babel/cli": "^7.14.3",
+    "@babel/core": "^7.14.3",
     "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.14.2",
     "@commitlint/cli": "^11.0.0",
@@ -200,8 +201,8 @@
     "rollup": "^2.48.0",
     "typescript": "^4.2.4",
     "watch-run": "^1.2.5",
-    "webpack": "^5.37.0",
-    "webpack-bundle-analyzer": "^4.4.1",
+    "webpack": "^5.37.1",
+    "webpack-bundle-analyzer": "^4.4.2",
     "webpack-cli": "^4.7.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "reporter": "dot"
   },
   "dependencies": {
-    "date-holidays-parser": "^3.1.0",
+    "date-holidays-parser": "^3.2.0",
     "js-yaml": "^4.1.0",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
@@ -187,9 +187,9 @@
     "@mocha/contributors": "git+https://github.com/commenthol/contributors.git#semver:1.1.0-0",
     "babel-loader": "^8.2.2",
     "dtslint": "^4.0.9",
-    "eslint": "^7.26.0",
+    "eslint": "^7.27.0",
     "eslint-config-standard": "^16.0.2",
-    "eslint-plugin-import": "^2.23.2",
+    "eslint-plugin-import": "^2.23.3",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.3.1",
     "hashtree": "^0.7.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'date-holidays' {
-  namespace Holidays {
+  export namespace HolidaysTypes {
     export interface Country {
       /** IANA country code */
       country: string;
@@ -71,7 +71,7 @@ declare module 'date-holidays' {
   }
 
   export class HolidayRule {
-    constructor(ruleObj: Holidays.HolidayRule);
+    constructor(ruleObj: HolidaysTypes.HolidayRule);
     /**
      * disable rule in year (month)
      */
@@ -79,17 +79,17 @@ declare module 'date-holidays' {
   }
 
   export default class Holidays {
-    constructor(opts?: Holidays.Options);
-    constructor(country: Holidays.Country | string, opts?: Holidays.Options);
-    constructor(country: Holidays.Country | string, state: string, opts?: Holidays.Options);
-    constructor(country: Holidays.Country | string, state: string, region: string, opts?: Holidays.Options);
+    constructor(opts?: HolidaysTypes.Options);
+    constructor(country: HolidaysTypes.Country | string, opts?: HolidaysTypes.Options);
+    constructor(country: HolidaysTypes.Country | string, state: string, opts?: HolidaysTypes.Options);
+    constructor(country: HolidaysTypes.Country | string, state: string, region: string, opts?: HolidaysTypes.Options);
 
     /**
      * initialize holidays for a country/state/region
      */
-    init(country?: Holidays.Country | string, opts?: Holidays.Options): void;
-    init(country?: string, state?: string, opts?: Holidays.Options): void;
-    init(country?: string, state?: string, region?: string, opts?: Holidays.Options): void;
+    init(country?: HolidaysTypes.Country | string, opts?: HolidaysTypes.Options): void;
+    init(country?: string, state?: string, opts?: HolidaysTypes.Options): void;
+    init(country?: string, state?: string, region?: string, opts?: HolidaysTypes.Options): void;
 
     /**
      * set (custom) holiday
@@ -100,19 +100,19 @@ declare module 'date-holidays' {
      * @param opts.type - holiday type `public|bank|school|observance`
      * @returns `true` if holiday could be set returns `true`
      */
-    setHoliday(rule: string, opts: Holidays.HolidayOptions | string): boolean;
+    setHoliday(rule: string, opts: HolidaysTypes.HolidayOptions | string): boolean;
     /**
      * get all holidays for `year` with names using prefered `language`
      * @param [year] - if omitted current year is choosen
      * @param [language] - ISO 639-1 code for language
      * @returns of found holidays in given year sorted by Date:
      */
-    getHolidays(year?: string | number | Date, lang?: string): Holidays.Holiday[];
+    getHolidays(year?: string | number | Date, lang?: string): HolidaysTypes.Holiday[];
     /**
      * check whether `date` is a holiday or not
      * @returns of found holidays in given year sorted by Date:
      */
-    isHoliday(date: Date|string): Holidays.Holiday[] | false;
+    isHoliday(date: Date|string): HolidaysTypes.Holiday[] | false;
 
     /**
      * set or update rule

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -27,15 +27,18 @@ rimraf('./dist')
 
 function createConfig (options) {
   const plugins = [
-    // ---- do not bundle moment locales
     new webpack.IgnorePlugin({
-      resourceRegExp: /^\.\/locale$/,
-      contextRegExp: /moment$/
-    }),
-    // ---- do not bundle astronomia vsop planet data
-    new webpack.IgnorePlugin({
-      resourceRegExp: /^\.\/vsop87B[^e].*$/,
-      contextRegExp: /astronomia$/
+      checkResource (resource, context) {
+        // ---- do not bundle astronomia vsop planet data
+        if (/\/astronomia\/data$/.test(context)) {
+          return !['./deltat.js', './vsop87Bearth.js'].includes(resource)
+        }
+        // ---- do not bundle moment locales
+        if (/\/moment\/locale$/.test(context)) {
+          return true
+        }
+        return false
+      }
     })
     // ---- using a custom set of timezones
     // new webpack.NormalModuleReplacementPlugin(


### PR DESCRIPTION
fixes #244 
corrects date-holidays-parser imports and type exports

in your typescript project use
```ts
import Holidays, { HolidaysTypes } from "date-holidays";
```