### PR TITLE
fix(GB,GG,GI,IM,JE): Replace Early May with Spring bank holiday

### DIFF
--- a/data/countries/GB.yaml
+++ b/data/countries/GB.yaml
@@ -31,7 +31,6 @@ holidays:
           en: Early May bank holiday
         disable:
           - '2020-05-04'
-          - '2022-05-02' # moved to 2022-06-02
       # applies to GG, JE, IM as well
       # @source https://www.itv.com/news/channel/2019-07-19/guernsey-will-have-a-bank-holiday-on-friday-8-may-2020/
       # @source https://www.itv.com/news/channel/2019-06-13/extra-bank-holiday-proposed-for-ve-day-75-in-jersey/
@@ -48,6 +47,8 @@ holidays:
       1st monday before 06-01:
         name:
           en: Spring bank holiday
+        disable:
+          - '2022-05-30' # was moved to 2022-06-02
       12-25:
         _name: 12-25
       substitutes 12-25 if saturday then next tuesday:

--- a/test/fixtures/GB-2022.json
+++ b/test/fixtures/GB-2022.json
@@ -55,12 +55,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-05-30 00:00:00",
-    "start": "2022-05-29T23:00:00.000Z",
-    "end": "2022-05-30T23:00:00.000Z",
-    "name": "Spring bank holiday",
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-01T23:00:00.000Z",
+    "end": "2022-05-02T23:00:00.000Z",
+    "name": "Early May bank holiday",
     "type": "public",
-    "rule": "1st monday before 06-01",
+    "rule": "1st monday in May",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/GB-ALD-2022.json
+++ b/test/fixtures/GB-ALD-2022.json
@@ -55,12 +55,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-05-30 00:00:00",
-    "start": "2022-05-29T23:00:00.000Z",
-    "end": "2022-05-30T23:00:00.000Z",
-    "name": "Spring bank holiday",
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-01T23:00:00.000Z",
+    "end": "2022-05-02T23:00:00.000Z",
+    "name": "Early May bank holiday",
     "type": "public",
-    "rule": "1st monday before 06-01",
+    "rule": "1st monday in May",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/GB-ENG-2022.json
+++ b/test/fixtures/GB-ENG-2022.json
@@ -55,12 +55,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-05-30 00:00:00",
-    "start": "2022-05-29T23:00:00.000Z",
-    "end": "2022-05-30T23:00:00.000Z",
-    "name": "Spring bank holiday",
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-01T23:00:00.000Z",
+    "end": "2022-05-02T23:00:00.000Z",
+    "name": "Early May bank holiday",
     "type": "public",
-    "rule": "1st monday before 06-01",
+    "rule": "1st monday in May",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/GB-NIR-2022.json
+++ b/test/fixtures/GB-NIR-2022.json
@@ -64,12 +64,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-05-30 00:00:00",
-    "start": "2022-05-29T23:00:00.000Z",
-    "end": "2022-05-30T23:00:00.000Z",
-    "name": "Spring bank holiday",
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-01T23:00:00.000Z",
+    "end": "2022-05-02T23:00:00.000Z",
+    "name": "Early May bank holiday",
     "type": "public",
-    "rule": "1st monday before 06-01",
+    "rule": "1st monday in May",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/GB-SCT-2022.json
+++ b/test/fixtures/GB-SCT-2022.json
@@ -74,12 +74,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-05-30 00:00:00",
-    "start": "2022-05-29T23:00:00.000Z",
-    "end": "2022-05-30T23:00:00.000Z",
-    "name": "Spring bank holiday",
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-01T23:00:00.000Z",
+    "end": "2022-05-02T23:00:00.000Z",
+    "name": "Early May bank holiday",
     "type": "public",
-    "rule": "1st monday before 06-01",
+    "rule": "1st monday in May",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/GB-WLS-2022.json
+++ b/test/fixtures/GB-WLS-2022.json
@@ -55,12 +55,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-05-30 00:00:00",
-    "start": "2022-05-29T23:00:00.000Z",
-    "end": "2022-05-30T23:00:00.000Z",
-    "name": "Spring bank holiday",
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-01T23:00:00.000Z",
+    "end": "2022-05-02T23:00:00.000Z",
+    "name": "Early May bank holiday",
     "type": "public",
-    "rule": "1st monday before 06-01",
+    "rule": "1st monday in May",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/GG-2022.json
+++ b/test/fixtures/GG-2022.json
@@ -55,21 +55,21 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-01T23:00:00.000Z",
+    "end": "2022-05-02T23:00:00.000Z",
+    "name": "Early May bank holiday",
+    "type": "public",
+    "rule": "1st monday in May",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-05-09 00:00:00",
     "start": "2022-05-08T23:00:00.000Z",
     "end": "2022-05-09T23:00:00.000Z",
     "name": "Liberation Day",
     "type": "public",
     "rule": "05-09",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2022-05-30 00:00:00",
-    "start": "2022-05-29T23:00:00.000Z",
-    "end": "2022-05-30T23:00:00.000Z",
-    "name": "Spring bank holiday",
-    "type": "public",
-    "rule": "1st monday before 06-01",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/GI-2022.json
+++ b/test/fixtures/GI-2022.json
@@ -82,15 +82,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-05-30 00:00:00",
-    "start": "2022-05-29T22:00:00.000Z",
-    "end": "2022-05-30T22:00:00.000Z",
-    "name": "Spring bank holiday",
-    "type": "public",
-    "rule": "1st monday before 06-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T22:00:00.000Z",
     "end": "2022-06-02T22:00:00.000Z",

--- a/test/fixtures/IM-2022.json
+++ b/test/fixtures/IM-2022.json
@@ -55,12 +55,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-05-30 00:00:00",
-    "start": "2022-05-29T23:00:00.000Z",
-    "end": "2022-05-30T23:00:00.000Z",
-    "name": "Spring bank holiday",
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-01T23:00:00.000Z",
+    "end": "2022-05-02T23:00:00.000Z",
+    "name": "Early May bank holiday",
     "type": "public",
-    "rule": "1st monday before 06-01",
+    "rule": "1st monday in May",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/JE-2022.json
+++ b/test/fixtures/JE-2022.json
@@ -55,21 +55,21 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-01T23:00:00.000Z",
+    "end": "2022-05-02T23:00:00.000Z",
+    "name": "Early May bank holiday",
+    "type": "public",
+    "rule": "1st monday in May",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-05-09 00:00:00",
     "start": "2022-05-08T23:00:00.000Z",
     "end": "2022-05-09T23:00:00.000Z",
     "name": "Liberation Day",
     "type": "public",
     "rule": "05-09",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2022-05-30 00:00:00",
-    "start": "2022-05-29T23:00:00.000Z",
-    "end": "2022-05-30T23:00:00.000Z",
-    "name": "Spring bank holiday",
-    "type": "public",
-    "rule": "1st monday before 06-01",
     "_weekday": "Mon"
   },
   {


### PR DESCRIPTION
The Early May bank holiday was erroneously choosen as being shifted
because of the Queens Platinum Jubilee instead of the Spring bank
holiday.