### PR TITLE
feat: added Mothers day to au

### DIFF
--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -45,6 +45,9 @@ holidays:
       12-26 and if saturday then next monday if sunday then next tuesday:
         substitute: true
         _name: 12-26
+      2nd sunday in May:
+        _name: Mothers Day
+        type: observance
     states:
       # @source https://www.legislation.act.gov.au/a/1958-19
       ACT:

--- a/test/fixtures/AU-2015.json
+++ b/test/fixtures/AU-2015.json
@@ -63,6 +63,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T14:00:00.000Z",
+    "end": "2015-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T13:00:00.000Z",
     "end": "2015-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2016.json
+++ b/test/fixtures/AU-2016.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T14:00:00.000Z",
+    "end": "2016-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T13:00:00.000Z",
     "end": "2016-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2017.json
+++ b/test/fixtures/AU-2017.json
@@ -72,6 +72,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T14:00:00.000Z",
+    "end": "2017-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T13:00:00.000Z",
     "end": "2017-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2018.json
+++ b/test/fixtures/AU-2018.json
@@ -63,6 +63,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T14:00:00.000Z",
+    "end": "2018-05-13T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T13:00:00.000Z",
     "end": "2018-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2019.json
+++ b/test/fixtures/AU-2019.json
@@ -63,6 +63,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T14:00:00.000Z",
+    "end": "2019-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T13:00:00.000Z",
     "end": "2019-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2020.json
+++ b/test/fixtures/AU-2020.json
@@ -63,6 +63,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T14:00:00.000Z",
+    "end": "2020-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T13:00:00.000Z",
     "end": "2020-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2021.json
+++ b/test/fixtures/AU-2021.json
@@ -63,6 +63,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T14:00:00.000Z",
+    "end": "2021-05-09T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T13:00:00.000Z",
     "end": "2021-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2022.json
+++ b/test/fixtures/AU-2022.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T14:00:00.000Z",
+    "end": "2022-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T13:00:00.000Z",
     "end": "2022-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2023.json
+++ b/test/fixtures/AU-2023.json
@@ -72,6 +72,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T14:00:00.000Z",
+    "end": "2023-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T13:00:00.000Z",
     "end": "2023-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2024.json
+++ b/test/fixtures/AU-2024.json
@@ -63,6 +63,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T14:00:00.000Z",
+    "end": "2024-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T13:00:00.000Z",
     "end": "2024-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-2025.json
+++ b/test/fixtures/AU-2025.json
@@ -63,6 +63,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T14:00:00.000Z",
+    "end": "2025-05-11T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T13:00:00.000Z",
     "end": "2025-12-25T13:00:00.000Z",

--- a/test/fixtures/AU-ACT-2015.json
+++ b/test/fixtures/AU-ACT-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T14:00:00.000Z",
+    "end": "2015-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-06-01 00:00:00",
     "start": "2015-05-31T14:00:00.000Z",
     "end": "2015-06-01T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2016.json
+++ b/test/fixtures/AU-ACT-2016.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T14:00:00.000Z",
+    "end": "2016-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-05-30 00:00:00",
     "start": "2016-05-29T14:00:00.000Z",
     "end": "2016-05-30T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2017.json
+++ b/test/fixtures/AU-ACT-2017.json
@@ -81,6 +81,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T14:00:00.000Z",
+    "end": "2017-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-05-29 00:00:00",
     "start": "2017-05-28T14:00:00.000Z",
     "end": "2017-05-29T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2018.json
+++ b/test/fixtures/AU-ACT-2018.json
@@ -72,6 +72,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T14:00:00.000Z",
+    "end": "2018-05-13T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-05-28 00:00:00",
     "start": "2018-05-27T14:00:00.000Z",
     "end": "2018-05-28T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2019.json
+++ b/test/fixtures/AU-ACT-2019.json
@@ -72,6 +72,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T14:00:00.000Z",
+    "end": "2019-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-05-27 00:00:00",
     "start": "2019-05-26T14:00:00.000Z",
     "end": "2019-05-27T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2020.json
+++ b/test/fixtures/AU-ACT-2020.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T14:00:00.000Z",
+    "end": "2020-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-06-01 00:00:00",
     "start": "2020-05-31T14:00:00.000Z",
     "end": "2020-06-01T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2021.json
+++ b/test/fixtures/AU-ACT-2021.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T14:00:00.000Z",
+    "end": "2021-05-09T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-05-31 00:00:00",
     "start": "2021-05-30T14:00:00.000Z",
     "end": "2021-05-31T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2022.json
+++ b/test/fixtures/AU-ACT-2022.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T14:00:00.000Z",
+    "end": "2022-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-05-30 00:00:00",
     "start": "2022-05-29T14:00:00.000Z",
     "end": "2022-05-30T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2023.json
+++ b/test/fixtures/AU-ACT-2023.json
@@ -81,6 +81,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T14:00:00.000Z",
+    "end": "2023-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-05-29 00:00:00",
     "start": "2023-05-28T14:00:00.000Z",
     "end": "2023-05-29T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2024.json
+++ b/test/fixtures/AU-ACT-2024.json
@@ -72,6 +72,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T14:00:00.000Z",
+    "end": "2024-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-05-27 00:00:00",
     "start": "2024-05-26T14:00:00.000Z",
     "end": "2024-05-27T14:00:00.000Z",

--- a/test/fixtures/AU-ACT-2025.json
+++ b/test/fixtures/AU-ACT-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T14:00:00.000Z",
+    "end": "2025-05-11T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-06-02 00:00:00",
     "start": "2025-06-01T14:00:00.000Z",
     "end": "2025-06-02T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2015.json
+++ b/test/fixtures/AU-NSW-2015.json
@@ -63,6 +63,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T14:00:00.000Z",
+    "end": "2015-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-06-08 00:00:00",
     "start": "2015-06-07T14:00:00.000Z",
     "end": "2015-06-08T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2016.json
+++ b/test/fixtures/AU-NSW-2016.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T14:00:00.000Z",
+    "end": "2016-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-06-13 00:00:00",
     "start": "2016-06-12T14:00:00.000Z",
     "end": "2016-06-13T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2017.json
+++ b/test/fixtures/AU-NSW-2017.json
@@ -72,6 +72,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T14:00:00.000Z",
+    "end": "2017-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-06-12 00:00:00",
     "start": "2017-06-11T14:00:00.000Z",
     "end": "2017-06-12T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2018.json
+++ b/test/fixtures/AU-NSW-2018.json
@@ -63,6 +63,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T14:00:00.000Z",
+    "end": "2018-05-13T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-06-11 00:00:00",
     "start": "2018-06-10T14:00:00.000Z",
     "end": "2018-06-11T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2019.json
+++ b/test/fixtures/AU-NSW-2019.json
@@ -63,6 +63,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T14:00:00.000Z",
+    "end": "2019-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-06-10 00:00:00",
     "start": "2019-06-09T14:00:00.000Z",
     "end": "2019-06-10T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2020.json
+++ b/test/fixtures/AU-NSW-2020.json
@@ -63,6 +63,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T14:00:00.000Z",
+    "end": "2020-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-06-08 00:00:00",
     "start": "2020-06-07T14:00:00.000Z",
     "end": "2020-06-08T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2021.json
+++ b/test/fixtures/AU-NSW-2021.json
@@ -63,6 +63,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T14:00:00.000Z",
+    "end": "2021-05-09T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-06-14 00:00:00",
     "start": "2021-06-13T14:00:00.000Z",
     "end": "2021-06-14T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2022.json
+++ b/test/fixtures/AU-NSW-2022.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T14:00:00.000Z",
+    "end": "2022-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-06-13 00:00:00",
     "start": "2022-06-12T14:00:00.000Z",
     "end": "2022-06-13T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2023.json
+++ b/test/fixtures/AU-NSW-2023.json
@@ -72,6 +72,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T14:00:00.000Z",
+    "end": "2023-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:00:00.000Z",
     "end": "2023-06-12T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2024.json
+++ b/test/fixtures/AU-NSW-2024.json
@@ -63,6 +63,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T14:00:00.000Z",
+    "end": "2024-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:00:00.000Z",
     "end": "2024-06-10T14:00:00.000Z",

--- a/test/fixtures/AU-NSW-2025.json
+++ b/test/fixtures/AU-NSW-2025.json
@@ -63,6 +63,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T14:00:00.000Z",
+    "end": "2025-05-11T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:00:00.000Z",
     "end": "2025-06-09T14:00:00.000Z",

--- a/test/fixtures/AU-NT-2015.json
+++ b/test/fixtures/AU-NT-2015.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T14:30:00.000Z",
+    "end": "2015-05-10T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-06-08 00:00:00",
     "start": "2015-06-07T14:30:00.000Z",
     "end": "2015-06-08T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2016.json
+++ b/test/fixtures/AU-NT-2016.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T14:30:00.000Z",
+    "end": "2016-05-08T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-06-13 00:00:00",
     "start": "2016-06-12T14:30:00.000Z",
     "end": "2016-06-13T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2017.json
+++ b/test/fixtures/AU-NT-2017.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T14:30:00.000Z",
+    "end": "2017-05-14T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-06-12 00:00:00",
     "start": "2017-06-11T14:30:00.000Z",
     "end": "2017-06-12T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2018.json
+++ b/test/fixtures/AU-NT-2018.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T14:30:00.000Z",
+    "end": "2018-05-13T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-06-11 00:00:00",
     "start": "2018-06-10T14:30:00.000Z",
     "end": "2018-06-11T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2019.json
+++ b/test/fixtures/AU-NT-2019.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T14:30:00.000Z",
+    "end": "2019-05-12T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-06-10 00:00:00",
     "start": "2019-06-09T14:30:00.000Z",
     "end": "2019-06-10T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2020.json
+++ b/test/fixtures/AU-NT-2020.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T14:30:00.000Z",
+    "end": "2020-05-10T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-06-08 00:00:00",
     "start": "2020-06-07T14:30:00.000Z",
     "end": "2020-06-08T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2021.json
+++ b/test/fixtures/AU-NT-2021.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T14:30:00.000Z",
+    "end": "2021-05-09T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-06-14 00:00:00",
     "start": "2021-06-13T14:30:00.000Z",
     "end": "2021-06-14T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2022.json
+++ b/test/fixtures/AU-NT-2022.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T14:30:00.000Z",
+    "end": "2022-05-08T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-06-13 00:00:00",
     "start": "2022-06-12T14:30:00.000Z",
     "end": "2022-06-13T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2023.json
+++ b/test/fixtures/AU-NT-2023.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T14:30:00.000Z",
+    "end": "2023-05-14T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:30:00.000Z",
     "end": "2023-06-12T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2024.json
+++ b/test/fixtures/AU-NT-2024.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T14:30:00.000Z",
+    "end": "2024-05-12T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:30:00.000Z",
     "end": "2024-06-10T14:30:00.000Z",

--- a/test/fixtures/AU-NT-2025.json
+++ b/test/fixtures/AU-NT-2025.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T14:30:00.000Z",
+    "end": "2025-05-11T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:30:00.000Z",
     "end": "2025-06-09T14:30:00.000Z",

--- a/test/fixtures/AU-QLD-2015.json
+++ b/test/fixtures/AU-QLD-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T14:00:00.000Z",
+    "end": "2015-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-10-05 00:00:00",
     "start": "2015-10-04T14:00:00.000Z",
     "end": "2015-10-05T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2016.json
+++ b/test/fixtures/AU-QLD-2016.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T14:00:00.000Z",
+    "end": "2016-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-10-03 00:00:00",
     "start": "2016-10-02T14:00:00.000Z",
     "end": "2016-10-03T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2017.json
+++ b/test/fixtures/AU-QLD-2017.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T14:00:00.000Z",
+    "end": "2017-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-10-02 00:00:00",
     "start": "2017-10-01T14:00:00.000Z",
     "end": "2017-10-02T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2018.json
+++ b/test/fixtures/AU-QLD-2018.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T14:00:00.000Z",
+    "end": "2018-05-13T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-10-01 00:00:00",
     "start": "2018-09-30T14:00:00.000Z",
     "end": "2018-10-01T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2019.json
+++ b/test/fixtures/AU-QLD-2019.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T14:00:00.000Z",
+    "end": "2019-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-10-07 00:00:00",
     "start": "2019-10-06T14:00:00.000Z",
     "end": "2019-10-07T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2020.json
+++ b/test/fixtures/AU-QLD-2020.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T14:00:00.000Z",
+    "end": "2020-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-10-05 00:00:00",
     "start": "2020-10-04T14:00:00.000Z",
     "end": "2020-10-05T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2021.json
+++ b/test/fixtures/AU-QLD-2021.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T14:00:00.000Z",
+    "end": "2021-05-09T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-10-04 00:00:00",
     "start": "2021-10-03T14:00:00.000Z",
     "end": "2021-10-04T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2022.json
+++ b/test/fixtures/AU-QLD-2022.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T14:00:00.000Z",
+    "end": "2022-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-10-03 00:00:00",
     "start": "2022-10-02T14:00:00.000Z",
     "end": "2022-10-03T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2023.json
+++ b/test/fixtures/AU-QLD-2023.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T14:00:00.000Z",
+    "end": "2023-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-10-02 00:00:00",
     "start": "2023-10-01T14:00:00.000Z",
     "end": "2023-10-02T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2024.json
+++ b/test/fixtures/AU-QLD-2024.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T14:00:00.000Z",
+    "end": "2024-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-10-07 00:00:00",
     "start": "2024-10-06T14:00:00.000Z",
     "end": "2024-10-07T14:00:00.000Z",

--- a/test/fixtures/AU-QLD-2025.json
+++ b/test/fixtures/AU-QLD-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T14:00:00.000Z",
+    "end": "2025-05-11T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-10-06 00:00:00",
     "start": "2025-10-05T14:00:00.000Z",
     "end": "2025-10-06T14:00:00.000Z",

--- a/test/fixtures/AU-SA-2015.json
+++ b/test/fixtures/AU-SA-2015.json
@@ -63,6 +63,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T14:30:00.000Z",
+    "end": "2015-05-10T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-06-08 00:00:00",
     "start": "2015-06-07T14:30:00.000Z",
     "end": "2015-06-08T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2016.json
+++ b/test/fixtures/AU-SA-2016.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T14:30:00.000Z",
+    "end": "2016-05-08T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-06-13 00:00:00",
     "start": "2016-06-12T14:30:00.000Z",
     "end": "2016-06-13T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2017.json
+++ b/test/fixtures/AU-SA-2017.json
@@ -72,6 +72,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T14:30:00.000Z",
+    "end": "2017-05-14T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-06-12 00:00:00",
     "start": "2017-06-11T14:30:00.000Z",
     "end": "2017-06-12T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2018.json
+++ b/test/fixtures/AU-SA-2018.json
@@ -63,6 +63,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T14:30:00.000Z",
+    "end": "2018-05-13T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-06-11 00:00:00",
     "start": "2018-06-10T14:30:00.000Z",
     "end": "2018-06-11T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2019.json
+++ b/test/fixtures/AU-SA-2019.json
@@ -63,6 +63,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T14:30:00.000Z",
+    "end": "2019-05-12T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-06-10 00:00:00",
     "start": "2019-06-09T14:30:00.000Z",
     "end": "2019-06-10T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2020.json
+++ b/test/fixtures/AU-SA-2020.json
@@ -63,6 +63,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T14:30:00.000Z",
+    "end": "2020-05-10T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-06-08 00:00:00",
     "start": "2020-06-07T14:30:00.000Z",
     "end": "2020-06-08T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2021.json
+++ b/test/fixtures/AU-SA-2021.json
@@ -63,6 +63,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T14:30:00.000Z",
+    "end": "2021-05-09T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-06-14 00:00:00",
     "start": "2021-06-13T14:30:00.000Z",
     "end": "2021-06-14T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2022.json
+++ b/test/fixtures/AU-SA-2022.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T14:30:00.000Z",
+    "end": "2022-05-08T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-06-13 00:00:00",
     "start": "2022-06-12T14:30:00.000Z",
     "end": "2022-06-13T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2023.json
+++ b/test/fixtures/AU-SA-2023.json
@@ -72,6 +72,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T14:30:00.000Z",
+    "end": "2023-05-14T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:30:00.000Z",
     "end": "2023-06-12T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2024.json
+++ b/test/fixtures/AU-SA-2024.json
@@ -63,6 +63,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T14:30:00.000Z",
+    "end": "2024-05-12T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:30:00.000Z",
     "end": "2024-06-10T14:30:00.000Z",

--- a/test/fixtures/AU-SA-2025.json
+++ b/test/fixtures/AU-SA-2025.json
@@ -63,6 +63,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T14:30:00.000Z",
+    "end": "2025-05-11T14:30:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:30:00.000Z",
     "end": "2025-06-09T14:30:00.000Z",

--- a/test/fixtures/AU-TAS-2015.json
+++ b/test/fixtures/AU-TAS-2015.json
@@ -64,6 +64,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T14:00:00.000Z",
+    "end": "2015-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-06-08 00:00:00",
     "start": "2015-06-07T14:00:00.000Z",
     "end": "2015-06-08T14:00:00.000Z",

--- a/test/fixtures/AU-TAS-2016.json
+++ b/test/fixtures/AU-TAS-2016.json
@@ -64,6 +64,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T14:00:00.000Z",
+    "end": "2016-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-06-13 00:00:00",
     "start": "2016-06-12T14:00:00.000Z",
     "end": "2016-06-13T14:00:00.000Z",

--- a/test/fixtures/AU-TAS-2017.json
+++ b/test/fixtures/AU-TAS-2017.json
@@ -64,6 +64,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T14:00:00.000Z",
+    "end": "2017-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-06-12 00:00:00",
     "start": "2017-06-11T14:00:00.000Z",
     "end": "2017-06-12T14:00:00.000Z",

--- a/test/fixtures/AU-TAS-2018.json
+++ b/test/fixtures/AU-TAS-2018.json
@@ -64,6 +64,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T14:00:00.000Z",
+    "end": "2018-05-13T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-06-11 00:00:00",
     "start": "2018-06-10T14:00:00.000Z",
     "end": "2018-06-11T14:00:00.000Z",

--- a/test/fixtures/AU-TAS-2019.json
+++ b/test/fixtures/AU-TAS-2019.json
@@ -64,6 +64,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T14:00:00.000Z",
+    "end": "2019-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-06-10 00:00:00",
     "start": "2019-06-09T14:00:00.000Z",
     "end": "2019-06-10T14:00:00.000Z",

--- a/test/fixtures/AU-TAS-2020.json
+++ b/test/fixtures/AU-TAS-2020.json
@@ -64,6 +64,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T14:00:00.000Z",
+    "end": "2020-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-06-08 00:00:00",
     "start": "2020-06-07T14:00:00.000Z",
     "end": "2020-06-08T14:00:00.000Z",

--- a/test/fixtures/AU-TAS-2021.json
+++ b/test/fixtures/AU-TAS-2021.json
@@ -64,6 +64,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T14:00:00.000Z",
+    "end": "2021-05-09T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-06-14 00:00:00",
     "start": "2021-06-13T14:00:00.000Z",
     "end": "2021-06-14T14:00:00.000Z",

--- a/test/fixtures/AU-TAS-2022.json
+++ b/test/fixtures/AU-TAS-2022.json
@@ -64,6 +64,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T14:00:00.000Z",
+    "end": "2022-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-06-13 00:00:00",
     "start": "2022-06-12T14:00:00.000Z",
     "end": "2022-06-13T14:00:00.000Z",

--- a/test/fixtures/AU-TAS-2023.json
+++ b/test/fixtures/AU-TAS-2023.json
@@ -64,6 +64,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T14:00:00.000Z",
+    "end": "2023-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:00:00.000Z",
     "end": "2023-06-12T14:00:00.000Z",

--- a/test/fixtures/AU-TAS-2024.json
+++ b/test/fixtures/AU-TAS-2024.json
@@ -64,6 +64,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T14:00:00.000Z",
+    "end": "2024-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:00:00.000Z",
     "end": "2024-06-10T14:00:00.000Z",

--- a/test/fixtures/AU-TAS-2025.json
+++ b/test/fixtures/AU-TAS-2025.json
@@ -64,6 +64,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T14:00:00.000Z",
+    "end": "2025-05-11T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:00:00.000Z",
     "end": "2025-06-09T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2015.json
+++ b/test/fixtures/AU-VIC-2015.json
@@ -72,6 +72,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T14:00:00.000Z",
+    "end": "2015-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-06-08 00:00:00",
     "start": "2015-06-07T14:00:00.000Z",
     "end": "2015-06-08T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2016.json
+++ b/test/fixtures/AU-VIC-2016.json
@@ -72,6 +72,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T14:00:00.000Z",
+    "end": "2016-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-06-13 00:00:00",
     "start": "2016-06-12T14:00:00.000Z",
     "end": "2016-06-13T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2017.json
+++ b/test/fixtures/AU-VIC-2017.json
@@ -81,6 +81,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T14:00:00.000Z",
+    "end": "2017-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-06-12 00:00:00",
     "start": "2017-06-11T14:00:00.000Z",
     "end": "2017-06-12T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2018.json
+++ b/test/fixtures/AU-VIC-2018.json
@@ -72,6 +72,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T14:00:00.000Z",
+    "end": "2018-05-13T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-06-11 00:00:00",
     "start": "2018-06-10T14:00:00.000Z",
     "end": "2018-06-11T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2019.json
+++ b/test/fixtures/AU-VIC-2019.json
@@ -72,6 +72,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T14:00:00.000Z",
+    "end": "2019-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-06-10 00:00:00",
     "start": "2019-06-09T14:00:00.000Z",
     "end": "2019-06-10T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2020.json
+++ b/test/fixtures/AU-VIC-2020.json
@@ -72,6 +72,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T14:00:00.000Z",
+    "end": "2020-05-10T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-06-08 00:00:00",
     "start": "2020-06-07T14:00:00.000Z",
     "end": "2020-06-08T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2021.json
+++ b/test/fixtures/AU-VIC-2021.json
@@ -72,6 +72,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T14:00:00.000Z",
+    "end": "2021-05-09T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-06-14 00:00:00",
     "start": "2021-06-13T14:00:00.000Z",
     "end": "2021-06-14T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2022.json
+++ b/test/fixtures/AU-VIC-2022.json
@@ -81,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T14:00:00.000Z",
+    "end": "2022-05-08T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-06-13 00:00:00",
     "start": "2022-06-12T14:00:00.000Z",
     "end": "2022-06-13T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2023.json
+++ b/test/fixtures/AU-VIC-2023.json
@@ -81,6 +81,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T14:00:00.000Z",
+    "end": "2023-05-14T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:00:00.000Z",
     "end": "2023-06-12T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2024.json
+++ b/test/fixtures/AU-VIC-2024.json
@@ -72,6 +72,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T14:00:00.000Z",
+    "end": "2024-05-12T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:00:00.000Z",
     "end": "2024-06-10T14:00:00.000Z",

--- a/test/fixtures/AU-VIC-2025.json
+++ b/test/fixtures/AU-VIC-2025.json
@@ -72,6 +72,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T14:00:00.000Z",
+    "end": "2025-05-11T14:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:00:00.000Z",
     "end": "2025-06-09T14:00:00.000Z",

--- a/test/fixtures/AU-WA-2015.json
+++ b/test/fixtures/AU-WA-2015.json
@@ -64,6 +64,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T16:00:00.000Z",
+    "end": "2015-05-10T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-06-01 00:00:00",
     "start": "2015-05-31T16:00:00.000Z",
     "end": "2015-06-01T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2016.json
+++ b/test/fixtures/AU-WA-2016.json
@@ -54,6 +54,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T16:00:00.000Z",
+    "end": "2016-05-08T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2016-06-06 00:00:00",
     "start": "2016-06-05T16:00:00.000Z",
     "end": "2016-06-06T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2017.json
+++ b/test/fixtures/AU-WA-2017.json
@@ -63,6 +63,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T16:00:00.000Z",
+    "end": "2017-05-14T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2017-06-05 00:00:00",
     "start": "2017-06-04T16:00:00.000Z",
     "end": "2017-06-05T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2018.json
+++ b/test/fixtures/AU-WA-2018.json
@@ -54,6 +54,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T16:00:00.000Z",
+    "end": "2018-05-13T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2018-06-04 00:00:00",
     "start": "2018-06-03T16:00:00.000Z",
     "end": "2018-06-04T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2019.json
+++ b/test/fixtures/AU-WA-2019.json
@@ -54,6 +54,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T16:00:00.000Z",
+    "end": "2019-05-12T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-06-03 00:00:00",
     "start": "2019-06-02T16:00:00.000Z",
     "end": "2019-06-03T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2020.json
+++ b/test/fixtures/AU-WA-2020.json
@@ -64,6 +64,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T16:00:00.000Z",
+    "end": "2020-05-10T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-06-01 00:00:00",
     "start": "2020-05-31T16:00:00.000Z",
     "end": "2020-06-01T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2021.json
+++ b/test/fixtures/AU-WA-2021.json
@@ -64,6 +64,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T16:00:00.000Z",
+    "end": "2021-05-09T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2021-06-07 00:00:00",
     "start": "2021-06-06T16:00:00.000Z",
     "end": "2021-06-07T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2022.json
+++ b/test/fixtures/AU-WA-2022.json
@@ -63,6 +63,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T16:00:00.000Z",
+    "end": "2022-05-08T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-06-06 00:00:00",
     "start": "2022-06-05T16:00:00.000Z",
     "end": "2022-06-06T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2023.json
+++ b/test/fixtures/AU-WA-2023.json
@@ -63,6 +63,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T16:00:00.000Z",
+    "end": "2023-05-14T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-06-05 00:00:00",
     "start": "2023-06-04T16:00:00.000Z",
     "end": "2023-06-05T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2024.json
+++ b/test/fixtures/AU-WA-2024.json
@@ -54,6 +54,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T16:00:00.000Z",
+    "end": "2024-05-12T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2024-06-03 00:00:00",
     "start": "2024-06-02T16:00:00.000Z",
     "end": "2024-06-03T16:00:00.000Z",

--- a/test/fixtures/AU-WA-2025.json
+++ b/test/fixtures/AU-WA-2025.json
@@ -54,6 +54,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T16:00:00.000Z",
+    "end": "2025-05-11T16:00:00.000Z",
+    "name": "Mother's Day",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2025-06-02 00:00:00",
     "start": "2025-06-01T16:00:00.000Z",
     "end": "2025-06-02T16:00:00.000Z",


### PR DESCRIPTION
Added Mothers day to Au: Second Sunday in May: https://www.timeanddate.com/holidays/australia/mother-day