### PR TITLE
Update SE.yaml

### DIFF
--- a/data/countries/SE.yaml
+++ b/data/countries/SE.yaml
@@ -47,6 +47,7 @@ holidays:
         type: observance
       easter -1:
         _name: easter -1
+        type: observance
       easter 1:
         _name: easter 1
       05-01:
@@ -57,6 +58,7 @@ holidays:
         name:
           sv: Pingstafton
           en: Whitsun Eve
+        type: observance
       easter 49:
         _name: easter 49
         type: public

--- a/data/countries/SE.yaml
+++ b/data/countries/SE.yaml
@@ -16,6 +16,7 @@ holidays:
       01-05:
         name:
           sv: Trettondagsafton
+        type: observance
       01-06:
         _name: 01-06
       01-13:

--- a/data/countries/SE.yaml
+++ b/data/countries/SE.yaml
@@ -13,10 +13,10 @@ holidays:
     days:
       01-01:
         _name: 01-01
-      01-05:
+      01-05 12:00:
         name:
           sv: Trettondagsafton
-        type: observance
+        type: optional
       01-06:
         _name: 01-06
       01-13:
@@ -32,11 +32,11 @@ holidays:
           sv: Marie Bebådelsedag
           lat: Annuntiatio Mariæ
         type: observance
-      04-30:
+      04-30 12:00:
         name:
           sv: Valborgsmässoafton
           en: Walpurgis Night
-        type: observance
+        type: optional
       easter -3:
         _name: easter -3
         type: observance
@@ -83,11 +83,11 @@ holidays:
           sv: Midsommardagen
           en: Midsummer Day
           fi: Juhannuspäivä
-      friday after 10-30:
+      friday after 10-30 12:00:
         name:
           sv: Allhelgonaafton
           en: Halloween
-        type: observance
+        type: optional
       saturday after 10-31:
         _name: 11-01
       11-06:

--- a/test/fixtures/SE-2015.json
+++ b/test/fixtures/SE-2015.json
@@ -9,12 +9,12 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2015-01-05 00:00:00",
-    "start": "2015-01-04T23:00:00.000Z",
+    "date": "2015-01-05 12:00:00",
+    "start": "2015-01-05T11:00:00.000Z",
     "end": "2015-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Mon"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2015-04-30 00:00:00",
-    "start": "2015-04-29T22:00:00.000Z",
+    "date": "2015-04-30 12:00:00",
+    "start": "2015-04-30T10:00:00.000Z",
     "end": "2015-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Thu"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2015-10-30 00:00:00",
-    "start": "2015-10-29T23:00:00.000Z",
+    "date": "2015-10-30 12:00:00",
+    "start": "2015-10-30T11:00:00.000Z",
     "end": "2015-10-30T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2015.json
+++ b/test/fixtures/SE-2015.json
@@ -13,7 +13,7 @@
     "start": "2015-01-04T23:00:00.000Z",
     "end": "2015-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Mon"
   },
@@ -76,7 +76,7 @@
     "start": "2015-04-03T22:00:00.000Z",
     "end": "2015-04-04T22:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -130,7 +130,7 @@
     "start": "2015-05-22T22:00:00.000Z",
     "end": "2015-05-23T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },

--- a/test/fixtures/SE-2016.json
+++ b/test/fixtures/SE-2016.json
@@ -13,7 +13,7 @@
     "start": "2016-01-04T23:00:00.000Z",
     "end": "2016-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Tue"
   },
@@ -76,7 +76,7 @@
     "start": "2016-03-25T23:00:00.000Z",
     "end": "2016-03-26T23:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -130,7 +130,7 @@
     "start": "2016-05-13T22:00:00.000Z",
     "end": "2016-05-14T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },

--- a/test/fixtures/SE-2016.json
+++ b/test/fixtures/SE-2016.json
@@ -9,12 +9,12 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-01-05 00:00:00",
-    "start": "2016-01-04T23:00:00.000Z",
+    "date": "2016-01-05 12:00:00",
+    "start": "2016-01-05T11:00:00.000Z",
     "end": "2016-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Tue"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2016-04-30 00:00:00",
-    "start": "2016-04-29T22:00:00.000Z",
+    "date": "2016-04-30 12:00:00",
+    "start": "2016-04-30T10:00:00.000Z",
     "end": "2016-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Sat"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2016-11-04 00:00:00",
-    "start": "2016-11-03T23:00:00.000Z",
+    "date": "2016-11-04 12:00:00",
+    "start": "2016-11-04T11:00:00.000Z",
     "end": "2016-11-04T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2017.json
+++ b/test/fixtures/SE-2017.json
@@ -9,12 +9,12 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2017-01-05 00:00:00",
-    "start": "2017-01-04T23:00:00.000Z",
+    "date": "2017-01-05 12:00:00",
+    "start": "2017-01-05T11:00:00.000Z",
     "end": "2017-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Thu"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2017-04-30 00:00:00",
-    "start": "2017-04-29T22:00:00.000Z",
+    "date": "2017-04-30 12:00:00",
+    "start": "2017-04-30T10:00:00.000Z",
     "end": "2017-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Sun"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2017-11-03 00:00:00",
-    "start": "2017-11-02T23:00:00.000Z",
+    "date": "2017-11-03 12:00:00",
+    "start": "2017-11-03T11:00:00.000Z",
     "end": "2017-11-03T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2017.json
+++ b/test/fixtures/SE-2017.json
@@ -13,7 +13,7 @@
     "start": "2017-01-04T23:00:00.000Z",
     "end": "2017-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Thu"
   },
@@ -76,7 +76,7 @@
     "start": "2017-04-14T22:00:00.000Z",
     "end": "2017-04-15T22:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -139,7 +139,7 @@
     "start": "2017-06-02T22:00:00.000Z",
     "end": "2017-06-03T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },

--- a/test/fixtures/SE-2018.json
+++ b/test/fixtures/SE-2018.json
@@ -13,7 +13,7 @@
     "start": "2018-01-04T23:00:00.000Z",
     "end": "2018-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Fri"
   },
@@ -76,7 +76,7 @@
     "start": "2018-03-30T22:00:00.000Z",
     "end": "2018-03-31T22:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -130,7 +130,7 @@
     "start": "2018-05-18T22:00:00.000Z",
     "end": "2018-05-19T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },

--- a/test/fixtures/SE-2018.json
+++ b/test/fixtures/SE-2018.json
@@ -9,12 +9,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2018-01-05 00:00:00",
-    "start": "2018-01-04T23:00:00.000Z",
+    "date": "2018-01-05 12:00:00",
+    "start": "2018-01-05T11:00:00.000Z",
     "end": "2018-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Fri"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2018-04-30 00:00:00",
-    "start": "2018-04-29T22:00:00.000Z",
+    "date": "2018-04-30 12:00:00",
+    "start": "2018-04-30T10:00:00.000Z",
     "end": "2018-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Mon"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2018-11-02 00:00:00",
-    "start": "2018-11-01T23:00:00.000Z",
+    "date": "2018-11-02 12:00:00",
+    "start": "2018-11-02T11:00:00.000Z",
     "end": "2018-11-02T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2019.json
+++ b/test/fixtures/SE-2019.json
@@ -9,12 +9,12 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2019-01-05 00:00:00",
-    "start": "2019-01-04T23:00:00.000Z",
+    "date": "2019-01-05 12:00:00",
+    "start": "2019-01-05T11:00:00.000Z",
     "end": "2019-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Sat"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2019-04-30 00:00:00",
-    "start": "2019-04-29T22:00:00.000Z",
+    "date": "2019-04-30 12:00:00",
+    "start": "2019-04-30T10:00:00.000Z",
     "end": "2019-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Tue"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2019-11-01 00:00:00",
-    "start": "2019-10-31T23:00:00.000Z",
+    "date": "2019-11-01 12:00:00",
+    "start": "2019-11-01T11:00:00.000Z",
     "end": "2019-11-01T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2019.json
+++ b/test/fixtures/SE-2019.json
@@ -13,7 +13,7 @@
     "start": "2019-01-04T23:00:00.000Z",
     "end": "2019-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Sat"
   },
@@ -76,7 +76,7 @@
     "start": "2019-04-19T22:00:00.000Z",
     "end": "2019-04-20T22:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -148,7 +148,7 @@
     "start": "2019-06-07T22:00:00.000Z",
     "end": "2019-06-08T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },

--- a/test/fixtures/SE-2020.json
+++ b/test/fixtures/SE-2020.json
@@ -13,7 +13,7 @@
     "start": "2020-01-04T23:00:00.000Z",
     "end": "2020-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Sun"
   },
@@ -76,7 +76,7 @@
     "start": "2020-04-10T22:00:00.000Z",
     "end": "2020-04-11T22:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -130,7 +130,7 @@
     "start": "2020-05-29T22:00:00.000Z",
     "end": "2020-05-30T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },

--- a/test/fixtures/SE-2020.json
+++ b/test/fixtures/SE-2020.json
@@ -9,12 +9,12 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2020-01-05 00:00:00",
-    "start": "2020-01-04T23:00:00.000Z",
+    "date": "2020-01-05 12:00:00",
+    "start": "2020-01-05T11:00:00.000Z",
     "end": "2020-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Sun"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2020-04-30 00:00:00",
-    "start": "2020-04-29T22:00:00.000Z",
+    "date": "2020-04-30 12:00:00",
+    "start": "2020-04-30T10:00:00.000Z",
     "end": "2020-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Thu"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2020-10-30 00:00:00",
-    "start": "2020-10-29T23:00:00.000Z",
+    "date": "2020-10-30 12:00:00",
+    "start": "2020-10-30T11:00:00.000Z",
     "end": "2020-10-30T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2021.json
+++ b/test/fixtures/SE-2021.json
@@ -9,12 +9,12 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-01-05 00:00:00",
-    "start": "2021-01-04T23:00:00.000Z",
+    "date": "2021-01-05 12:00:00",
+    "start": "2021-01-05T11:00:00.000Z",
     "end": "2021-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Tue"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2021-04-30 00:00:00",
-    "start": "2021-04-29T22:00:00.000Z",
+    "date": "2021-04-30 12:00:00",
+    "start": "2021-04-30T10:00:00.000Z",
     "end": "2021-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Fri"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2021-11-05 00:00:00",
-    "start": "2021-11-04T23:00:00.000Z",
+    "date": "2021-11-05 12:00:00",
+    "start": "2021-11-05T11:00:00.000Z",
     "end": "2021-11-05T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2021.json
+++ b/test/fixtures/SE-2021.json
@@ -13,7 +13,7 @@
     "start": "2021-01-04T23:00:00.000Z",
     "end": "2021-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Tue"
   },
@@ -76,7 +76,7 @@
     "start": "2021-04-02T22:00:00.000Z",
     "end": "2021-04-03T22:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -130,7 +130,7 @@
     "start": "2021-05-21T22:00:00.000Z",
     "end": "2021-05-22T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },

--- a/test/fixtures/SE-2022.json
+++ b/test/fixtures/SE-2022.json
@@ -13,7 +13,7 @@
     "start": "2022-01-04T23:00:00.000Z",
     "end": "2022-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Wed"
   },
@@ -76,7 +76,7 @@
     "start": "2022-04-15T22:00:00.000Z",
     "end": "2022-04-16T22:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -139,7 +139,7 @@
     "start": "2022-06-03T22:00:00.000Z",
     "end": "2022-06-04T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },

--- a/test/fixtures/SE-2022.json
+++ b/test/fixtures/SE-2022.json
@@ -9,12 +9,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2022-01-05 00:00:00",
-    "start": "2022-01-04T23:00:00.000Z",
+    "date": "2022-01-05 12:00:00",
+    "start": "2022-01-05T11:00:00.000Z",
     "end": "2022-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Wed"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-04-30 00:00:00",
-    "start": "2022-04-29T22:00:00.000Z",
+    "date": "2022-04-30 12:00:00",
+    "start": "2022-04-30T10:00:00.000Z",
     "end": "2022-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Sat"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2022-11-04 00:00:00",
-    "start": "2022-11-03T23:00:00.000Z",
+    "date": "2022-11-04 12:00:00",
+    "start": "2022-11-04T11:00:00.000Z",
     "end": "2022-11-04T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2023.json
+++ b/test/fixtures/SE-2023.json
@@ -9,12 +9,12 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2023-01-05 00:00:00",
-    "start": "2023-01-04T23:00:00.000Z",
+    "date": "2023-01-05 12:00:00",
+    "start": "2023-01-05T11:00:00.000Z",
     "end": "2023-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Thu"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2023-04-30 00:00:00",
-    "start": "2023-04-29T22:00:00.000Z",
+    "date": "2023-04-30 12:00:00",
+    "start": "2023-04-30T10:00:00.000Z",
     "end": "2023-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Sun"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2023-11-03 00:00:00",
-    "start": "2023-11-02T23:00:00.000Z",
+    "date": "2023-11-03 12:00:00",
+    "start": "2023-11-03T11:00:00.000Z",
     "end": "2023-11-03T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2023.json
+++ b/test/fixtures/SE-2023.json
@@ -13,7 +13,7 @@
     "start": "2023-01-04T23:00:00.000Z",
     "end": "2023-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Thu"
   },
@@ -76,7 +76,7 @@
     "start": "2023-04-07T22:00:00.000Z",
     "end": "2023-04-08T22:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -130,7 +130,7 @@
     "start": "2023-05-26T22:00:00.000Z",
     "end": "2023-05-27T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },

--- a/test/fixtures/SE-2024.json
+++ b/test/fixtures/SE-2024.json
@@ -9,12 +9,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2024-01-05 00:00:00",
-    "start": "2024-01-04T23:00:00.000Z",
+    "date": "2024-01-05 12:00:00",
+    "start": "2024-01-05T11:00:00.000Z",
     "end": "2024-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Fri"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2024-04-30 00:00:00",
-    "start": "2024-04-29T22:00:00.000Z",
+    "date": "2024-04-30 12:00:00",
+    "start": "2024-04-30T10:00:00.000Z",
     "end": "2024-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Tue"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2024-11-01 00:00:00",
-    "start": "2024-10-31T23:00:00.000Z",
+    "date": "2024-11-01 12:00:00",
+    "start": "2024-11-01T11:00:00.000Z",
     "end": "2024-11-01T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2024.json
+++ b/test/fixtures/SE-2024.json
@@ -13,7 +13,7 @@
     "start": "2024-01-04T23:00:00.000Z",
     "end": "2024-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Fri"
   },
@@ -76,7 +76,7 @@
     "start": "2024-03-29T23:00:00.000Z",
     "end": "2024-03-30T23:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -130,7 +130,7 @@
     "start": "2024-05-17T22:00:00.000Z",
     "end": "2024-05-18T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },

--- a/test/fixtures/SE-2025.json
+++ b/test/fixtures/SE-2025.json
@@ -9,12 +9,12 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2025-01-05 00:00:00",
-    "start": "2025-01-04T23:00:00.000Z",
+    "date": "2025-01-05 12:00:00",
+    "start": "2025-01-05T11:00:00.000Z",
     "end": "2025-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "observance",
-    "rule": "01-05",
+    "type": "optional",
+    "rule": "01-05 12:00",
     "_weekday": "Sun"
   },
   {
@@ -99,12 +99,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2025-04-30 00:00:00",
-    "start": "2025-04-29T22:00:00.000Z",
+    "date": "2025-04-30 12:00:00",
+    "start": "2025-04-30T10:00:00.000Z",
     "end": "2025-04-30T22:00:00.000Z",
     "name": "Valborgsmässoafton",
-    "type": "observance",
-    "rule": "04-30",
+    "type": "optional",
+    "rule": "04-30 12:00",
     "_weekday": "Wed"
   },
   {
@@ -189,12 +189,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2025-10-31 00:00:00",
-    "start": "2025-10-30T23:00:00.000Z",
+    "date": "2025-10-31 12:00:00",
+    "start": "2025-10-31T11:00:00.000Z",
     "end": "2025-10-31T23:00:00.000Z",
     "name": "Allhelgonaafton",
-    "type": "observance",
-    "rule": "friday after 10-30",
+    "type": "optional",
+    "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SE-2025.json
+++ b/test/fixtures/SE-2025.json
@@ -13,7 +13,7 @@
     "start": "2025-01-04T23:00:00.000Z",
     "end": "2025-01-05T23:00:00.000Z",
     "name": "Trettondagsafton",
-    "type": "public",
+    "type": "observance",
     "rule": "01-05",
     "_weekday": "Sun"
   },
@@ -76,7 +76,7 @@
     "start": "2025-04-18T22:00:00.000Z",
     "end": "2025-04-19T22:00:00.000Z",
     "name": "Påskafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
   },
@@ -148,7 +148,7 @@
     "start": "2025-06-06T22:00:00.000Z",
     "end": "2025-06-07T22:00:00.000Z",
     "name": "Pingstafton",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
   },


### PR DESCRIPTION
Jan 5th is not a public holiday in Sweden, and neither is Whitsun Eve or Holy Saturday

Source(s):

https://sv.wikipedia.org/wiki/Helgdagar_i_Sverige
https://en.wikipedia.org/wiki/Public_holidays_in_Sweden