### PR TITLE
feat: fathers day for au, gb and ie

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -45,6 +45,9 @@ holidays:
       12-26 and if saturday then next monday if sunday then next tuesday:
         substitute: true
         _name: 12-26
+      1st sunday in September:
+        _name: Fathers Day
+        type: observance
     states:
       # @source https://www.legislation.act.gov.au/a/1958-19
       ACT:

--- a/data/countries/GB.yaml
+++ b/data/countries/GB.yaml
@@ -62,6 +62,9 @@ holidays:
       "2022-06-03":
         name:
           en: Queen’s Platinum Jubilee
+      3rd sunday in June:
+        _name: Fathers Day
+        type: observance
     states:
       ALD:
         name: Alderney

--- a/data/countries/IE.yaml
+++ b/data/countries/IE.yaml
@@ -66,3 +66,6 @@ holidays:
         name:
           en: Christmas Bank Holiday
         type: bank
+      3rd sunday in June:
+        _name: Fathers Day
+        type: observance

--- a/test/fixtures/AU-2015.json
+++ b/test/fixtures/AU-2015.json
@@ -63,6 +63,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2015-09-06 00:00:00",
+    "start": "2015-09-05T14:00:00.000Z",
+    "end": "2015-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T13:00:00.000Z",
     "end": "2015-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2016.json
+++ b/test/fixtures/AU-2016.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-09-04 00:00:00",
+    "start": "2016-09-03T14:00:00.000Z",
+    "end": "2016-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T13:00:00.000Z",
     "end": "2016-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2017.json
+++ b/test/fixtures/AU-2017.json
@@ -72,6 +72,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2017-09-03 00:00:00",
+    "start": "2017-09-02T14:00:00.000Z",
+    "end": "2017-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T13:00:00.000Z",
     "end": "2017-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2018.json
+++ b/test/fixtures/AU-2018.json
@@ -63,6 +63,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2018-09-02 00:00:00",
+    "start": "2018-09-01T14:00:00.000Z",
+    "end": "2018-09-02T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T13:00:00.000Z",
     "end": "2018-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2019.json
+++ b/test/fixtures/AU-2019.json
@@ -63,6 +63,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2019-09-01 00:00:00",
+    "start": "2019-08-31T14:00:00.000Z",
+    "end": "2019-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T13:00:00.000Z",
     "end": "2019-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2020.json
+++ b/test/fixtures/AU-2020.json
@@ -63,6 +63,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2020-09-06 00:00:00",
+    "start": "2020-09-05T14:00:00.000Z",
+    "end": "2020-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T13:00:00.000Z",
     "end": "2020-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2021.json
+++ b/test/fixtures/AU-2021.json
@@ -63,6 +63,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-09-05 00:00:00",
+    "start": "2021-09-04T14:00:00.000Z",
+    "end": "2021-09-05T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T13:00:00.000Z",
     "end": "2021-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2022.json
+++ b/test/fixtures/AU-2022.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-09-04 00:00:00",
+    "start": "2022-09-03T14:00:00.000Z",
+    "end": "2022-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T13:00:00.000Z",
     "end": "2022-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2023.json
+++ b/test/fixtures/AU-2023.json
@@ -72,6 +72,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2023-09-03 00:00:00",
+    "start": "2023-09-02T14:00:00.000Z",
+    "end": "2023-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T13:00:00.000Z",
     "end": "2023-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2024.json
+++ b/test/fixtures/AU-2024.json
@@ -63,6 +63,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2024-09-01 00:00:00",
+    "start": "2024-08-31T14:00:00.000Z",
+    "end": "2024-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T13:00:00.000Z",
     "end": "2024-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2025.json
+++ b/test/fixtures/AU-2025.json
@@ -63,6 +63,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-06T14:00:00.000Z",
+    "end": "2025-09-07T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T13:00:00.000Z",
     "end": "2025-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2015.json
+++ b/test/fixtures/AU-ACT-2015.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-09-06 00:00:00",
+    "start": "2015-09-05T14:00:00.000Z",
+    "end": "2015-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-10-05 00:00:00",
     "start": "2015-10-04T13:00:00.000Z",
     "end": "2015-10-05T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2016.json
+++ b/test/fixtures/AU-ACT-2016.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-09-04 00:00:00",
+    "start": "2016-09-03T14:00:00.000Z",
+    "end": "2016-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-10-03 00:00:00",
     "start": "2016-10-02T13:00:00.000Z",
     "end": "2016-10-03T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2017.json
+++ b/test/fixtures/AU-ACT-2017.json
@@ -99,6 +99,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-09-03 00:00:00",
+    "start": "2017-09-02T14:00:00.000Z",
+    "end": "2017-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-10-02 00:00:00",
     "start": "2017-10-01T13:00:00.000Z",
     "end": "2017-10-02T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2018.json
+++ b/test/fixtures/AU-ACT-2018.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-09-02 00:00:00",
+    "start": "2018-09-01T14:00:00.000Z",
+    "end": "2018-09-02T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-10-01 00:00:00",
     "start": "2018-09-30T14:00:00.000Z",
     "end": "2018-10-01T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2019.json
+++ b/test/fixtures/AU-ACT-2019.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-09-01 00:00:00",
+    "start": "2019-08-31T14:00:00.000Z",
+    "end": "2019-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-10-07 00:00:00",
     "start": "2019-10-06T13:00:00.000Z",
     "end": "2019-10-07T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2020.json
+++ b/test/fixtures/AU-ACT-2020.json
@@ -99,6 +99,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-09-06 00:00:00",
+    "start": "2020-09-05T14:00:00.000Z",
+    "end": "2020-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-10-05 00:00:00",
     "start": "2020-10-04T13:00:00.000Z",
     "end": "2020-10-05T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2021.json
+++ b/test/fixtures/AU-ACT-2021.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-09-05 00:00:00",
+    "start": "2021-09-04T14:00:00.000Z",
+    "end": "2021-09-05T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-10-04 00:00:00",
     "start": "2021-10-03T13:00:00.000Z",
     "end": "2021-10-04T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2022.json
+++ b/test/fixtures/AU-ACT-2022.json
@@ -99,6 +99,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-09-04 00:00:00",
+    "start": "2022-09-03T14:00:00.000Z",
+    "end": "2022-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-10-03 00:00:00",
     "start": "2022-10-02T13:00:00.000Z",
     "end": "2022-10-03T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2023.json
+++ b/test/fixtures/AU-ACT-2023.json
@@ -99,6 +99,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-09-03 00:00:00",
+    "start": "2023-09-02T14:00:00.000Z",
+    "end": "2023-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-10-02 00:00:00",
     "start": "2023-10-01T13:00:00.000Z",
     "end": "2023-10-02T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2024.json
+++ b/test/fixtures/AU-ACT-2024.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-09-01 00:00:00",
+    "start": "2024-08-31T14:00:00.000Z",
+    "end": "2024-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-10-07 00:00:00",
     "start": "2024-10-06T13:00:00.000Z",
     "end": "2024-10-07T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2025.json
+++ b/test/fixtures/AU-ACT-2025.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-06T14:00:00.000Z",
+    "end": "2025-09-07T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-10-06 00:00:00",
     "start": "2025-10-05T13:00:00.000Z",
     "end": "2025-10-06T13:00:00.000Z",

--- a/test/fixtures/AU-NSW-2015.json
+++ b/test/fixtures/AU-NSW-2015.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-09-06 00:00:00",
+    "start": "2015-09-05T14:00:00.000Z",
+    "end": "2015-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-10-05 00:00:00",
     "start": "2015-10-04T13:00:00.000Z",
     "end": "2015-10-05T13:00:00.000Z",

--- a/test/fixtures/AU-NSW-2016.json
+++ b/test/fixtures/AU-NSW-2016.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-09-04 00:00:00",
+    "start": "2016-09-03T14:00:00.000Z",
+    "end": "2016-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-10-03 00:00:00",
     "start": "2016-10-02T13:00:00.000Z",
     "end": "2016-10-03T13:00:00.000Z",

--- a/test/fixtures/AU-NSW-2017.json
+++ b/test/fixtures/AU-NSW-2017.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-09-03 00:00:00",
+    "start": "2017-09-02T14:00:00.000Z",
+    "end": "2017-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-10-02 00:00:00",
     "start": "2017-10-01T13:00:00.000Z",
     "end": "2017-10-02T13:00:00.000Z",

--- a/test/fixtures/AU-NSW-2018.json
+++ b/test/fixtures/AU-NSW-2018.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-09-02 00:00:00",
+    "start": "2018-09-01T14:00:00.000Z",
+    "end": "2018-09-02T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-10-01 00:00:00",
     "start": "2018-09-30T14:00:00.000Z",
     "end": "2018-10-01T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2019.json
+++ b/test/fixtures/AU-NSW-2019.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-09-01 00:00:00",
+    "start": "2019-08-31T14:00:00.000Z",
+    "end": "2019-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-10-07 00:00:00",
     "start": "2019-10-06T13:00:00.000Z",
     "end": "2019-10-07T13:00:00.000Z",

--- a/test/fixtures/AU-NSW-2020.json
+++ b/test/fixtures/AU-NSW-2020.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-09-06 00:00:00",
+    "start": "2020-09-05T14:00:00.000Z",
+    "end": "2020-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-10-05 00:00:00",
     "start": "2020-10-04T13:00:00.000Z",
     "end": "2020-10-05T13:00:00.000Z",

--- a/test/fixtures/AU-NSW-2021.json
+++ b/test/fixtures/AU-NSW-2021.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-09-05 00:00:00",
+    "start": "2021-09-04T14:00:00.000Z",
+    "end": "2021-09-05T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-10-04 00:00:00",
     "start": "2021-10-03T13:00:00.000Z",
     "end": "2021-10-04T13:00:00.000Z",

--- a/test/fixtures/AU-NSW-2022.json
+++ b/test/fixtures/AU-NSW-2022.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-09-04 00:00:00",
+    "start": "2022-09-03T14:00:00.000Z",
+    "end": "2022-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-10-03 00:00:00",
     "start": "2022-10-02T13:00:00.000Z",
     "end": "2022-10-03T13:00:00.000Z",

--- a/test/fixtures/AU-NSW-2023.json
+++ b/test/fixtures/AU-NSW-2023.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-09-03 00:00:00",
+    "start": "2023-09-02T14:00:00.000Z",
+    "end": "2023-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-10-02 00:00:00",
     "start": "2023-10-01T13:00:00.000Z",
     "end": "2023-10-02T13:00:00.000Z",

--- a/test/fixtures/AU-NSW-2024.json
+++ b/test/fixtures/AU-NSW-2024.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-09-01 00:00:00",
+    "start": "2024-08-31T14:00:00.000Z",
+    "end": "2024-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-10-07 00:00:00",
     "start": "2024-10-06T13:00:00.000Z",
     "end": "2024-10-07T13:00:00.000Z",

--- a/test/fixtures/AU-NSW-2025.json
+++ b/test/fixtures/AU-NSW-2025.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-06T14:00:00.000Z",
+    "end": "2025-09-07T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-10-06 00:00:00",
     "start": "2025-10-05T13:00:00.000Z",
     "end": "2025-10-06T13:00:00.000Z",

--- a/test/fixtures/AU-NT-2015.json
+++ b/test/fixtures/AU-NT-2015.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-09-06 00:00:00",
+    "start": "2015-09-05T14:30:00.000Z",
+    "end": "2015-09-06T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-24 19:00:00",
     "start": "2015-12-24T09:30:00.000Z",
     "end": "2015-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2016.json
+++ b/test/fixtures/AU-NT-2016.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-09-04 00:00:00",
+    "start": "2016-09-03T14:30:00.000Z",
+    "end": "2016-09-04T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-12-24 19:00:00",
     "start": "2016-12-24T09:30:00.000Z",
     "end": "2016-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2017.json
+++ b/test/fixtures/AU-NT-2017.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-09-03 00:00:00",
+    "start": "2017-09-02T14:30:00.000Z",
+    "end": "2017-09-03T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-12-24 19:00:00",
     "start": "2017-12-24T09:30:00.000Z",
     "end": "2017-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2018.json
+++ b/test/fixtures/AU-NT-2018.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-09-02 00:00:00",
+    "start": "2018-09-01T14:30:00.000Z",
+    "end": "2018-09-02T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-12-24 19:00:00",
     "start": "2018-12-24T09:30:00.000Z",
     "end": "2018-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2019.json
+++ b/test/fixtures/AU-NT-2019.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-09-01 00:00:00",
+    "start": "2019-08-31T14:30:00.000Z",
+    "end": "2019-09-01T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-12-24 19:00:00",
     "start": "2019-12-24T09:30:00.000Z",
     "end": "2019-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2020.json
+++ b/test/fixtures/AU-NT-2020.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-09-06 00:00:00",
+    "start": "2020-09-05T14:30:00.000Z",
+    "end": "2020-09-06T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-24 19:00:00",
     "start": "2020-12-24T09:30:00.000Z",
     "end": "2020-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2021.json
+++ b/test/fixtures/AU-NT-2021.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-09-05 00:00:00",
+    "start": "2021-09-04T14:30:00.000Z",
+    "end": "2021-09-05T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-12-24 19:00:00",
     "start": "2021-12-24T09:30:00.000Z",
     "end": "2021-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2022.json
+++ b/test/fixtures/AU-NT-2022.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-09-04 00:00:00",
+    "start": "2022-09-03T14:30:00.000Z",
+    "end": "2022-09-04T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-12-24 19:00:00",
     "start": "2022-12-24T09:30:00.000Z",
     "end": "2022-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2023.json
+++ b/test/fixtures/AU-NT-2023.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-09-03 00:00:00",
+    "start": "2023-09-02T14:30:00.000Z",
+    "end": "2023-09-03T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-12-24 19:00:00",
     "start": "2023-12-24T09:30:00.000Z",
     "end": "2023-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2024.json
+++ b/test/fixtures/AU-NT-2024.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-09-01 00:00:00",
+    "start": "2024-08-31T14:30:00.000Z",
+    "end": "2024-09-01T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-12-24 19:00:00",
     "start": "2024-12-24T09:30:00.000Z",
     "end": "2024-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2025.json
+++ b/test/fixtures/AU-NT-2025.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-06T14:30:00.000Z",
+    "end": "2025-09-07T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-12-24 19:00:00",
     "start": "2025-12-24T09:30:00.000Z",
     "end": "2025-12-24T14:30:00.000Z",

--- a/test/fixtures/AU-QLD-2015.json
+++ b/test/fixtures/AU-QLD-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-09-06 00:00:00",
+    "start": "2015-09-05T14:00:00.000Z",
+    "end": "2015-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-10-05 00:00:00",
     "start": "2015-10-04T14:00:00.000Z",
     "end": "2015-10-05T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2016.json
+++ b/test/fixtures/AU-QLD-2016.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-09-04 00:00:00",
+    "start": "2016-09-03T14:00:00.000Z",
+    "end": "2016-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-10-03 00:00:00",
     "start": "2016-10-02T14:00:00.000Z",
     "end": "2016-10-03T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2017.json
+++ b/test/fixtures/AU-QLD-2017.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-09-03 00:00:00",
+    "start": "2017-09-02T14:00:00.000Z",
+    "end": "2017-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-10-02 00:00:00",
     "start": "2017-10-01T14:00:00.000Z",
     "end": "2017-10-02T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2018.json
+++ b/test/fixtures/AU-QLD-2018.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-09-02 00:00:00",
+    "start": "2018-09-01T14:00:00.000Z",
+    "end": "2018-09-02T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-10-01 00:00:00",
     "start": "2018-09-30T14:00:00.000Z",
     "end": "2018-10-01T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2019.json
+++ b/test/fixtures/AU-QLD-2019.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-09-01 00:00:00",
+    "start": "2019-08-31T14:00:00.000Z",
+    "end": "2019-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-10-07 00:00:00",
     "start": "2019-10-06T14:00:00.000Z",
     "end": "2019-10-07T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2020.json
+++ b/test/fixtures/AU-QLD-2020.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-09-06 00:00:00",
+    "start": "2020-09-05T14:00:00.000Z",
+    "end": "2020-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-10-05 00:00:00",
     "start": "2020-10-04T14:00:00.000Z",
     "end": "2020-10-05T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2021.json
+++ b/test/fixtures/AU-QLD-2021.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-09-05 00:00:00",
+    "start": "2021-09-04T14:00:00.000Z",
+    "end": "2021-09-05T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-10-04 00:00:00",
     "start": "2021-10-03T14:00:00.000Z",
     "end": "2021-10-04T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2022.json
+++ b/test/fixtures/AU-QLD-2022.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-09-04 00:00:00",
+    "start": "2022-09-03T14:00:00.000Z",
+    "end": "2022-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-10-03 00:00:00",
     "start": "2022-10-02T14:00:00.000Z",
     "end": "2022-10-03T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2023.json
+++ b/test/fixtures/AU-QLD-2023.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-09-03 00:00:00",
+    "start": "2023-09-02T14:00:00.000Z",
+    "end": "2023-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-10-02 00:00:00",
     "start": "2023-10-01T14:00:00.000Z",
     "end": "2023-10-02T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2024.json
+++ b/test/fixtures/AU-QLD-2024.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-09-01 00:00:00",
+    "start": "2024-08-31T14:00:00.000Z",
+    "end": "2024-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-10-07 00:00:00",
     "start": "2024-10-06T14:00:00.000Z",
     "end": "2024-10-07T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2025.json
+++ b/test/fixtures/AU-QLD-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-06T14:00:00.000Z",
+    "end": "2025-09-07T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-10-06 00:00:00",
     "start": "2025-10-05T14:00:00.000Z",
     "end": "2025-10-06T14:00:00.000Z",

--- a/test/fixtures/AU-SA-2015.json
+++ b/test/fixtures/AU-SA-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-09-06 00:00:00",
+    "start": "2015-09-05T14:30:00.000Z",
+    "end": "2015-09-06T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-10-05 00:00:00",
     "start": "2015-10-04T13:30:00.000Z",
     "end": "2015-10-05T13:30:00.000Z",

--- a/test/fixtures/AU-SA-2016.json
+++ b/test/fixtures/AU-SA-2016.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-09-04 00:00:00",
+    "start": "2016-09-03T14:30:00.000Z",
+    "end": "2016-09-04T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-10-03 00:00:00",
     "start": "2016-10-02T13:30:00.000Z",
     "end": "2016-10-03T13:30:00.000Z",

--- a/test/fixtures/AU-SA-2017.json
+++ b/test/fixtures/AU-SA-2017.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-09-03 00:00:00",
+    "start": "2017-09-02T14:30:00.000Z",
+    "end": "2017-09-03T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-10-02 00:00:00",
     "start": "2017-10-01T13:30:00.000Z",
     "end": "2017-10-02T13:30:00.000Z",

--- a/test/fixtures/AU-SA-2018.json
+++ b/test/fixtures/AU-SA-2018.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-09-02 00:00:00",
+    "start": "2018-09-01T14:30:00.000Z",
+    "end": "2018-09-02T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-10-01 00:00:00",
     "start": "2018-09-30T14:30:00.000Z",
     "end": "2018-10-01T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2019.json
+++ b/test/fixtures/AU-SA-2019.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-09-01 00:00:00",
+    "start": "2019-08-31T14:30:00.000Z",
+    "end": "2019-09-01T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-10-07 00:00:00",
     "start": "2019-10-06T13:30:00.000Z",
     "end": "2019-10-07T13:30:00.000Z",

--- a/test/fixtures/AU-SA-2020.json
+++ b/test/fixtures/AU-SA-2020.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-09-06 00:00:00",
+    "start": "2020-09-05T14:30:00.000Z",
+    "end": "2020-09-06T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-10-05 00:00:00",
     "start": "2020-10-04T13:30:00.000Z",
     "end": "2020-10-05T13:30:00.000Z",

--- a/test/fixtures/AU-SA-2021.json
+++ b/test/fixtures/AU-SA-2021.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-09-05 00:00:00",
+    "start": "2021-09-04T14:30:00.000Z",
+    "end": "2021-09-05T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-10-04 00:00:00",
     "start": "2021-10-03T13:30:00.000Z",
     "end": "2021-10-04T13:30:00.000Z",

--- a/test/fixtures/AU-SA-2022.json
+++ b/test/fixtures/AU-SA-2022.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-09-04 00:00:00",
+    "start": "2022-09-03T14:30:00.000Z",
+    "end": "2022-09-04T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-10-03 00:00:00",
     "start": "2022-10-02T13:30:00.000Z",
     "end": "2022-10-03T13:30:00.000Z",

--- a/test/fixtures/AU-SA-2023.json
+++ b/test/fixtures/AU-SA-2023.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-09-03 00:00:00",
+    "start": "2023-09-02T14:30:00.000Z",
+    "end": "2023-09-03T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-10-02 00:00:00",
     "start": "2023-10-01T13:30:00.000Z",
     "end": "2023-10-02T13:30:00.000Z",

--- a/test/fixtures/AU-SA-2024.json
+++ b/test/fixtures/AU-SA-2024.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-09-01 00:00:00",
+    "start": "2024-08-31T14:30:00.000Z",
+    "end": "2024-09-01T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-10-07 00:00:00",
     "start": "2024-10-06T13:30:00.000Z",
     "end": "2024-10-07T13:30:00.000Z",

--- a/test/fixtures/AU-SA-2025.json
+++ b/test/fixtures/AU-SA-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-06T14:30:00.000Z",
+    "end": "2025-09-07T14:30:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-10-06 00:00:00",
     "start": "2025-10-05T13:30:00.000Z",
     "end": "2025-10-06T13:30:00.000Z",

--- a/test/fixtures/AU-TAS-2015.json
+++ b/test/fixtures/AU-TAS-2015.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-09-06 00:00:00",
+    "start": "2015-09-05T14:00:00.000Z",
+    "end": "2015-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T13:00:00.000Z",
     "end": "2015-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-TAS-2016.json
+++ b/test/fixtures/AU-TAS-2016.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-09-04 00:00:00",
+    "start": "2016-09-03T14:00:00.000Z",
+    "end": "2016-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T13:00:00.000Z",
     "end": "2016-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-TAS-2017.json
+++ b/test/fixtures/AU-TAS-2017.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-09-03 00:00:00",
+    "start": "2017-09-02T14:00:00.000Z",
+    "end": "2017-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T13:00:00.000Z",
     "end": "2017-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-TAS-2018.json
+++ b/test/fixtures/AU-TAS-2018.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-09-02 00:00:00",
+    "start": "2018-09-01T14:00:00.000Z",
+    "end": "2018-09-02T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T13:00:00.000Z",
     "end": "2018-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-TAS-2019.json
+++ b/test/fixtures/AU-TAS-2019.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-09-01 00:00:00",
+    "start": "2019-08-31T14:00:00.000Z",
+    "end": "2019-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T13:00:00.000Z",
     "end": "2019-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-TAS-2020.json
+++ b/test/fixtures/AU-TAS-2020.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-09-06 00:00:00",
+    "start": "2020-09-05T14:00:00.000Z",
+    "end": "2020-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T13:00:00.000Z",
     "end": "2020-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-TAS-2021.json
+++ b/test/fixtures/AU-TAS-2021.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-09-05 00:00:00",
+    "start": "2021-09-04T14:00:00.000Z",
+    "end": "2021-09-05T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T13:00:00.000Z",
     "end": "2021-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-TAS-2022.json
+++ b/test/fixtures/AU-TAS-2022.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-09-04 00:00:00",
+    "start": "2022-09-03T14:00:00.000Z",
+    "end": "2022-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T13:00:00.000Z",
     "end": "2022-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-TAS-2023.json
+++ b/test/fixtures/AU-TAS-2023.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-09-03 00:00:00",
+    "start": "2023-09-02T14:00:00.000Z",
+    "end": "2023-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T13:00:00.000Z",
     "end": "2023-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-TAS-2024.json
+++ b/test/fixtures/AU-TAS-2024.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-09-01 00:00:00",
+    "start": "2024-08-31T14:00:00.000Z",
+    "end": "2024-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T13:00:00.000Z",
     "end": "2024-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-TAS-2025.json
+++ b/test/fixtures/AU-TAS-2025.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-06T14:00:00.000Z",
+    "end": "2025-09-07T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T13:00:00.000Z",
     "end": "2025-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-VIC-2015.json
+++ b/test/fixtures/AU-VIC-2015.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-09-06 00:00:00",
+    "start": "2015-09-05T14:00:00.000Z",
+    "end": "2015-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-09-25 00:00:00",
     "start": "2015-09-24T14:00:00.000Z",
     "end": "2015-09-25T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2016.json
+++ b/test/fixtures/AU-VIC-2016.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-09-04 00:00:00",
+    "start": "2016-09-03T14:00:00.000Z",
+    "end": "2016-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-09-30 00:00:00",
     "start": "2016-09-29T14:00:00.000Z",
     "end": "2016-09-30T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2017.json
+++ b/test/fixtures/AU-VIC-2017.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-09-03 00:00:00",
+    "start": "2017-09-02T14:00:00.000Z",
+    "end": "2017-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-09-29 00:00:00",
     "start": "2017-09-28T14:00:00.000Z",
     "end": "2017-09-29T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2018.json
+++ b/test/fixtures/AU-VIC-2018.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-09-02 00:00:00",
+    "start": "2018-09-01T14:00:00.000Z",
+    "end": "2018-09-02T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-09-28 00:00:00",
     "start": "2018-09-27T14:00:00.000Z",
     "end": "2018-09-28T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2019.json
+++ b/test/fixtures/AU-VIC-2019.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-09-01 00:00:00",
+    "start": "2019-08-31T14:00:00.000Z",
+    "end": "2019-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-09-27 00:00:00",
     "start": "2019-09-26T14:00:00.000Z",
     "end": "2019-09-27T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2020.json
+++ b/test/fixtures/AU-VIC-2020.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-09-06 00:00:00",
+    "start": "2020-09-05T14:00:00.000Z",
+    "end": "2020-09-06T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-09-25 00:00:00",
     "start": "2020-09-24T14:00:00.000Z",
     "end": "2020-09-25T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2021.json
+++ b/test/fixtures/AU-VIC-2021.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-09-05 00:00:00",
+    "start": "2021-09-04T14:00:00.000Z",
+    "end": "2021-09-05T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-09-24 00:00:00",
     "start": "2021-09-23T14:00:00.000Z",
     "end": "2021-09-24T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2022.json
+++ b/test/fixtures/AU-VIC-2022.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-09-04 00:00:00",
+    "start": "2022-09-03T14:00:00.000Z",
+    "end": "2022-09-04T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-09-30 00:00:00",
     "start": "2022-09-29T14:00:00.000Z",
     "end": "2022-09-30T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2023.json
+++ b/test/fixtures/AU-VIC-2023.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-09-03 00:00:00",
+    "start": "2023-09-02T14:00:00.000Z",
+    "end": "2023-09-03T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-09-29 00:00:00",
     "start": "2023-09-28T14:00:00.000Z",
     "end": "2023-09-29T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2024.json
+++ b/test/fixtures/AU-VIC-2024.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-09-01 00:00:00",
+    "start": "2024-08-31T14:00:00.000Z",
+    "end": "2024-09-01T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-09-27 00:00:00",
     "start": "2024-09-26T14:00:00.000Z",
     "end": "2024-09-27T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2025.json
+++ b/test/fixtures/AU-VIC-2025.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-06T14:00:00.000Z",
+    "end": "2025-09-07T14:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-09-26 00:00:00",
     "start": "2025-09-25T14:00:00.000Z",
     "end": "2025-09-26T14:00:00.000Z",

--- a/test/fixtures/AU-WA-2015.json
+++ b/test/fixtures/AU-WA-2015.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-09-06 00:00:00",
+    "start": "2015-09-05T16:00:00.000Z",
+    "end": "2015-09-06T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-09-28 00:00:00",
     "start": "2015-09-27T16:00:00.000Z",
     "end": "2015-09-28T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2016.json
+++ b/test/fixtures/AU-WA-2016.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-09-04 00:00:00",
+    "start": "2016-09-03T16:00:00.000Z",
+    "end": "2016-09-04T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-09-26 00:00:00",
     "start": "2016-09-25T16:00:00.000Z",
     "end": "2016-09-26T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2017.json
+++ b/test/fixtures/AU-WA-2017.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-09-03 00:00:00",
+    "start": "2017-09-02T16:00:00.000Z",
+    "end": "2017-09-03T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-09-25 00:00:00",
     "start": "2017-09-24T16:00:00.000Z",
     "end": "2017-09-25T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2018.json
+++ b/test/fixtures/AU-WA-2018.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-09-02 00:00:00",
+    "start": "2018-09-01T16:00:00.000Z",
+    "end": "2018-09-02T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-09-24 00:00:00",
     "start": "2018-09-23T16:00:00.000Z",
     "end": "2018-09-24T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2019.json
+++ b/test/fixtures/AU-WA-2019.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-09-01 00:00:00",
+    "start": "2019-08-31T16:00:00.000Z",
+    "end": "2019-09-01T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-09-30 00:00:00",
     "start": "2019-09-29T16:00:00.000Z",
     "end": "2019-09-30T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2020.json
+++ b/test/fixtures/AU-WA-2020.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-09-06 00:00:00",
+    "start": "2020-09-05T16:00:00.000Z",
+    "end": "2020-09-06T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-09-28 00:00:00",
     "start": "2020-09-27T16:00:00.000Z",
     "end": "2020-09-28T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2021.json
+++ b/test/fixtures/AU-WA-2021.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-09-05 00:00:00",
+    "start": "2021-09-04T16:00:00.000Z",
+    "end": "2021-09-05T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-09-27 00:00:00",
     "start": "2021-09-26T16:00:00.000Z",
     "end": "2021-09-27T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2022.json
+++ b/test/fixtures/AU-WA-2022.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-09-04 00:00:00",
+    "start": "2022-09-03T16:00:00.000Z",
+    "end": "2022-09-04T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-09-26 00:00:00",
     "start": "2022-09-25T16:00:00.000Z",
     "end": "2022-09-26T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2023.json
+++ b/test/fixtures/AU-WA-2023.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-09-03 00:00:00",
+    "start": "2023-09-02T16:00:00.000Z",
+    "end": "2023-09-03T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-09-25 00:00:00",
     "start": "2023-09-24T16:00:00.000Z",
     "end": "2023-09-25T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2024.json
+++ b/test/fixtures/AU-WA-2024.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-09-01 00:00:00",
+    "start": "2024-08-31T16:00:00.000Z",
+    "end": "2024-09-01T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-09-30 00:00:00",
     "start": "2024-09-29T16:00:00.000Z",
     "end": "2024-09-30T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2025.json
+++ b/test/fixtures/AU-WA-2025.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-06T16:00:00.000Z",
+    "end": "2025-09-07T16:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "1st sunday in September",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-09-29 00:00:00",
     "start": "2025-09-28T16:00:00.000Z",
     "end": "2025-09-29T16:00:00.000Z",

--- a/test/fixtures/GB-2015.json
+++ b/test/fixtures/GB-2015.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T23:00:00.000Z",
+    "end": "2015-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-25T00:00:00.000Z",
     "end": "2015-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-2016.json
+++ b/test/fixtures/GB-2016.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T23:00:00.000Z",
+    "end": "2016-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-25T00:00:00.000Z",
     "end": "2016-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-2017.json
+++ b/test/fixtures/GB-2017.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T23:00:00.000Z",
+    "end": "2017-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-25T00:00:00.000Z",
     "end": "2017-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-2018.json
+++ b/test/fixtures/GB-2018.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T23:00:00.000Z",
+    "end": "2018-06-17T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-25T00:00:00.000Z",
     "end": "2018-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-2019.json
+++ b/test/fixtures/GB-2019.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T23:00:00.000Z",
+    "end": "2019-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-25T00:00:00.000Z",
     "end": "2019-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-2020.json
+++ b/test/fixtures/GB-2020.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T23:00:00.000Z",
+    "end": "2020-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-25T00:00:00.000Z",
     "end": "2020-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-2021.json
+++ b/test/fixtures/GB-2021.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T23:00:00.000Z",
+    "end": "2021-06-20T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-25T00:00:00.000Z",
     "end": "2021-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-2022.json
+++ b/test/fixtures/GB-2022.json
@@ -82,6 +82,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T23:00:00.000Z",
+    "end": "2022-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-25T00:00:00.000Z",
     "end": "2022-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-2023.json
+++ b/test/fixtures/GB-2023.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T23:00:00.000Z",
+    "end": "2023-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-25T00:00:00.000Z",
     "end": "2023-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-2024.json
+++ b/test/fixtures/GB-2024.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T23:00:00.000Z",
+    "end": "2024-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-25T00:00:00.000Z",
     "end": "2024-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-2025.json
+++ b/test/fixtures/GB-2025.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T23:00:00.000Z",
+    "end": "2025-06-15T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-25T00:00:00.000Z",
     "end": "2025-12-26T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2015.json
+++ b/test/fixtures/GB-ALD-2015.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T23:00:00.000Z",
+    "end": "2015-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-15 00:00:00",
     "start": "2015-12-15T00:00:00.000Z",
     "end": "2015-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2016.json
+++ b/test/fixtures/GB-ALD-2016.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T23:00:00.000Z",
+    "end": "2016-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-12-15 00:00:00",
     "start": "2016-12-15T00:00:00.000Z",
     "end": "2016-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2017.json
+++ b/test/fixtures/GB-ALD-2017.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T23:00:00.000Z",
+    "end": "2017-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-12-15 00:00:00",
     "start": "2017-12-15T00:00:00.000Z",
     "end": "2017-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2018.json
+++ b/test/fixtures/GB-ALD-2018.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T23:00:00.000Z",
+    "end": "2018-06-17T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-12-15 00:00:00",
     "start": "2018-12-15T00:00:00.000Z",
     "end": "2018-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2019.json
+++ b/test/fixtures/GB-ALD-2019.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T23:00:00.000Z",
+    "end": "2019-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-12-15 00:00:00",
     "start": "2019-12-15T00:00:00.000Z",
     "end": "2019-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2020.json
+++ b/test/fixtures/GB-ALD-2020.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T23:00:00.000Z",
+    "end": "2020-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-15 00:00:00",
     "start": "2020-12-15T00:00:00.000Z",
     "end": "2020-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2021.json
+++ b/test/fixtures/GB-ALD-2021.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T23:00:00.000Z",
+    "end": "2021-06-20T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-12-15 00:00:00",
     "start": "2021-12-15T00:00:00.000Z",
     "end": "2021-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2022.json
+++ b/test/fixtures/GB-ALD-2022.json
@@ -82,6 +82,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T23:00:00.000Z",
+    "end": "2022-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-12-15 00:00:00",
     "start": "2022-12-15T00:00:00.000Z",
     "end": "2022-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2023.json
+++ b/test/fixtures/GB-ALD-2023.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T23:00:00.000Z",
+    "end": "2023-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-12-15 00:00:00",
     "start": "2023-12-15T00:00:00.000Z",
     "end": "2023-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2024.json
+++ b/test/fixtures/GB-ALD-2024.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T23:00:00.000Z",
+    "end": "2024-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-12-15 00:00:00",
     "start": "2024-12-15T00:00:00.000Z",
     "end": "2024-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ALD-2025.json
+++ b/test/fixtures/GB-ALD-2025.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T23:00:00.000Z",
+    "end": "2025-06-15T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-12-15 00:00:00",
     "start": "2025-12-15T00:00:00.000Z",
     "end": "2025-12-16T00:00:00.000Z",

--- a/test/fixtures/GB-ENG-2015.json
+++ b/test/fixtures/GB-ENG-2015.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T23:00:00.000Z",
+    "end": "2015-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-08-31 00:00:00",
     "start": "2015-08-30T23:00:00.000Z",
     "end": "2015-08-31T23:00:00.000Z",

--- a/test/fixtures/GB-ENG-2016.json
+++ b/test/fixtures/GB-ENG-2016.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T23:00:00.000Z",
+    "end": "2016-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-08-29 00:00:00",
     "start": "2016-08-28T23:00:00.000Z",
     "end": "2016-08-29T23:00:00.000Z",

--- a/test/fixtures/GB-ENG-2017.json
+++ b/test/fixtures/GB-ENG-2017.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T23:00:00.000Z",
+    "end": "2017-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-08-28 00:00:00",
     "start": "2017-08-27T23:00:00.000Z",
     "end": "2017-08-28T23:00:00.000Z",

--- a/test/fixtures/GB-ENG-2018.json
+++ b/test/fixtures/GB-ENG-2018.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T23:00:00.000Z",
+    "end": "2018-06-17T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-08-27 00:00:00",
     "start": "2018-08-26T23:00:00.000Z",
     "end": "2018-08-27T23:00:00.000Z",

--- a/test/fixtures/GB-ENG-2019.json
+++ b/test/fixtures/GB-ENG-2019.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T23:00:00.000Z",
+    "end": "2019-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-08-26 00:00:00",
     "start": "2019-08-25T23:00:00.000Z",
     "end": "2019-08-26T23:00:00.000Z",

--- a/test/fixtures/GB-ENG-2020.json
+++ b/test/fixtures/GB-ENG-2020.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T23:00:00.000Z",
+    "end": "2020-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-08-31 00:00:00",
     "start": "2020-08-30T23:00:00.000Z",
     "end": "2020-08-31T23:00:00.000Z",

--- a/test/fixtures/GB-ENG-2021.json
+++ b/test/fixtures/GB-ENG-2021.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T23:00:00.000Z",
+    "end": "2021-06-20T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-08-30 00:00:00",
     "start": "2021-08-29T23:00:00.000Z",
     "end": "2021-08-30T23:00:00.000Z",

--- a/test/fixtures/GB-ENG-2022.json
+++ b/test/fixtures/GB-ENG-2022.json
@@ -82,6 +82,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T23:00:00.000Z",
+    "end": "2022-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-08-29 00:00:00",
     "start": "2022-08-28T23:00:00.000Z",
     "end": "2022-08-29T23:00:00.000Z",

--- a/test/fixtures/GB-ENG-2023.json
+++ b/test/fixtures/GB-ENG-2023.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T23:00:00.000Z",
+    "end": "2023-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-08-28 00:00:00",
     "start": "2023-08-27T23:00:00.000Z",
     "end": "2023-08-28T23:00:00.000Z",

--- a/test/fixtures/GB-ENG-2024.json
+++ b/test/fixtures/GB-ENG-2024.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T23:00:00.000Z",
+    "end": "2024-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-08-26 00:00:00",
     "start": "2024-08-25T23:00:00.000Z",
     "end": "2024-08-26T23:00:00.000Z",

--- a/test/fixtures/GB-ENG-2025.json
+++ b/test/fixtures/GB-ENG-2025.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T23:00:00.000Z",
+    "end": "2025-06-15T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-08-25 00:00:00",
     "start": "2025-08-24T23:00:00.000Z",
     "end": "2025-08-25T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2015.json
+++ b/test/fixtures/GB-NIR-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T23:00:00.000Z",
+    "end": "2015-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-07-12 00:00:00",
     "start": "2015-07-11T23:00:00.000Z",
     "end": "2015-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2016.json
+++ b/test/fixtures/GB-NIR-2016.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T23:00:00.000Z",
+    "end": "2016-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-07-12 00:00:00",
     "start": "2016-07-11T23:00:00.000Z",
     "end": "2016-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2017.json
+++ b/test/fixtures/GB-NIR-2017.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T23:00:00.000Z",
+    "end": "2017-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-07-12 00:00:00",
     "start": "2017-07-11T23:00:00.000Z",
     "end": "2017-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2018.json
+++ b/test/fixtures/GB-NIR-2018.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T23:00:00.000Z",
+    "end": "2018-06-17T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-07-12 00:00:00",
     "start": "2018-07-11T23:00:00.000Z",
     "end": "2018-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2019.json
+++ b/test/fixtures/GB-NIR-2019.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T23:00:00.000Z",
+    "end": "2019-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-07-12 00:00:00",
     "start": "2019-07-11T23:00:00.000Z",
     "end": "2019-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2020.json
+++ b/test/fixtures/GB-NIR-2020.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T23:00:00.000Z",
+    "end": "2020-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-07-12 00:00:00",
     "start": "2020-07-11T23:00:00.000Z",
     "end": "2020-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2021.json
+++ b/test/fixtures/GB-NIR-2021.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T23:00:00.000Z",
+    "end": "2021-06-20T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-07-12 00:00:00",
     "start": "2021-07-11T23:00:00.000Z",
     "end": "2021-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2022.json
+++ b/test/fixtures/GB-NIR-2022.json
@@ -91,6 +91,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T23:00:00.000Z",
+    "end": "2022-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-07-12 00:00:00",
     "start": "2022-07-11T23:00:00.000Z",
     "end": "2022-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2023.json
+++ b/test/fixtures/GB-NIR-2023.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T23:00:00.000Z",
+    "end": "2023-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-07-12 00:00:00",
     "start": "2023-07-11T23:00:00.000Z",
     "end": "2023-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2024.json
+++ b/test/fixtures/GB-NIR-2024.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T23:00:00.000Z",
+    "end": "2024-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-07-12 00:00:00",
     "start": "2024-07-11T23:00:00.000Z",
     "end": "2024-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-NIR-2025.json
+++ b/test/fixtures/GB-NIR-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T23:00:00.000Z",
+    "end": "2025-06-15T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-07-12 00:00:00",
     "start": "2025-07-11T23:00:00.000Z",
     "end": "2025-07-12T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2015.json
+++ b/test/fixtures/GB-SCT-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T23:00:00.000Z",
+    "end": "2015-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-08-03 00:00:00",
     "start": "2015-08-02T23:00:00.000Z",
     "end": "2015-08-03T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2016.json
+++ b/test/fixtures/GB-SCT-2016.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T23:00:00.000Z",
+    "end": "2016-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-08-01 00:00:00",
     "start": "2016-07-31T23:00:00.000Z",
     "end": "2016-08-01T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2017.json
+++ b/test/fixtures/GB-SCT-2017.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T23:00:00.000Z",
+    "end": "2017-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-08-07 00:00:00",
     "start": "2017-08-06T23:00:00.000Z",
     "end": "2017-08-07T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2018.json
+++ b/test/fixtures/GB-SCT-2018.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T23:00:00.000Z",
+    "end": "2018-06-17T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-08-06 00:00:00",
     "start": "2018-08-05T23:00:00.000Z",
     "end": "2018-08-06T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2019.json
+++ b/test/fixtures/GB-SCT-2019.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T23:00:00.000Z",
+    "end": "2019-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-08-05 00:00:00",
     "start": "2019-08-04T23:00:00.000Z",
     "end": "2019-08-05T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2020.json
+++ b/test/fixtures/GB-SCT-2020.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T23:00:00.000Z",
+    "end": "2020-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-08-03 00:00:00",
     "start": "2020-08-02T23:00:00.000Z",
     "end": "2020-08-03T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2021.json
+++ b/test/fixtures/GB-SCT-2021.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T23:00:00.000Z",
+    "end": "2021-06-20T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-08-02 00:00:00",
     "start": "2021-08-01T23:00:00.000Z",
     "end": "2021-08-02T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2022.json
+++ b/test/fixtures/GB-SCT-2022.json
@@ -101,6 +101,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T23:00:00.000Z",
+    "end": "2022-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-08-01 00:00:00",
     "start": "2022-07-31T23:00:00.000Z",
     "end": "2022-08-01T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2023.json
+++ b/test/fixtures/GB-SCT-2023.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T23:00:00.000Z",
+    "end": "2023-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-08-07 00:00:00",
     "start": "2023-08-06T23:00:00.000Z",
     "end": "2023-08-07T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2024.json
+++ b/test/fixtures/GB-SCT-2024.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T23:00:00.000Z",
+    "end": "2024-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-08-05 00:00:00",
     "start": "2024-08-04T23:00:00.000Z",
     "end": "2024-08-05T23:00:00.000Z",

--- a/test/fixtures/GB-SCT-2025.json
+++ b/test/fixtures/GB-SCT-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T23:00:00.000Z",
+    "end": "2025-06-15T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-08-04 00:00:00",
     "start": "2025-08-03T23:00:00.000Z",
     "end": "2025-08-04T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2015.json
+++ b/test/fixtures/GB-WLS-2015.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T23:00:00.000Z",
+    "end": "2015-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-08-31 00:00:00",
     "start": "2015-08-30T23:00:00.000Z",
     "end": "2015-08-31T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2016.json
+++ b/test/fixtures/GB-WLS-2016.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T23:00:00.000Z",
+    "end": "2016-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-08-29 00:00:00",
     "start": "2016-08-28T23:00:00.000Z",
     "end": "2016-08-29T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2017.json
+++ b/test/fixtures/GB-WLS-2017.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T23:00:00.000Z",
+    "end": "2017-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-08-28 00:00:00",
     "start": "2017-08-27T23:00:00.000Z",
     "end": "2017-08-28T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2018.json
+++ b/test/fixtures/GB-WLS-2018.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T23:00:00.000Z",
+    "end": "2018-06-17T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-08-27 00:00:00",
     "start": "2018-08-26T23:00:00.000Z",
     "end": "2018-08-27T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2019.json
+++ b/test/fixtures/GB-WLS-2019.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T23:00:00.000Z",
+    "end": "2019-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-08-26 00:00:00",
     "start": "2019-08-25T23:00:00.000Z",
     "end": "2019-08-26T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2020.json
+++ b/test/fixtures/GB-WLS-2020.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T23:00:00.000Z",
+    "end": "2020-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-08-31 00:00:00",
     "start": "2020-08-30T23:00:00.000Z",
     "end": "2020-08-31T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2021.json
+++ b/test/fixtures/GB-WLS-2021.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T23:00:00.000Z",
+    "end": "2021-06-20T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-08-30 00:00:00",
     "start": "2021-08-29T23:00:00.000Z",
     "end": "2021-08-30T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2022.json
+++ b/test/fixtures/GB-WLS-2022.json
@@ -82,6 +82,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T23:00:00.000Z",
+    "end": "2022-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-08-29 00:00:00",
     "start": "2022-08-28T23:00:00.000Z",
     "end": "2022-08-29T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2023.json
+++ b/test/fixtures/GB-WLS-2023.json
@@ -73,6 +73,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T23:00:00.000Z",
+    "end": "2023-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-08-28 00:00:00",
     "start": "2023-08-27T23:00:00.000Z",
     "end": "2023-08-28T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2024.json
+++ b/test/fixtures/GB-WLS-2024.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T23:00:00.000Z",
+    "end": "2024-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-08-26 00:00:00",
     "start": "2024-08-25T23:00:00.000Z",
     "end": "2024-08-26T23:00:00.000Z",

--- a/test/fixtures/GB-WLS-2025.json
+++ b/test/fixtures/GB-WLS-2025.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T23:00:00.000Z",
+    "end": "2025-06-15T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-08-25 00:00:00",
     "start": "2025-08-24T23:00:00.000Z",
     "end": "2025-08-25T23:00:00.000Z",

--- a/test/fixtures/GG-2015.json
+++ b/test/fixtures/GG-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T23:00:00.000Z",
+    "end": "2015-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-25T00:00:00.000Z",
     "end": "2015-12-26T00:00:00.000Z",

--- a/test/fixtures/GG-2016.json
+++ b/test/fixtures/GG-2016.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T23:00:00.000Z",
+    "end": "2016-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-25T00:00:00.000Z",
     "end": "2016-12-26T00:00:00.000Z",

--- a/test/fixtures/GG-2017.json
+++ b/test/fixtures/GG-2017.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T23:00:00.000Z",
+    "end": "2017-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-25T00:00:00.000Z",
     "end": "2017-12-26T00:00:00.000Z",

--- a/test/fixtures/GG-2018.json
+++ b/test/fixtures/GG-2018.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T23:00:00.000Z",
+    "end": "2018-06-17T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-25T00:00:00.000Z",
     "end": "2018-12-26T00:00:00.000Z",

--- a/test/fixtures/GG-2019.json
+++ b/test/fixtures/GG-2019.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T23:00:00.000Z",
+    "end": "2019-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-25T00:00:00.000Z",
     "end": "2019-12-26T00:00:00.000Z",

--- a/test/fixtures/GG-2020.json
+++ b/test/fixtures/GG-2020.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T23:00:00.000Z",
+    "end": "2020-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-25T00:00:00.000Z",
     "end": "2020-12-26T00:00:00.000Z",

--- a/test/fixtures/GG-2021.json
+++ b/test/fixtures/GG-2021.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T23:00:00.000Z",
+    "end": "2021-06-20T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-25T00:00:00.000Z",
     "end": "2021-12-26T00:00:00.000Z",

--- a/test/fixtures/GG-2022.json
+++ b/test/fixtures/GG-2022.json
@@ -91,6 +91,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T23:00:00.000Z",
+    "end": "2022-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-25T00:00:00.000Z",
     "end": "2022-12-26T00:00:00.000Z",

--- a/test/fixtures/GG-2023.json
+++ b/test/fixtures/GG-2023.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T23:00:00.000Z",
+    "end": "2023-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-25T00:00:00.000Z",
     "end": "2023-12-26T00:00:00.000Z",

--- a/test/fixtures/GG-2024.json
+++ b/test/fixtures/GG-2024.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T23:00:00.000Z",
+    "end": "2024-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-25T00:00:00.000Z",
     "end": "2024-12-26T00:00:00.000Z",

--- a/test/fixtures/GG-2025.json
+++ b/test/fixtures/GG-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T23:00:00.000Z",
+    "end": "2025-06-15T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-25T00:00:00.000Z",
     "end": "2025-12-26T00:00:00.000Z",

--- a/test/fixtures/GI-2015.json
+++ b/test/fixtures/GI-2015.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T22:00:00.000Z",
+    "end": "2015-06-21T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-08-31 00:00:00",
     "start": "2015-08-30T22:00:00.000Z",
     "end": "2015-08-31T22:00:00.000Z",

--- a/test/fixtures/GI-2016.json
+++ b/test/fixtures/GI-2016.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T22:00:00.000Z",
+    "end": "2016-06-19T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-08-29 00:00:00",
     "start": "2016-08-28T22:00:00.000Z",
     "end": "2016-08-29T22:00:00.000Z",

--- a/test/fixtures/GI-2017.json
+++ b/test/fixtures/GI-2017.json
@@ -91,6 +91,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T22:00:00.000Z",
+    "end": "2017-06-18T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-06-19 00:00:00",
     "start": "2017-06-18T22:00:00.000Z",
     "end": "2017-06-19T22:00:00.000Z",

--- a/test/fixtures/GI-2018.json
+++ b/test/fixtures/GI-2018.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T22:00:00.000Z",
+    "end": "2018-06-17T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-06-18 00:00:00",
     "start": "2018-06-17T22:00:00.000Z",
     "end": "2018-06-18T22:00:00.000Z",

--- a/test/fixtures/GI-2019.json
+++ b/test/fixtures/GI-2019.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T22:00:00.000Z",
+    "end": "2019-06-16T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-06-17 00:00:00",
     "start": "2019-06-16T22:00:00.000Z",
     "end": "2019-06-17T22:00:00.000Z",

--- a/test/fixtures/GI-2020.json
+++ b/test/fixtures/GI-2020.json
@@ -99,6 +99,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T22:00:00.000Z",
+    "end": "2020-06-21T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-08-31 00:00:00",
     "start": "2020-08-30T22:00:00.000Z",
     "end": "2020-08-31T22:00:00.000Z",

--- a/test/fixtures/GI-2021.json
+++ b/test/fixtures/GI-2021.json
@@ -90,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T22:00:00.000Z",
+    "end": "2021-06-20T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-08-30 00:00:00",
     "start": "2021-08-29T22:00:00.000Z",
     "end": "2021-08-30T22:00:00.000Z",

--- a/test/fixtures/GI-2022.json
+++ b/test/fixtures/GI-2022.json
@@ -109,6 +109,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T22:00:00.000Z",
+    "end": "2022-06-19T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-08-29 00:00:00",
     "start": "2022-08-28T22:00:00.000Z",
     "end": "2022-08-29T22:00:00.000Z",

--- a/test/fixtures/GI-2023.json
+++ b/test/fixtures/GI-2023.json
@@ -91,6 +91,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T22:00:00.000Z",
+    "end": "2023-06-18T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-06-19 00:00:00",
     "start": "2023-06-18T22:00:00.000Z",
     "end": "2023-06-19T22:00:00.000Z",

--- a/test/fixtures/GI-2024.json
+++ b/test/fixtures/GI-2024.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T22:00:00.000Z",
+    "end": "2024-06-16T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-06-17 00:00:00",
     "start": "2024-06-16T22:00:00.000Z",
     "end": "2024-06-17T22:00:00.000Z",

--- a/test/fixtures/GI-2025.json
+++ b/test/fixtures/GI-2025.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T22:00:00.000Z",
+    "end": "2025-06-15T22:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-06-16 00:00:00",
     "start": "2025-06-15T22:00:00.000Z",
     "end": "2025-06-16T22:00:00.000Z",

--- a/test/fixtures/IE-2015.json
+++ b/test/fixtures/IE-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T23:00:00.000Z",
+    "end": "2015-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-08-03 00:00:00",
     "start": "2015-08-02T23:00:00.000Z",
     "end": "2015-08-03T23:00:00.000Z",

--- a/test/fixtures/IE-2016.json
+++ b/test/fixtures/IE-2016.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T23:00:00.000Z",
+    "end": "2016-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-08-01 00:00:00",
     "start": "2016-07-31T23:00:00.000Z",
     "end": "2016-08-01T23:00:00.000Z",

--- a/test/fixtures/IE-2017.json
+++ b/test/fixtures/IE-2017.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T23:00:00.000Z",
+    "end": "2017-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-08-07 00:00:00",
     "start": "2017-08-06T23:00:00.000Z",
     "end": "2017-08-07T23:00:00.000Z",

--- a/test/fixtures/IE-2018.json
+++ b/test/fixtures/IE-2018.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T23:00:00.000Z",
+    "end": "2018-06-17T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-08-06 00:00:00",
     "start": "2018-08-05T23:00:00.000Z",
     "end": "2018-08-06T23:00:00.000Z",

--- a/test/fixtures/IE-2019.json
+++ b/test/fixtures/IE-2019.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T23:00:00.000Z",
+    "end": "2019-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-08-05 00:00:00",
     "start": "2019-08-04T23:00:00.000Z",
     "end": "2019-08-05T23:00:00.000Z",

--- a/test/fixtures/IE-2020.json
+++ b/test/fixtures/IE-2020.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T23:00:00.000Z",
+    "end": "2020-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-08-03 00:00:00",
     "start": "2020-08-02T23:00:00.000Z",
     "end": "2020-08-03T23:00:00.000Z",

--- a/test/fixtures/IE-2021.json
+++ b/test/fixtures/IE-2021.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T23:00:00.000Z",
+    "end": "2021-06-20T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-08-02 00:00:00",
     "start": "2021-08-01T23:00:00.000Z",
     "end": "2021-08-02T23:00:00.000Z",

--- a/test/fixtures/IE-2022.json
+++ b/test/fixtures/IE-2022.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T23:00:00.000Z",
+    "end": "2022-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-08-01 00:00:00",
     "start": "2022-07-31T23:00:00.000Z",
     "end": "2022-08-01T23:00:00.000Z",

--- a/test/fixtures/IE-2023.json
+++ b/test/fixtures/IE-2023.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T23:00:00.000Z",
+    "end": "2023-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-08-07 00:00:00",
     "start": "2023-08-06T23:00:00.000Z",
     "end": "2023-08-07T23:00:00.000Z",

--- a/test/fixtures/IE-2024.json
+++ b/test/fixtures/IE-2024.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T23:00:00.000Z",
+    "end": "2024-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-08-05 00:00:00",
     "start": "2024-08-04T23:00:00.000Z",
     "end": "2024-08-05T23:00:00.000Z",

--- a/test/fixtures/IE-2025.json
+++ b/test/fixtures/IE-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T23:00:00.000Z",
+    "end": "2025-06-15T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-08-04 00:00:00",
     "start": "2025-08-03T23:00:00.000Z",
     "end": "2025-08-04T23:00:00.000Z",

--- a/test/fixtures/IM-2015.json
+++ b/test/fixtures/IM-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T23:00:00.000Z",
+    "end": "2015-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-07-05 00:00:00",
     "start": "2015-07-04T23:00:00.000Z",
     "end": "2015-07-05T23:00:00.000Z",

--- a/test/fixtures/IM-2016.json
+++ b/test/fixtures/IM-2016.json
@@ -72,6 +72,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T23:00:00.000Z",
+    "end": "2016-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-07-05 00:00:00",
     "start": "2016-07-04T23:00:00.000Z",
     "end": "2016-07-05T23:00:00.000Z",

--- a/test/fixtures/IM-2017.json
+++ b/test/fixtures/IM-2017.json
@@ -82,6 +82,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T23:00:00.000Z",
+    "end": "2017-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-07-05 00:00:00",
     "start": "2017-07-04T23:00:00.000Z",
     "end": "2017-07-05T23:00:00.000Z",

--- a/test/fixtures/IM-2018.json
+++ b/test/fixtures/IM-2018.json
@@ -72,6 +72,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T23:00:00.000Z",
+    "end": "2018-06-17T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-07-05 00:00:00",
     "start": "2018-07-04T23:00:00.000Z",
     "end": "2018-07-05T23:00:00.000Z",

--- a/test/fixtures/IM-2019.json
+++ b/test/fixtures/IM-2019.json
@@ -72,6 +72,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T23:00:00.000Z",
+    "end": "2019-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-07-05 00:00:00",
     "start": "2019-07-04T23:00:00.000Z",
     "end": "2019-07-05T23:00:00.000Z",

--- a/test/fixtures/IM-2020.json
+++ b/test/fixtures/IM-2020.json
@@ -72,6 +72,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T23:00:00.000Z",
+    "end": "2020-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-07-05 00:00:00",
     "start": "2020-07-04T23:00:00.000Z",
     "end": "2020-07-05T23:00:00.000Z",

--- a/test/fixtures/IM-2021.json
+++ b/test/fixtures/IM-2021.json
@@ -72,6 +72,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T23:00:00.000Z",
+    "end": "2021-06-20T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-07-05 00:00:00",
     "start": "2021-07-04T23:00:00.000Z",
     "end": "2021-07-05T23:00:00.000Z",

--- a/test/fixtures/IM-2022.json
+++ b/test/fixtures/IM-2022.json
@@ -91,6 +91,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T23:00:00.000Z",
+    "end": "2022-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-07-05 00:00:00",
     "start": "2022-07-04T23:00:00.000Z",
     "end": "2022-07-05T23:00:00.000Z",

--- a/test/fixtures/IM-2023.json
+++ b/test/fixtures/IM-2023.json
@@ -82,6 +82,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T23:00:00.000Z",
+    "end": "2023-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-07-05 00:00:00",
     "start": "2023-07-04T23:00:00.000Z",
     "end": "2023-07-05T23:00:00.000Z",

--- a/test/fixtures/IM-2024.json
+++ b/test/fixtures/IM-2024.json
@@ -72,6 +72,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T23:00:00.000Z",
+    "end": "2024-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-07-05 00:00:00",
     "start": "2024-07-04T23:00:00.000Z",
     "end": "2024-07-05T23:00:00.000Z",

--- a/test/fixtures/IM-2025.json
+++ b/test/fixtures/IM-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T23:00:00.000Z",
+    "end": "2025-06-15T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-07-05 00:00:00",
     "start": "2025-07-04T23:00:00.000Z",
     "end": "2025-07-05T23:00:00.000Z",

--- a/test/fixtures/JE-2015.json
+++ b/test/fixtures/JE-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-20T23:00:00.000Z",
+    "end": "2015-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-25T00:00:00.000Z",
     "end": "2015-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2016.json
+++ b/test/fixtures/JE-2016.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-06-19 00:00:00",
+    "start": "2016-06-18T23:00:00.000Z",
+    "end": "2016-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-25T00:00:00.000Z",
     "end": "2016-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2017.json
+++ b/test/fixtures/JE-2017.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-18 00:00:00",
+    "start": "2017-06-17T23:00:00.000Z",
+    "end": "2017-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-25T00:00:00.000Z",
     "end": "2017-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2018.json
+++ b/test/fixtures/JE-2018.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-16T23:00:00.000Z",
+    "end": "2018-06-17T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-25T00:00:00.000Z",
     "end": "2018-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2019.json
+++ b/test/fixtures/JE-2019.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-06-16 00:00:00",
+    "start": "2019-06-15T23:00:00.000Z",
+    "end": "2019-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-25T00:00:00.000Z",
     "end": "2019-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2020.json
+++ b/test/fixtures/JE-2020.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-20T23:00:00.000Z",
+    "end": "2020-06-21T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-25T00:00:00.000Z",
     "end": "2020-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2021.json
+++ b/test/fixtures/JE-2021.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-20 00:00:00",
+    "start": "2021-06-19T23:00:00.000Z",
+    "end": "2021-06-20T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-25T00:00:00.000Z",
     "end": "2021-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2022.json
+++ b/test/fixtures/JE-2022.json
@@ -91,6 +91,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-06-19 00:00:00",
+    "start": "2022-06-18T23:00:00.000Z",
+    "end": "2022-06-19T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-25T00:00:00.000Z",
     "end": "2022-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2023.json
+++ b/test/fixtures/JE-2023.json
@@ -82,6 +82,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-18 00:00:00",
+    "start": "2023-06-17T23:00:00.000Z",
+    "end": "2023-06-18T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-25T00:00:00.000Z",
     "end": "2023-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2024.json
+++ b/test/fixtures/JE-2024.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-16 00:00:00",
+    "start": "2024-06-15T23:00:00.000Z",
+    "end": "2024-06-16T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-25T00:00:00.000Z",
     "end": "2024-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2025.json
+++ b/test/fixtures/JE-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-06-15 00:00:00",
+    "start": "2025-06-14T23:00:00.000Z",
+    "end": "2025-06-15T23:00:00.000Z",
+    "name": "Father's Day",
+    "type": "observance",
+    "rule": "3rd sunday in June",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-25T00:00:00.000Z",
     "end": "2025-12-26T00:00:00.000Z",


### PR DESCRIPTION
Added in the fathers day dates for Australia, United Kingdom and Ireland

Australia: https://www.officeholidays.com/holidays/australia/fathers-day
United Kingdom: https://www.timeanddate.com/holidays/uk/father-day
Ireland: https://publicholidays.ie/fathers-day/