### PR TITLE
fix(ID): fixing Indonesia's independence day

### DIFF
--- a/data/countries/ID.yaml
+++ b/data/countries/ID.yaml
@@ -12,7 +12,7 @@ holidays:
       - Asia/Pontianak
       - Asia/Makassar
       - Asia/Jayapura
-    dayoff: 'sunday'
+    dayoff: "sunday"
     days:
       01-01:
         _name: 01-01
@@ -30,7 +30,7 @@ holidays:
         name:
           en: Pancasila Day
           id: Hari Lahir Pancasila
-      08-21:
+      08-17:
         _name: Independence Day
       12-25:
         _name: 12-25
@@ -49,125 +49,125 @@ holidays:
         _name: 10 Dhu al-Hijjah
       # Nyepi
       # @attrib https://en.wikipedia.org/wiki/Nyepi
-      '2009-03-26':
+      "2009-03-26":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2010-03-16':
+      "2010-03-16":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2011-03-05':
+      "2011-03-05":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2012-03-23':
+      "2012-03-23":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2013-03-12':
+      "2013-03-12":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2014-03-31':
+      "2014-03-31":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2015-03-21':
+      "2015-03-21":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2016-03-09':
+      "2016-03-09":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2017-03-28':
+      "2017-03-28":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2018-03-17':
+      "2018-03-17":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2019-03-07':
+      "2019-03-07":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2020-03-25':
+      "2020-03-25":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2021-03-14':
+      "2021-03-14":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2022-03-03':
+      "2022-03-03":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2023-03-22':
+      "2023-03-22":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2024-03-11':
+      "2024-03-11":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2025-03-29':
+      "2025-03-29":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
-      '2026-03-19':
+      "2026-03-19":
         name:
           en: Nyepi
           id: Hari Raya Nyepi
       # Vesak
       # @attrib https://en.wikipedia.org/wiki/Vesak#Dates_of_observance
-      '2001-05-07':
+      "2001-05-07":
         _name: Vesak
-      '2002-05-26':
+      "2002-05-26":
         _name: Vesak
-      '2003-05-16':
+      "2003-05-16":
         _name: Vesak
-      '2004-06-03':
+      "2004-06-03":
         _name: Vesak
-      '2005-05-24':
+      "2005-05-24":
         _name: Vesak
-      '2006-05-13':
+      "2006-05-13":
         _name: Vesak
-      '2007-06-01':
+      "2007-06-01":
         _name: Vesak
-      '2008-05-20':
+      "2008-05-20":
         _name: Vesak
-      '2009-05-09':
+      "2009-05-09":
         _name: Vesak
-      '2010-05-28':
+      "2010-05-28":
         _name: Vesak
-      '2011-05-17':
+      "2011-05-17":
         _name: Vesak
-      '2012-05-06':
+      "2012-05-06":
         _name: Vesak
-      '2013-05-25':
+      "2013-05-25":
         _name: Vesak
-      '2014-05-15':
+      "2014-05-15":
         _name: Vesak
-      '2015-06-02':
+      "2015-06-02":
         _name: Vesak
-      '2016-05-22':
+      "2016-05-22":
         _name: Vesak
-      '2017-05-11':
+      "2017-05-11":
         _name: Vesak
-      '2018-05-29':
+      "2018-05-29":
         _name: Vesak
-      '2019-05-19':
+      "2019-05-19":
         _name: Vesak
-      '2020-05-07':
+      "2020-05-07":
         _name: Vesak
-      '2021-05-26':
+      "2021-05-26":
         _name: Vesak
-      '2022-05-16':
+      "2022-05-16":
         _name: Vesak
-      '2023-05-06':
+      "2023-05-06":
         _name: Vesak
-      '2024-05-23':
+      "2024-05-23":
         _name: Vesak

--- a/test/fixtures/ID-2015.json
+++ b/test/fixtures/ID-2015.json
@@ -108,13 +108,13 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2015-08-21 00:00:00",
-    "start": "2015-08-20T17:00:00.000Z",
-    "end": "2015-08-21T17:00:00.000Z",
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-16T17:00:00.000Z",
+    "end": "2015-08-17T17:00:00.000Z",
     "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
     "type": "public",
-    "rule": "08-21",
-    "_weekday": "Fri"
+    "rule": "08-17",
+    "_weekday": "Mon"
   },
   {
     "date": "2015-09-23 00:00:00 -0600",

--- a/test/fixtures/ID-2016.json
+++ b/test/fixtures/ID-2016.json
@@ -99,13 +99,13 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2016-08-21 00:00:00",
-    "start": "2016-08-20T17:00:00.000Z",
-    "end": "2016-08-21T17:00:00.000Z",
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-16T17:00:00.000Z",
+    "end": "2016-08-17T17:00:00.000Z",
     "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
     "type": "public",
-    "rule": "08-21",
-    "_weekday": "Sun"
+    "rule": "08-17",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-09-11 00:00:00 -0600",

--- a/test/fixtures/ID-2017.json
+++ b/test/fixtures/ID-2017.json
@@ -99,13 +99,13 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2017-08-21 00:00:00",
-    "start": "2017-08-20T17:00:00.000Z",
-    "end": "2017-08-21T17:00:00.000Z",
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-16T17:00:00.000Z",
+    "end": "2017-08-17T17:00:00.000Z",
     "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
     "type": "public",
-    "rule": "08-21",
-    "_weekday": "Mon"
+    "rule": "08-17",
+    "_weekday": "Thu"
   },
   {
     "date": "2017-09-01 00:00:00 -0600",

--- a/test/fixtures/ID-2018.json
+++ b/test/fixtures/ID-2018.json
@@ -99,21 +99,21 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-16T17:00:00.000Z",
+    "end": "2018-08-17T17:00:00.000Z",
+    "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
+    "type": "public",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2018-08-21 00:00:00 -0600",
     "start": "2018-08-20T11:00:00.000Z",
     "end": "2018-08-21T11:00:00.000Z",
     "name": "Hari Raya Idul Adha",
     "type": "public",
     "rule": "10 Dhu al-Hijjah",
-    "_weekday": "Tue"
-  },
-  {
-    "date": "2018-08-21 00:00:00",
-    "start": "2018-08-20T17:00:00.000Z",
-    "end": "2018-08-21T17:00:00.000Z",
-    "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
-    "type": "public",
-    "rule": "08-21",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/ID-2019.json
+++ b/test/fixtures/ID-2019.json
@@ -108,13 +108,13 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2019-08-21 00:00:00",
-    "start": "2019-08-20T17:00:00.000Z",
-    "end": "2019-08-21T17:00:00.000Z",
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-16T17:00:00.000Z",
+    "end": "2019-08-17T17:00:00.000Z",
     "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
     "type": "public",
-    "rule": "08-21",
-    "_weekday": "Wed"
+    "rule": "08-17",
+    "_weekday": "Sat"
   },
   {
     "date": "2019-08-31 00:00:00 -0600",

--- a/test/fixtures/ID-2020.json
+++ b/test/fixtures/ID-2020.json
@@ -108,6 +108,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-16T17:00:00.000Z",
+    "end": "2020-08-17T17:00:00.000Z",
+    "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
+    "type": "public",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2020-08-20 00:00:00 -0600",
     "start": "2020-08-19T11:00:00.000Z",
     "end": "2020-08-20T11:00:00.000Z",
@@ -115,15 +124,6 @@
     "type": "public",
     "rule": "1 Muharram",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2020-08-21 00:00:00",
-    "start": "2020-08-20T17:00:00.000Z",
-    "end": "2020-08-21T17:00:00.000Z",
-    "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
-    "type": "public",
-    "rule": "08-21",
-    "_weekday": "Fri"
   },
   {
     "date": "2020-10-29 00:00:00 -0600",

--- a/test/fixtures/ID-2021.json
+++ b/test/fixtures/ID-2021.json
@@ -117,13 +117,13 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2021-08-21 00:00:00",
-    "start": "2021-08-20T17:00:00.000Z",
-    "end": "2021-08-21T17:00:00.000Z",
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-16T17:00:00.000Z",
+    "end": "2021-08-17T17:00:00.000Z",
     "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
     "type": "public",
-    "rule": "08-21",
-    "_weekday": "Sat"
+    "rule": "08-17",
+    "_weekday": "Tue"
   },
   {
     "date": "2021-10-18 00:00:00 -0600",

--- a/test/fixtures/ID-2022.json
+++ b/test/fixtures/ID-2022.json
@@ -117,13 +117,13 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2022-08-21 00:00:00",
-    "start": "2022-08-20T17:00:00.000Z",
-    "end": "2022-08-21T17:00:00.000Z",
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-16T17:00:00.000Z",
+    "end": "2022-08-17T17:00:00.000Z",
     "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
     "type": "public",
-    "rule": "08-21",
-    "_weekday": "Sun"
+    "rule": "08-17",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-10-08 00:00:00 -0600",

--- a/test/fixtures/ID-2023.json
+++ b/test/fixtures/ID-2023.json
@@ -117,13 +117,13 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2023-08-21 00:00:00",
-    "start": "2023-08-20T17:00:00.000Z",
-    "end": "2023-08-21T17:00:00.000Z",
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-16T17:00:00.000Z",
+    "end": "2023-08-17T17:00:00.000Z",
     "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
     "type": "public",
-    "rule": "08-21",
-    "_weekday": "Mon"
+    "rule": "08-17",
+    "_weekday": "Thu"
   },
   {
     "date": "2023-09-27 00:00:00 -0600",

--- a/test/fixtures/ID-2024.json
+++ b/test/fixtures/ID-2024.json
@@ -117,13 +117,13 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2024-08-21 00:00:00",
-    "start": "2024-08-20T17:00:00.000Z",
-    "end": "2024-08-21T17:00:00.000Z",
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-16T17:00:00.000Z",
+    "end": "2024-08-17T17:00:00.000Z",
     "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
     "type": "public",
-    "rule": "08-21",
-    "_weekday": "Wed"
+    "rule": "08-17",
+    "_weekday": "Sat"
   },
   {
     "date": "2024-09-15 00:00:00 -0600",

--- a/test/fixtures/ID-2025.json
+++ b/test/fixtures/ID-2025.json
@@ -108,13 +108,13 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2025-08-21 00:00:00",
-    "start": "2025-08-20T17:00:00.000Z",
-    "end": "2025-08-21T17:00:00.000Z",
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-16T17:00:00.000Z",
+    "end": "2025-08-17T17:00:00.000Z",
     "name": "Hari Ulang Tahun Kemerdekaan Republik Indonesia",
     "type": "public",
-    "rule": "08-21",
-    "_weekday": "Thu"
+    "rule": "08-17",
+    "_weekday": "Sun"
   },
   {
     "date": "2025-09-04 00:00:00 -0600",


### PR DESCRIPTION
Independence day corrections for Indonesia
Should be 17th August