### PR TITLE
fix(GB,#303): Spring bank holiday

### DIFF
--- a/data/countries/GB.yaml
+++ b/data/countries/GB.yaml
@@ -24,6 +24,7 @@ holidays:
         _name: easter -2
       easter:
         _name: easter
+        type: observance
       easter 1:
         _name: easter 1
       1st monday in May:
@@ -39,6 +40,8 @@ holidays:
           en: Spring bank holiday
         disable:
           - "2022-05-30" # was moved to 2022-06-02
+        enable:
+          - "2022-06-02"
       12-25:
         _name: 12-25
       substitutes 12-25 if saturday then next monday if sunday then next tuesday:
@@ -56,9 +59,6 @@ holidays:
         name:
           en: Early May bank holiday (VE day)
       # @source https://www.gov.uk/government/news/extra-bank-holiday-to-mark-the-queens-platinum-jubilee-in-2022
-      "2022-06-02":
-        name:
-          en: Queen’s Platinum Jubilee
       "2022-06-03":
         name:
           en: Queen’s Platinum Jubilee

--- a/test/fixtures/GB-2015.json
+++ b/test/fixtures/GB-2015.json
@@ -31,7 +31,7 @@
     "start": "2015-04-04T23:00:00.000Z",
     "end": "2015-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-2016.json
+++ b/test/fixtures/GB-2016.json
@@ -31,7 +31,7 @@
     "start": "2016-03-27T00:00:00.000Z",
     "end": "2016-03-27T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-2017.json
+++ b/test/fixtures/GB-2017.json
@@ -41,7 +41,7 @@
     "start": "2017-04-15T23:00:00.000Z",
     "end": "2017-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-2018.json
+++ b/test/fixtures/GB-2018.json
@@ -31,7 +31,7 @@
     "start": "2018-03-31T23:00:00.000Z",
     "end": "2018-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-2019.json
+++ b/test/fixtures/GB-2019.json
@@ -31,7 +31,7 @@
     "start": "2019-04-20T23:00:00.000Z",
     "end": "2019-04-21T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-2020.json
+++ b/test/fixtures/GB-2020.json
@@ -31,7 +31,7 @@
     "start": "2020-04-11T23:00:00.000Z",
     "end": "2020-04-12T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-2021.json
+++ b/test/fixtures/GB-2021.json
@@ -31,7 +31,7 @@
     "start": "2021-04-03T23:00:00.000Z",
     "end": "2021-04-04T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-2022.json
+++ b/test/fixtures/GB-2022.json
@@ -41,7 +41,7 @@
     "start": "2022-04-16T23:00:00.000Z",
     "end": "2022-04-17T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -67,9 +67,9 @@
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T23:00:00.000Z",
     "end": "2022-06-02T23:00:00.000Z",
-    "name": "Queen’s Platinum Jubilee",
+    "name": "Spring bank holiday",
     "type": "public",
-    "rule": "2022-06-02",
+    "rule": "1st monday before 06-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/GB-2023.json
+++ b/test/fixtures/GB-2023.json
@@ -41,7 +41,7 @@
     "start": "2023-04-08T23:00:00.000Z",
     "end": "2023-04-09T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-2024.json
+++ b/test/fixtures/GB-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-03-31T00:00:00.000Z",
     "end": "2024-03-31T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-2025.json
+++ b/test/fixtures/GB-2025.json
@@ -31,7 +31,7 @@
     "start": "2025-04-19T23:00:00.000Z",
     "end": "2025-04-20T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ALD-2015.json
+++ b/test/fixtures/GB-ALD-2015.json
@@ -31,7 +31,7 @@
     "start": "2015-04-04T23:00:00.000Z",
     "end": "2015-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ALD-2016.json
+++ b/test/fixtures/GB-ALD-2016.json
@@ -31,7 +31,7 @@
     "start": "2016-03-27T00:00:00.000Z",
     "end": "2016-03-27T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ALD-2017.json
+++ b/test/fixtures/GB-ALD-2017.json
@@ -41,7 +41,7 @@
     "start": "2017-04-15T23:00:00.000Z",
     "end": "2017-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ALD-2018.json
+++ b/test/fixtures/GB-ALD-2018.json
@@ -31,7 +31,7 @@
     "start": "2018-03-31T23:00:00.000Z",
     "end": "2018-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ALD-2019.json
+++ b/test/fixtures/GB-ALD-2019.json
@@ -31,7 +31,7 @@
     "start": "2019-04-20T23:00:00.000Z",
     "end": "2019-04-21T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ALD-2020.json
+++ b/test/fixtures/GB-ALD-2020.json
@@ -31,7 +31,7 @@
     "start": "2020-04-11T23:00:00.000Z",
     "end": "2020-04-12T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ALD-2021.json
+++ b/test/fixtures/GB-ALD-2021.json
@@ -31,7 +31,7 @@
     "start": "2021-04-03T23:00:00.000Z",
     "end": "2021-04-04T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ALD-2022.json
+++ b/test/fixtures/GB-ALD-2022.json
@@ -41,7 +41,7 @@
     "start": "2022-04-16T23:00:00.000Z",
     "end": "2022-04-17T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -67,9 +67,9 @@
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T23:00:00.000Z",
     "end": "2022-06-02T23:00:00.000Z",
-    "name": "Queen’s Platinum Jubilee",
+    "name": "Spring bank holiday",
     "type": "public",
-    "rule": "2022-06-02",
+    "rule": "1st monday before 06-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/GB-ALD-2023.json
+++ b/test/fixtures/GB-ALD-2023.json
@@ -41,7 +41,7 @@
     "start": "2023-04-08T23:00:00.000Z",
     "end": "2023-04-09T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ALD-2024.json
+++ b/test/fixtures/GB-ALD-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-03-31T00:00:00.000Z",
     "end": "2024-03-31T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ALD-2025.json
+++ b/test/fixtures/GB-ALD-2025.json
@@ -31,7 +31,7 @@
     "start": "2025-04-19T23:00:00.000Z",
     "end": "2025-04-20T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ENG-2015.json
+++ b/test/fixtures/GB-ENG-2015.json
@@ -31,7 +31,7 @@
     "start": "2015-04-04T23:00:00.000Z",
     "end": "2015-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ENG-2016.json
+++ b/test/fixtures/GB-ENG-2016.json
@@ -31,7 +31,7 @@
     "start": "2016-03-27T00:00:00.000Z",
     "end": "2016-03-27T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ENG-2017.json
+++ b/test/fixtures/GB-ENG-2017.json
@@ -41,7 +41,7 @@
     "start": "2017-04-15T23:00:00.000Z",
     "end": "2017-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ENG-2018.json
+++ b/test/fixtures/GB-ENG-2018.json
@@ -31,7 +31,7 @@
     "start": "2018-03-31T23:00:00.000Z",
     "end": "2018-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ENG-2019.json
+++ b/test/fixtures/GB-ENG-2019.json
@@ -31,7 +31,7 @@
     "start": "2019-04-20T23:00:00.000Z",
     "end": "2019-04-21T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ENG-2020.json
+++ b/test/fixtures/GB-ENG-2020.json
@@ -31,7 +31,7 @@
     "start": "2020-04-11T23:00:00.000Z",
     "end": "2020-04-12T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ENG-2021.json
+++ b/test/fixtures/GB-ENG-2021.json
@@ -31,7 +31,7 @@
     "start": "2021-04-03T23:00:00.000Z",
     "end": "2021-04-04T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ENG-2022.json
+++ b/test/fixtures/GB-ENG-2022.json
@@ -41,7 +41,7 @@
     "start": "2022-04-16T23:00:00.000Z",
     "end": "2022-04-17T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -67,9 +67,9 @@
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T23:00:00.000Z",
     "end": "2022-06-02T23:00:00.000Z",
-    "name": "Queen’s Platinum Jubilee",
+    "name": "Spring bank holiday",
     "type": "public",
-    "rule": "2022-06-02",
+    "rule": "1st monday before 06-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/GB-ENG-2023.json
+++ b/test/fixtures/GB-ENG-2023.json
@@ -41,7 +41,7 @@
     "start": "2023-04-08T23:00:00.000Z",
     "end": "2023-04-09T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ENG-2024.json
+++ b/test/fixtures/GB-ENG-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-03-31T00:00:00.000Z",
     "end": "2024-03-31T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-ENG-2025.json
+++ b/test/fixtures/GB-ENG-2025.json
@@ -31,7 +31,7 @@
     "start": "2025-04-19T23:00:00.000Z",
     "end": "2025-04-20T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-NIR-2015.json
+++ b/test/fixtures/GB-NIR-2015.json
@@ -40,7 +40,7 @@
     "start": "2015-04-04T23:00:00.000Z",
     "end": "2015-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-NIR-2016.json
+++ b/test/fixtures/GB-NIR-2016.json
@@ -40,7 +40,7 @@
     "start": "2016-03-27T00:00:00.000Z",
     "end": "2016-03-27T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-NIR-2017.json
+++ b/test/fixtures/GB-NIR-2017.json
@@ -50,7 +50,7 @@
     "start": "2017-04-15T23:00:00.000Z",
     "end": "2017-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-NIR-2018.json
+++ b/test/fixtures/GB-NIR-2018.json
@@ -50,7 +50,7 @@
     "start": "2018-03-31T23:00:00.000Z",
     "end": "2018-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-NIR-2019.json
+++ b/test/fixtures/GB-NIR-2019.json
@@ -50,7 +50,7 @@
     "start": "2019-04-20T23:00:00.000Z",
     "end": "2019-04-21T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-NIR-2020.json
+++ b/test/fixtures/GB-NIR-2020.json
@@ -40,7 +40,7 @@
     "start": "2020-04-11T23:00:00.000Z",
     "end": "2020-04-12T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-NIR-2021.json
+++ b/test/fixtures/GB-NIR-2021.json
@@ -40,7 +40,7 @@
     "start": "2021-04-03T23:00:00.000Z",
     "end": "2021-04-04T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-NIR-2022.json
+++ b/test/fixtures/GB-NIR-2022.json
@@ -50,7 +50,7 @@
     "start": "2022-04-16T23:00:00.000Z",
     "end": "2022-04-17T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -76,9 +76,9 @@
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T23:00:00.000Z",
     "end": "2022-06-02T23:00:00.000Z",
-    "name": "Queen’s Platinum Jubilee",
+    "name": "Spring bank holiday",
     "type": "public",
-    "rule": "2022-06-02",
+    "rule": "1st monday before 06-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/GB-NIR-2023.json
+++ b/test/fixtures/GB-NIR-2023.json
@@ -50,7 +50,7 @@
     "start": "2023-04-08T23:00:00.000Z",
     "end": "2023-04-09T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-NIR-2024.json
+++ b/test/fixtures/GB-NIR-2024.json
@@ -50,7 +50,7 @@
     "start": "2024-03-31T00:00:00.000Z",
     "end": "2024-03-31T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-NIR-2025.json
+++ b/test/fixtures/GB-NIR-2025.json
@@ -40,7 +40,7 @@
     "start": "2025-04-19T23:00:00.000Z",
     "end": "2025-04-20T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-SCT-2015.json
+++ b/test/fixtures/GB-SCT-2015.json
@@ -40,7 +40,7 @@
     "start": "2015-04-04T23:00:00.000Z",
     "end": "2015-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-SCT-2016.json
+++ b/test/fixtures/GB-SCT-2016.json
@@ -50,7 +50,7 @@
     "start": "2016-03-27T00:00:00.000Z",
     "end": "2016-03-27T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-SCT-2017.json
+++ b/test/fixtures/GB-SCT-2017.json
@@ -50,7 +50,7 @@
     "start": "2017-04-15T23:00:00.000Z",
     "end": "2017-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-SCT-2018.json
+++ b/test/fixtures/GB-SCT-2018.json
@@ -40,7 +40,7 @@
     "start": "2018-03-31T23:00:00.000Z",
     "end": "2018-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-SCT-2019.json
+++ b/test/fixtures/GB-SCT-2019.json
@@ -40,7 +40,7 @@
     "start": "2019-04-20T23:00:00.000Z",
     "end": "2019-04-21T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-SCT-2020.json
+++ b/test/fixtures/GB-SCT-2020.json
@@ -40,7 +40,7 @@
     "start": "2020-04-11T23:00:00.000Z",
     "end": "2020-04-12T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-SCT-2021.json
+++ b/test/fixtures/GB-SCT-2021.json
@@ -50,7 +50,7 @@
     "start": "2021-04-03T23:00:00.000Z",
     "end": "2021-04-04T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-SCT-2022.json
+++ b/test/fixtures/GB-SCT-2022.json
@@ -60,7 +60,7 @@
     "start": "2022-04-16T23:00:00.000Z",
     "end": "2022-04-17T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -86,9 +86,9 @@
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T23:00:00.000Z",
     "end": "2022-06-02T23:00:00.000Z",
-    "name": "Queen’s Platinum Jubilee",
+    "name": "Spring bank holiday",
     "type": "public",
-    "rule": "2022-06-02",
+    "rule": "1st monday before 06-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/GB-SCT-2023.json
+++ b/test/fixtures/GB-SCT-2023.json
@@ -50,7 +50,7 @@
     "start": "2023-04-08T23:00:00.000Z",
     "end": "2023-04-09T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-SCT-2024.json
+++ b/test/fixtures/GB-SCT-2024.json
@@ -40,7 +40,7 @@
     "start": "2024-03-31T00:00:00.000Z",
     "end": "2024-03-31T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-SCT-2025.json
+++ b/test/fixtures/GB-SCT-2025.json
@@ -40,7 +40,7 @@
     "start": "2025-04-19T23:00:00.000Z",
     "end": "2025-04-20T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-WLS-2015.json
+++ b/test/fixtures/GB-WLS-2015.json
@@ -31,7 +31,7 @@
     "start": "2015-04-04T23:00:00.000Z",
     "end": "2015-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-WLS-2016.json
+++ b/test/fixtures/GB-WLS-2016.json
@@ -31,7 +31,7 @@
     "start": "2016-03-27T00:00:00.000Z",
     "end": "2016-03-27T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-WLS-2017.json
+++ b/test/fixtures/GB-WLS-2017.json
@@ -41,7 +41,7 @@
     "start": "2017-04-15T23:00:00.000Z",
     "end": "2017-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-WLS-2018.json
+++ b/test/fixtures/GB-WLS-2018.json
@@ -31,7 +31,7 @@
     "start": "2018-03-31T23:00:00.000Z",
     "end": "2018-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-WLS-2019.json
+++ b/test/fixtures/GB-WLS-2019.json
@@ -31,7 +31,7 @@
     "start": "2019-04-20T23:00:00.000Z",
     "end": "2019-04-21T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-WLS-2020.json
+++ b/test/fixtures/GB-WLS-2020.json
@@ -31,7 +31,7 @@
     "start": "2020-04-11T23:00:00.000Z",
     "end": "2020-04-12T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-WLS-2021.json
+++ b/test/fixtures/GB-WLS-2021.json
@@ -31,7 +31,7 @@
     "start": "2021-04-03T23:00:00.000Z",
     "end": "2021-04-04T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-WLS-2022.json
+++ b/test/fixtures/GB-WLS-2022.json
@@ -41,7 +41,7 @@
     "start": "2022-04-16T23:00:00.000Z",
     "end": "2022-04-17T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -67,9 +67,9 @@
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T23:00:00.000Z",
     "end": "2022-06-02T23:00:00.000Z",
-    "name": "Queen’s Platinum Jubilee",
+    "name": "Spring bank holiday",
     "type": "public",
-    "rule": "2022-06-02",
+    "rule": "1st monday before 06-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/GB-WLS-2023.json
+++ b/test/fixtures/GB-WLS-2023.json
@@ -41,7 +41,7 @@
     "start": "2023-04-08T23:00:00.000Z",
     "end": "2023-04-09T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-WLS-2024.json
+++ b/test/fixtures/GB-WLS-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-03-31T00:00:00.000Z",
     "end": "2024-03-31T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GB-WLS-2025.json
+++ b/test/fixtures/GB-WLS-2025.json
@@ -31,7 +31,7 @@
     "start": "2025-04-19T23:00:00.000Z",
     "end": "2025-04-20T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GG-2015.json
+++ b/test/fixtures/GG-2015.json
@@ -31,7 +31,7 @@
     "start": "2015-04-04T23:00:00.000Z",
     "end": "2015-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GG-2016.json
+++ b/test/fixtures/GG-2016.json
@@ -31,7 +31,7 @@
     "start": "2016-03-27T00:00:00.000Z",
     "end": "2016-03-27T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GG-2017.json
+++ b/test/fixtures/GG-2017.json
@@ -41,7 +41,7 @@
     "start": "2017-04-15T23:00:00.000Z",
     "end": "2017-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GG-2018.json
+++ b/test/fixtures/GG-2018.json
@@ -31,7 +31,7 @@
     "start": "2018-03-31T23:00:00.000Z",
     "end": "2018-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GG-2019.json
+++ b/test/fixtures/GG-2019.json
@@ -31,7 +31,7 @@
     "start": "2019-04-20T23:00:00.000Z",
     "end": "2019-04-21T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GG-2020.json
+++ b/test/fixtures/GG-2020.json
@@ -31,7 +31,7 @@
     "start": "2020-04-11T23:00:00.000Z",
     "end": "2020-04-12T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GG-2021.json
+++ b/test/fixtures/GG-2021.json
@@ -31,7 +31,7 @@
     "start": "2021-04-03T23:00:00.000Z",
     "end": "2021-04-04T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GG-2022.json
+++ b/test/fixtures/GG-2022.json
@@ -41,7 +41,7 @@
     "start": "2022-04-16T23:00:00.000Z",
     "end": "2022-04-17T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -76,9 +76,9 @@
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T23:00:00.000Z",
     "end": "2022-06-02T23:00:00.000Z",
-    "name": "Queen’s Platinum Jubilee",
+    "name": "Spring bank holiday",
     "type": "public",
-    "rule": "2022-06-02",
+    "rule": "1st monday before 06-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/GG-2023.json
+++ b/test/fixtures/GG-2023.json
@@ -41,7 +41,7 @@
     "start": "2023-04-08T23:00:00.000Z",
     "end": "2023-04-09T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GG-2024.json
+++ b/test/fixtures/GG-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-03-31T00:00:00.000Z",
     "end": "2024-03-31T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GG-2025.json
+++ b/test/fixtures/GG-2025.json
@@ -31,7 +31,7 @@
     "start": "2025-04-19T23:00:00.000Z",
     "end": "2025-04-20T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GI-2022.json
+++ b/test/fixtures/GI-2022.json
@@ -85,9 +85,9 @@
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T22:00:00.000Z",
     "end": "2022-06-02T22:00:00.000Z",
-    "name": "Queen’s Platinum Jubilee",
+    "name": "Spring bank holiday",
     "type": "public",
-    "rule": "2022-06-02",
+    "rule": "1st monday before 06-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/IM-2015.json
+++ b/test/fixtures/IM-2015.json
@@ -31,7 +31,7 @@
     "start": "2015-04-04T23:00:00.000Z",
     "end": "2015-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/IM-2016.json
+++ b/test/fixtures/IM-2016.json
@@ -31,7 +31,7 @@
     "start": "2016-03-27T00:00:00.000Z",
     "end": "2016-03-27T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/IM-2017.json
+++ b/test/fixtures/IM-2017.json
@@ -41,7 +41,7 @@
     "start": "2017-04-15T23:00:00.000Z",
     "end": "2017-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/IM-2018.json
+++ b/test/fixtures/IM-2018.json
@@ -31,7 +31,7 @@
     "start": "2018-03-31T23:00:00.000Z",
     "end": "2018-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/IM-2019.json
+++ b/test/fixtures/IM-2019.json
@@ -31,7 +31,7 @@
     "start": "2019-04-20T23:00:00.000Z",
     "end": "2019-04-21T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/IM-2020.json
+++ b/test/fixtures/IM-2020.json
@@ -31,7 +31,7 @@
     "start": "2020-04-11T23:00:00.000Z",
     "end": "2020-04-12T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/IM-2021.json
+++ b/test/fixtures/IM-2021.json
@@ -31,7 +31,7 @@
     "start": "2021-04-03T23:00:00.000Z",
     "end": "2021-04-04T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/IM-2022.json
+++ b/test/fixtures/IM-2022.json
@@ -41,7 +41,7 @@
     "start": "2022-04-16T23:00:00.000Z",
     "end": "2022-04-17T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -67,9 +67,9 @@
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T23:00:00.000Z",
     "end": "2022-06-02T23:00:00.000Z",
-    "name": "Queen’s Platinum Jubilee",
+    "name": "Spring bank holiday",
     "type": "public",
-    "rule": "2022-06-02",
+    "rule": "1st monday before 06-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/IM-2023.json
+++ b/test/fixtures/IM-2023.json
@@ -41,7 +41,7 @@
     "start": "2023-04-08T23:00:00.000Z",
     "end": "2023-04-09T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/IM-2024.json
+++ b/test/fixtures/IM-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-03-31T00:00:00.000Z",
     "end": "2024-03-31T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/IM-2025.json
+++ b/test/fixtures/IM-2025.json
@@ -31,7 +31,7 @@
     "start": "2025-04-19T23:00:00.000Z",
     "end": "2025-04-20T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/JE-2015.json
+++ b/test/fixtures/JE-2015.json
@@ -31,7 +31,7 @@
     "start": "2015-04-04T23:00:00.000Z",
     "end": "2015-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/JE-2016.json
+++ b/test/fixtures/JE-2016.json
@@ -31,7 +31,7 @@
     "start": "2016-03-27T00:00:00.000Z",
     "end": "2016-03-27T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/JE-2017.json
+++ b/test/fixtures/JE-2017.json
@@ -41,7 +41,7 @@
     "start": "2017-04-15T23:00:00.000Z",
     "end": "2017-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/JE-2018.json
+++ b/test/fixtures/JE-2018.json
@@ -31,7 +31,7 @@
     "start": "2018-03-31T23:00:00.000Z",
     "end": "2018-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/JE-2019.json
+++ b/test/fixtures/JE-2019.json
@@ -31,7 +31,7 @@
     "start": "2019-04-20T23:00:00.000Z",
     "end": "2019-04-21T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/JE-2020.json
+++ b/test/fixtures/JE-2020.json
@@ -31,7 +31,7 @@
     "start": "2020-04-11T23:00:00.000Z",
     "end": "2020-04-12T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/JE-2021.json
+++ b/test/fixtures/JE-2021.json
@@ -31,7 +31,7 @@
     "start": "2021-04-03T23:00:00.000Z",
     "end": "2021-04-04T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/JE-2022.json
+++ b/test/fixtures/JE-2022.json
@@ -41,7 +41,7 @@
     "start": "2022-04-16T23:00:00.000Z",
     "end": "2022-04-17T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -76,9 +76,9 @@
     "date": "2022-06-02 00:00:00",
     "start": "2022-06-01T23:00:00.000Z",
     "end": "2022-06-02T23:00:00.000Z",
-    "name": "Queen’s Platinum Jubilee",
+    "name": "Spring bank holiday",
     "type": "public",
-    "rule": "2022-06-02",
+    "rule": "1st monday before 06-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/JE-2023.json
+++ b/test/fixtures/JE-2023.json
@@ -41,7 +41,7 @@
     "start": "2023-04-08T23:00:00.000Z",
     "end": "2023-04-09T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/JE-2024.json
+++ b/test/fixtures/JE-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-03-31T00:00:00.000Z",
     "end": "2024-03-31T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/JE-2025.json
+++ b/test/fixtures/JE-2025.json
@@ -31,7 +31,7 @@
     "start": "2025-04-19T23:00:00.000Z",
     "end": "2025-04-20T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },


### PR DESCRIPTION
- Rename 2022-06-02 to Spring bank holiday
- Easter Sunday type changed to observance

Fixes Issue #303