### PR TITLE
Easter isn't a paid holiday in Belgium

### DIFF
--- a/data/countries/BE.yaml
+++ b/data/countries/BE.yaml
@@ -27,6 +27,7 @@ holidays:
         type: observance
       easter:
         _name: easter
+        type: observance
       easter 1:
         _name: easter 1
       05-01:


### PR DESCRIPTION
The PR corrects a holiday, Easter is considered 'observance' since it's not a paid holiday.