### PR TITLE
fix(CH-GL): Näfelser Fahrt and other holidays

### DIFF
--- a/data/countries/CH.yaml
+++ b/data/countries/CH.yaml
@@ -234,6 +234,8 @@ holidays:
             _name: 12-26
             type: optional
       GL:
+        sources:
+          - https://www.gl.ch/verwaltung/staatskanzlei/oeffentliche-feiertage.html/1335
         names:
           de: Kanton Glarus
           fr: Canton de Glaris
@@ -245,12 +247,22 @@ holidays:
               de: Berchtoldstag
               fr: Saint-Berthold
             type: optional
-          thursday after 04-01:
+          # TODO: needs new rule: "Thursday after 04-02 if easter -3 then next Thursday"
+          thursday after 04-02:
             name:
-              de: Fahrtsfest
+              de: Näfelser Fahrt
               fr: Bataille de Näfels
+            disable:
+              - '2023-04-06'
+            enable:
+              - '2023-04-13'
+          3 sunday after 09-01: false
           11-01:
             _name: 11-01
+          12-24:
+            _name: 12-24
+          12-31:
+            _name: 12-31
       ZG:
         names:
           de: Kanton Zug

--- a/test/fixtures/CH-GL-2015.json
+++ b/test/fixtures/CH-GL-2015.json
@@ -21,9 +21,9 @@
     "date": "2015-04-02 00:00:00",
     "start": "2015-04-01T22:00:00.000Z",
     "end": "2015-04-02T22:00:00.000Z",
-    "name": "Fahrtsfest",
+    "name": "Näfelser Fahrt",
     "type": "public",
-    "rule": "thursday after 04-01",
+    "rule": "thursday after 04-02",
     "_weekday": "Thu"
   },
   {
@@ -108,15 +108,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2015-09-20 00:00:00",
-    "start": "2015-09-19T22:00:00.000Z",
-    "end": "2015-09-20T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-11-01 00:00:00",
     "start": "2015-10-31T23:00:00.000Z",
     "end": "2015-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-24 00:00:00",
+    "start": "2015-12-23T23:00:00.000Z",
+    "end": "2015-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Thu"
   },
   {
     "date": "2015-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2015-12-31 00:00:00",
+    "start": "2015-12-30T23:00:00.000Z",
+    "end": "2015-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CH-GL-2016.json
+++ b/test/fixtures/CH-GL-2016.json
@@ -48,9 +48,9 @@
     "date": "2016-04-07 00:00:00",
     "start": "2016-04-06T22:00:00.000Z",
     "end": "2016-04-07T22:00:00.000Z",
-    "name": "Fahrtsfest",
+    "name": "Näfelser Fahrt",
     "type": "public",
-    "rule": "thursday after 04-01",
+    "rule": "thursday after 04-02",
     "_weekday": "Thu"
   },
   {
@@ -108,15 +108,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2016-09-18 00:00:00",
-    "start": "2016-09-17T22:00:00.000Z",
-    "end": "2016-09-18T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-11-01 00:00:00",
     "start": "2016-10-31T23:00:00.000Z",
     "end": "2016-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2016-12-24 00:00:00",
+    "start": "2016-12-23T23:00:00.000Z",
+    "end": "2016-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Sat"
   },
   {
     "date": "2016-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2016-12-31 00:00:00",
+    "start": "2016-12-30T23:00:00.000Z",
+    "end": "2016-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CH-GL-2017.json
+++ b/test/fixtures/CH-GL-2017.json
@@ -21,9 +21,9 @@
     "date": "2017-04-06 00:00:00",
     "start": "2017-04-05T22:00:00.000Z",
     "end": "2017-04-06T22:00:00.000Z",
-    "name": "Fahrtsfest",
+    "name": "Näfelser Fahrt",
     "type": "public",
-    "rule": "thursday after 04-01",
+    "rule": "thursday after 04-02",
     "_weekday": "Thu"
   },
   {
@@ -108,15 +108,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2017-09-17 00:00:00",
-    "start": "2017-09-16T22:00:00.000Z",
-    "end": "2017-09-17T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-11-01 00:00:00",
     "start": "2017-10-31T23:00:00.000Z",
     "end": "2017-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2017-12-24 00:00:00",
+    "start": "2017-12-23T23:00:00.000Z",
+    "end": "2017-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Sun"
   },
   {
     "date": "2017-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2017-12-31 00:00:00",
+    "start": "2017-12-30T23:00:00.000Z",
+    "end": "2017-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CH-GL-2018.json
+++ b/test/fixtures/CH-GL-2018.json
@@ -48,9 +48,9 @@
     "date": "2018-04-05 00:00:00",
     "start": "2018-04-04T22:00:00.000Z",
     "end": "2018-04-05T22:00:00.000Z",
-    "name": "Fahrtsfest",
+    "name": "Näfelser Fahrt",
     "type": "public",
-    "rule": "thursday after 04-01",
+    "rule": "thursday after 04-02",
     "_weekday": "Thu"
   },
   {
@@ -108,15 +108,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2018-09-16 00:00:00",
-    "start": "2018-09-15T22:00:00.000Z",
-    "end": "2018-09-16T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-11-01 00:00:00",
     "start": "2018-10-31T23:00:00.000Z",
     "end": "2018-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2018-12-24 00:00:00",
+    "start": "2018-12-23T23:00:00.000Z",
+    "end": "2018-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Mon"
   },
   {
     "date": "2018-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2018-12-31 00:00:00",
+    "start": "2018-12-30T23:00:00.000Z",
+    "end": "2018-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CH-GL-2019.json
+++ b/test/fixtures/CH-GL-2019.json
@@ -21,9 +21,9 @@
     "date": "2019-04-04 00:00:00",
     "start": "2019-04-03T22:00:00.000Z",
     "end": "2019-04-04T22:00:00.000Z",
-    "name": "Fahrtsfest",
+    "name": "Näfelser Fahrt",
     "type": "public",
-    "rule": "thursday after 04-01",
+    "rule": "thursday after 04-02",
     "_weekday": "Thu"
   },
   {
@@ -108,15 +108,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2019-09-15 00:00:00",
-    "start": "2019-09-14T22:00:00.000Z",
-    "end": "2019-09-15T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-11-01 00:00:00",
     "start": "2019-10-31T23:00:00.000Z",
     "end": "2019-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2019-12-24 00:00:00",
+    "start": "2019-12-23T23:00:00.000Z",
+    "end": "2019-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Tue"
   },
   {
     "date": "2019-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2019-12-31 00:00:00",
+    "start": "2019-12-30T23:00:00.000Z",
+    "end": "2019-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CH-GL-2020.json
+++ b/test/fixtures/CH-GL-2020.json
@@ -21,9 +21,9 @@
     "date": "2020-04-02 00:00:00",
     "start": "2020-04-01T22:00:00.000Z",
     "end": "2020-04-02T22:00:00.000Z",
-    "name": "Fahrtsfest",
+    "name": "Näfelser Fahrt",
     "type": "public",
-    "rule": "thursday after 04-01",
+    "rule": "thursday after 04-02",
     "_weekday": "Thu"
   },
   {
@@ -108,15 +108,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2020-09-20 00:00:00",
-    "start": "2020-09-19T22:00:00.000Z",
-    "end": "2020-09-20T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-11-01 00:00:00",
     "start": "2020-10-31T23:00:00.000Z",
     "end": "2020-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-24 00:00:00",
+    "start": "2020-12-23T23:00:00.000Z",
+    "end": "2020-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Thu"
   },
   {
     "date": "2020-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2020-12-31 00:00:00",
+    "start": "2020-12-30T23:00:00.000Z",
+    "end": "2020-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CH-GL-2021.json
+++ b/test/fixtures/CH-GL-2021.json
@@ -18,15 +18,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2021-04-01 00:00:00",
-    "start": "2021-03-31T22:00:00.000Z",
-    "end": "2021-04-01T22:00:00.000Z",
-    "name": "Fahrtsfest",
-    "type": "public",
-    "rule": "thursday after 04-01",
-    "_weekday": "Thu"
-  },
-  {
     "date": "2021-04-02 00:00:00",
     "start": "2021-04-01T22:00:00.000Z",
     "end": "2021-04-02T22:00:00.000Z",
@@ -52,6 +43,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2021-04-08 00:00:00",
+    "start": "2021-04-07T22:00:00.000Z",
+    "end": "2021-04-08T22:00:00.000Z",
+    "name": "Näfelser Fahrt",
+    "type": "public",
+    "rule": "thursday after 04-02",
+    "_weekday": "Thu"
   },
   {
     "date": "2021-05-09 00:00:00",
@@ -108,15 +108,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2021-09-19 00:00:00",
-    "start": "2021-09-18T22:00:00.000Z",
-    "end": "2021-09-19T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-11-01 00:00:00",
     "start": "2021-10-31T23:00:00.000Z",
     "end": "2021-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2021-12-24 00:00:00",
+    "start": "2021-12-23T23:00:00.000Z",
+    "end": "2021-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Fri"
   },
   {
     "date": "2021-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2021-12-31 00:00:00",
+    "start": "2021-12-30T23:00:00.000Z",
+    "end": "2021-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CH-GL-2022.json
+++ b/test/fixtures/CH-GL-2022.json
@@ -21,9 +21,9 @@
     "date": "2022-04-07 00:00:00",
     "start": "2022-04-06T22:00:00.000Z",
     "end": "2022-04-07T22:00:00.000Z",
-    "name": "Fahrtsfest",
+    "name": "Näfelser Fahrt",
     "type": "public",
-    "rule": "thursday after 04-01",
+    "rule": "thursday after 04-02",
     "_weekday": "Thu"
   },
   {
@@ -108,15 +108,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-09-18 00:00:00",
-    "start": "2022-09-17T22:00:00.000Z",
-    "end": "2022-09-18T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-11-01 00:00:00",
     "start": "2022-10-31T23:00:00.000Z",
     "end": "2022-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2022-12-24 00:00:00",
+    "start": "2022-12-23T23:00:00.000Z",
+    "end": "2022-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Sat"
   },
   {
     "date": "2022-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2022-12-31 00:00:00",
+    "start": "2022-12-30T23:00:00.000Z",
+    "end": "2022-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CH-GL-2023.json
+++ b/test/fixtures/CH-GL-2023.json
@@ -18,15 +18,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2023-04-06 00:00:00",
-    "start": "2023-04-05T22:00:00.000Z",
-    "end": "2023-04-06T22:00:00.000Z",
-    "name": "Fahrtsfest",
-    "type": "public",
-    "rule": "thursday after 04-01",
-    "_weekday": "Thu"
-  },
-  {
     "date": "2023-04-07 00:00:00",
     "start": "2023-04-06T22:00:00.000Z",
     "end": "2023-04-07T22:00:00.000Z",
@@ -52,6 +43,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2023-04-13 00:00:00",
+    "start": "2023-04-12T22:00:00.000Z",
+    "end": "2023-04-13T22:00:00.000Z",
+    "name": "Näfelser Fahrt",
+    "type": "public",
+    "rule": "thursday after 04-02",
+    "_weekday": "Thu"
   },
   {
     "date": "2023-05-14 00:00:00",
@@ -108,15 +108,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2023-09-17 00:00:00",
-    "start": "2023-09-16T22:00:00.000Z",
-    "end": "2023-09-17T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-11-01 00:00:00",
     "start": "2023-10-31T23:00:00.000Z",
     "end": "2023-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2023-12-24 00:00:00",
+    "start": "2023-12-23T23:00:00.000Z",
+    "end": "2023-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Sun"
   },
   {
     "date": "2023-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2023-12-31 00:00:00",
+    "start": "2023-12-30T23:00:00.000Z",
+    "end": "2023-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CH-GL-2024.json
+++ b/test/fixtures/CH-GL-2024.json
@@ -48,9 +48,9 @@
     "date": "2024-04-04 00:00:00",
     "start": "2024-04-03T22:00:00.000Z",
     "end": "2024-04-04T22:00:00.000Z",
-    "name": "Fahrtsfest",
+    "name": "Näfelser Fahrt",
     "type": "public",
-    "rule": "thursday after 04-01",
+    "rule": "thursday after 04-02",
     "_weekday": "Thu"
   },
   {
@@ -108,15 +108,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2024-09-15 00:00:00",
-    "start": "2024-09-14T22:00:00.000Z",
-    "end": "2024-09-15T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-11-01 00:00:00",
     "start": "2024-10-31T23:00:00.000Z",
     "end": "2024-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2024-12-24 00:00:00",
+    "start": "2024-12-23T23:00:00.000Z",
+    "end": "2024-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Tue"
   },
   {
     "date": "2024-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2024-12-31 00:00:00",
+    "start": "2024-12-30T23:00:00.000Z",
+    "end": "2024-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CH-GL-2025.json
+++ b/test/fixtures/CH-GL-2025.json
@@ -21,9 +21,9 @@
     "date": "2025-04-03 00:00:00",
     "start": "2025-04-02T22:00:00.000Z",
     "end": "2025-04-03T22:00:00.000Z",
-    "name": "Fahrtsfest",
+    "name": "Näfelser Fahrt",
     "type": "public",
-    "rule": "thursday after 04-01",
+    "rule": "thursday after 04-02",
     "_weekday": "Thu"
   },
   {
@@ -108,15 +108,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-09-21 00:00:00",
-    "start": "2025-09-20T22:00:00.000Z",
-    "end": "2025-09-21T22:00:00.000Z",
-    "name": "Eidg. Dank-, Buss- und Bettag",
-    "type": "public",
-    "rule": "3 sunday after 09-01",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-11-01 00:00:00",
     "start": "2025-10-31T23:00:00.000Z",
     "end": "2025-11-01T23:00:00.000Z",
@@ -124,6 +115,15 @@
     "type": "public",
     "rule": "11-01",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2025-12-24 00:00:00",
+    "start": "2025-12-23T23:00:00.000Z",
+    "end": "2025-12-24T23:00:00.000Z",
+    "name": "Heiliger Abend",
+    "type": "public",
+    "rule": "12-24",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-12-25 00:00:00",
@@ -142,5 +142,14 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2025-12-31 00:00:00",
+    "start": "2025-12-30T23:00:00.000Z",
+    "end": "2025-12-31T23:00:00.000Z",
+    "name": "Silvester",
+    "type": "public",
+    "rule": "12-31",
+    "_weekday": "Wed"
   }
 ]


### PR DESCRIPTION
Näfelser Fahrt does not take place on April 1st. according to
https://www.gl.ch/verwaltung/staatskanzlei/oeffentliche-feiertage.html

Christmas Eve and Syvester added

Eidg. Dank-, Buss- und Bettag not celebrated