### PR TITLE
Update CA.yaml

### DIFF
--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -79,6 +79,10 @@ holidays:
           fr: Premier lundi d’août
       1st monday in September:
         _name: 05-01
+      09-30:
+        name:
+          en: National Day for Truth and Reconciliation
+          fr: Journée nationale de la vérité et de la réconciliation
       2nd monday after 10-01:
         name:
           en: Thanksgiving


### PR DESCRIPTION
Otherwise known as Orange Shirt day, this new statutory holiday was recognized by the Canadian Federal government in 2021 to recognize its legacy and involvement in the Canadian Aboriginal Residential School System