### PR TITLE
fix(DE-HB,DE-HE,DE-TH,#321): Dec. 31 is not a public holiday

### DIFF
--- a/data/countries/DE.yaml
+++ b/data/countries/DE.yaml
@@ -189,9 +189,6 @@ holidays:
       HB:
         name: Hansestadt Bremen
         days:
-          "12-31 14:00 if sunday then 00:00":
-            _name: 12-31
-            type: public
           10-31:
             _name: Reformation Day
             active:
@@ -202,8 +199,6 @@ holidays:
         days:
           easter 60:
             _name: easter 60
-          "12-31 14:00 if sunday then 00:00":
-            _name: 12-31
       HH:
         name: Hansestadt Hamburg
         days:
@@ -293,8 +288,6 @@ holidays:
               - from: 2019
           10-31:
             _name: Reformation Day
-          "12-31 14:00 if sunday then 00:00":
-            _name: 12-31
         regions:
           EIC:
             name: Landkreis Eichfeld

--- a/test/fixtures/DE-HB-2015.json
+++ b/test/fixtures/DE-HB-2015.json
@@ -265,7 +265,7 @@
     "start": "2015-12-31T13:00:00.000Z",
     "end": "2015-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-HB-2016.json
+++ b/test/fixtures/DE-HB-2016.json
@@ -265,7 +265,7 @@
     "start": "2016-12-31T13:00:00.000Z",
     "end": "2016-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-HB-2017.json
+++ b/test/fixtures/DE-HB-2017.json
@@ -274,7 +274,7 @@
     "start": "2017-12-30T23:00:00.000Z",
     "end": "2017-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-HB-2018.json
+++ b/test/fixtures/DE-HB-2018.json
@@ -274,7 +274,7 @@
     "start": "2018-12-31T13:00:00.000Z",
     "end": "2018-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Mon"
   }

--- a/test/fixtures/DE-HB-2019.json
+++ b/test/fixtures/DE-HB-2019.json
@@ -274,7 +274,7 @@
     "start": "2019-12-31T13:00:00.000Z",
     "end": "2019-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-HB-2020.json
+++ b/test/fixtures/DE-HB-2020.json
@@ -274,7 +274,7 @@
     "start": "2020-12-31T13:00:00.000Z",
     "end": "2020-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-HB-2021.json
+++ b/test/fixtures/DE-HB-2021.json
@@ -274,7 +274,7 @@
     "start": "2021-12-31T13:00:00.000Z",
     "end": "2021-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Fri"
   }

--- a/test/fixtures/DE-HB-2022.json
+++ b/test/fixtures/DE-HB-2022.json
@@ -274,7 +274,7 @@
     "start": "2022-12-31T13:00:00.000Z",
     "end": "2022-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-HB-2023.json
+++ b/test/fixtures/DE-HB-2023.json
@@ -274,7 +274,7 @@
     "start": "2023-12-30T23:00:00.000Z",
     "end": "2023-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-HB-2024.json
+++ b/test/fixtures/DE-HB-2024.json
@@ -274,7 +274,7 @@
     "start": "2024-12-31T13:00:00.000Z",
     "end": "2024-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-HB-2025.json
+++ b/test/fixtures/DE-HB-2025.json
@@ -274,7 +274,7 @@
     "start": "2025-12-31T13:00:00.000Z",
     "end": "2025-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Wed"
   }

--- a/test/fixtures/DE-HE-2015.json
+++ b/test/fixtures/DE-HE-2015.json
@@ -274,7 +274,7 @@
     "start": "2015-12-31T13:00:00.000Z",
     "end": "2015-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-HE-2016.json
+++ b/test/fixtures/DE-HE-2016.json
@@ -274,7 +274,7 @@
     "start": "2016-12-31T13:00:00.000Z",
     "end": "2016-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-HE-2017.json
+++ b/test/fixtures/DE-HE-2017.json
@@ -283,7 +283,7 @@
     "start": "2017-12-30T23:00:00.000Z",
     "end": "2017-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-HE-2018.json
+++ b/test/fixtures/DE-HE-2018.json
@@ -274,7 +274,7 @@
     "start": "2018-12-31T13:00:00.000Z",
     "end": "2018-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Mon"
   }

--- a/test/fixtures/DE-HE-2019.json
+++ b/test/fixtures/DE-HE-2019.json
@@ -274,7 +274,7 @@
     "start": "2019-12-31T13:00:00.000Z",
     "end": "2019-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-HE-2020.json
+++ b/test/fixtures/DE-HE-2020.json
@@ -274,7 +274,7 @@
     "start": "2020-12-31T13:00:00.000Z",
     "end": "2020-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-HE-2021.json
+++ b/test/fixtures/DE-HE-2021.json
@@ -274,7 +274,7 @@
     "start": "2021-12-31T13:00:00.000Z",
     "end": "2021-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Fri"
   }

--- a/test/fixtures/DE-HE-2022.json
+++ b/test/fixtures/DE-HE-2022.json
@@ -274,7 +274,7 @@
     "start": "2022-12-31T13:00:00.000Z",
     "end": "2022-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-HE-2023.json
+++ b/test/fixtures/DE-HE-2023.json
@@ -274,7 +274,7 @@
     "start": "2023-12-30T23:00:00.000Z",
     "end": "2023-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-HE-2024.json
+++ b/test/fixtures/DE-HE-2024.json
@@ -274,7 +274,7 @@
     "start": "2024-12-31T13:00:00.000Z",
     "end": "2024-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-HE-2025.json
+++ b/test/fixtures/DE-HE-2025.json
@@ -274,7 +274,7 @@
     "start": "2025-12-31T13:00:00.000Z",
     "end": "2025-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Wed"
   }

--- a/test/fixtures/DE-TH-2015.json
+++ b/test/fixtures/DE-TH-2015.json
@@ -283,7 +283,7 @@
     "start": "2015-12-31T13:00:00.000Z",
     "end": "2015-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-TH-2016.json
+++ b/test/fixtures/DE-TH-2016.json
@@ -283,7 +283,7 @@
     "start": "2016-12-31T13:00:00.000Z",
     "end": "2016-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-TH-2017.json
+++ b/test/fixtures/DE-TH-2017.json
@@ -283,7 +283,7 @@
     "start": "2017-12-30T23:00:00.000Z",
     "end": "2017-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-TH-2018.json
+++ b/test/fixtures/DE-TH-2018.json
@@ -283,7 +283,7 @@
     "start": "2018-12-31T13:00:00.000Z",
     "end": "2018-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Mon"
   }

--- a/test/fixtures/DE-TH-2019.json
+++ b/test/fixtures/DE-TH-2019.json
@@ -292,7 +292,7 @@
     "start": "2019-12-31T13:00:00.000Z",
     "end": "2019-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-TH-2020.json
+++ b/test/fixtures/DE-TH-2020.json
@@ -292,7 +292,7 @@
     "start": "2020-12-31T13:00:00.000Z",
     "end": "2020-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-TH-2021.json
+++ b/test/fixtures/DE-TH-2021.json
@@ -292,7 +292,7 @@
     "start": "2021-12-31T13:00:00.000Z",
     "end": "2021-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Fri"
   }

--- a/test/fixtures/DE-TH-2022.json
+++ b/test/fixtures/DE-TH-2022.json
@@ -292,7 +292,7 @@
     "start": "2022-12-31T13:00:00.000Z",
     "end": "2022-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-TH-2023.json
+++ b/test/fixtures/DE-TH-2023.json
@@ -292,7 +292,7 @@
     "start": "2023-12-30T23:00:00.000Z",
     "end": "2023-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-TH-2024.json
+++ b/test/fixtures/DE-TH-2024.json
@@ -292,7 +292,7 @@
     "start": "2024-12-31T13:00:00.000Z",
     "end": "2024-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-TH-2025.json
+++ b/test/fixtures/DE-TH-2025.json
@@ -292,7 +292,7 @@
     "start": "2025-12-31T13:00:00.000Z",
     "end": "2025-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Wed"
   }

--- a/test/fixtures/DE-TH-EIC-2015.json
+++ b/test/fixtures/DE-TH-EIC-2015.json
@@ -283,7 +283,7 @@
     "start": "2015-12-31T13:00:00.000Z",
     "end": "2015-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-TH-EIC-2016.json
+++ b/test/fixtures/DE-TH-EIC-2016.json
@@ -283,7 +283,7 @@
     "start": "2016-12-31T13:00:00.000Z",
     "end": "2016-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-TH-EIC-2017.json
+++ b/test/fixtures/DE-TH-EIC-2017.json
@@ -283,7 +283,7 @@
     "start": "2017-12-30T23:00:00.000Z",
     "end": "2017-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-TH-EIC-2018.json
+++ b/test/fixtures/DE-TH-EIC-2018.json
@@ -283,7 +283,7 @@
     "start": "2018-12-31T13:00:00.000Z",
     "end": "2018-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Mon"
   }

--- a/test/fixtures/DE-TH-EIC-2019.json
+++ b/test/fixtures/DE-TH-EIC-2019.json
@@ -292,7 +292,7 @@
     "start": "2019-12-31T13:00:00.000Z",
     "end": "2019-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-TH-EIC-2020.json
+++ b/test/fixtures/DE-TH-EIC-2020.json
@@ -292,7 +292,7 @@
     "start": "2020-12-31T13:00:00.000Z",
     "end": "2020-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-TH-EIC-2021.json
+++ b/test/fixtures/DE-TH-EIC-2021.json
@@ -292,7 +292,7 @@
     "start": "2021-12-31T13:00:00.000Z",
     "end": "2021-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Fri"
   }

--- a/test/fixtures/DE-TH-EIC-2022.json
+++ b/test/fixtures/DE-TH-EIC-2022.json
@@ -292,7 +292,7 @@
     "start": "2022-12-31T13:00:00.000Z",
     "end": "2022-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-TH-EIC-2023.json
+++ b/test/fixtures/DE-TH-EIC-2023.json
@@ -292,7 +292,7 @@
     "start": "2023-12-30T23:00:00.000Z",
     "end": "2023-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-TH-EIC-2024.json
+++ b/test/fixtures/DE-TH-EIC-2024.json
@@ -292,7 +292,7 @@
     "start": "2024-12-31T13:00:00.000Z",
     "end": "2024-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-TH-EIC-2025.json
+++ b/test/fixtures/DE-TH-EIC-2025.json
@@ -292,7 +292,7 @@
     "start": "2025-12-31T13:00:00.000Z",
     "end": "2025-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Wed"
   }

--- a/test/fixtures/DE-TH-UH-2015.json
+++ b/test/fixtures/DE-TH-UH-2015.json
@@ -284,7 +284,7 @@
     "start": "2015-12-31T13:00:00.000Z",
     "end": "2015-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-TH-UH-2016.json
+++ b/test/fixtures/DE-TH-UH-2016.json
@@ -284,7 +284,7 @@
     "start": "2016-12-31T13:00:00.000Z",
     "end": "2016-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-TH-UH-2017.json
+++ b/test/fixtures/DE-TH-UH-2017.json
@@ -284,7 +284,7 @@
     "start": "2017-12-30T23:00:00.000Z",
     "end": "2017-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-TH-UH-2018.json
+++ b/test/fixtures/DE-TH-UH-2018.json
@@ -284,7 +284,7 @@
     "start": "2018-12-31T13:00:00.000Z",
     "end": "2018-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Mon"
   }

--- a/test/fixtures/DE-TH-UH-2019.json
+++ b/test/fixtures/DE-TH-UH-2019.json
@@ -293,7 +293,7 @@
     "start": "2019-12-31T13:00:00.000Z",
     "end": "2019-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-TH-UH-2020.json
+++ b/test/fixtures/DE-TH-UH-2020.json
@@ -293,7 +293,7 @@
     "start": "2020-12-31T13:00:00.000Z",
     "end": "2020-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-TH-UH-2021.json
+++ b/test/fixtures/DE-TH-UH-2021.json
@@ -293,7 +293,7 @@
     "start": "2021-12-31T13:00:00.000Z",
     "end": "2021-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Fri"
   }

--- a/test/fixtures/DE-TH-UH-2022.json
+++ b/test/fixtures/DE-TH-UH-2022.json
@@ -293,7 +293,7 @@
     "start": "2022-12-31T13:00:00.000Z",
     "end": "2022-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-TH-UH-2023.json
+++ b/test/fixtures/DE-TH-UH-2023.json
@@ -293,7 +293,7 @@
     "start": "2023-12-30T23:00:00.000Z",
     "end": "2023-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-TH-UH-2024.json
+++ b/test/fixtures/DE-TH-UH-2024.json
@@ -293,7 +293,7 @@
     "start": "2024-12-31T13:00:00.000Z",
     "end": "2024-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-TH-UH-2025.json
+++ b/test/fixtures/DE-TH-UH-2025.json
@@ -293,7 +293,7 @@
     "start": "2025-12-31T13:00:00.000Z",
     "end": "2025-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Wed"
   }

--- a/test/fixtures/DE-TH-WAK-2015.json
+++ b/test/fixtures/DE-TH-WAK-2015.json
@@ -284,7 +284,7 @@
     "start": "2015-12-31T13:00:00.000Z",
     "end": "2015-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-TH-WAK-2016.json
+++ b/test/fixtures/DE-TH-WAK-2016.json
@@ -284,7 +284,7 @@
     "start": "2016-12-31T13:00:00.000Z",
     "end": "2016-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-TH-WAK-2017.json
+++ b/test/fixtures/DE-TH-WAK-2017.json
@@ -284,7 +284,7 @@
     "start": "2017-12-30T23:00:00.000Z",
     "end": "2017-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-TH-WAK-2018.json
+++ b/test/fixtures/DE-TH-WAK-2018.json
@@ -284,7 +284,7 @@
     "start": "2018-12-31T13:00:00.000Z",
     "end": "2018-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Mon"
   }

--- a/test/fixtures/DE-TH-WAK-2019.json
+++ b/test/fixtures/DE-TH-WAK-2019.json
@@ -293,7 +293,7 @@
     "start": "2019-12-31T13:00:00.000Z",
     "end": "2019-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-TH-WAK-2020.json
+++ b/test/fixtures/DE-TH-WAK-2020.json
@@ -293,7 +293,7 @@
     "start": "2020-12-31T13:00:00.000Z",
     "end": "2020-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Thu"
   }

--- a/test/fixtures/DE-TH-WAK-2021.json
+++ b/test/fixtures/DE-TH-WAK-2021.json
@@ -293,7 +293,7 @@
     "start": "2021-12-31T13:00:00.000Z",
     "end": "2021-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Fri"
   }

--- a/test/fixtures/DE-TH-WAK-2022.json
+++ b/test/fixtures/DE-TH-WAK-2022.json
@@ -293,7 +293,7 @@
     "start": "2022-12-31T13:00:00.000Z",
     "end": "2022-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sat"
   }

--- a/test/fixtures/DE-TH-WAK-2023.json
+++ b/test/fixtures/DE-TH-WAK-2023.json
@@ -293,7 +293,7 @@
     "start": "2023-12-30T23:00:00.000Z",
     "end": "2023-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Sun"
   }

--- a/test/fixtures/DE-TH-WAK-2024.json
+++ b/test/fixtures/DE-TH-WAK-2024.json
@@ -293,7 +293,7 @@
     "start": "2024-12-31T13:00:00.000Z",
     "end": "2024-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Tue"
   }

--- a/test/fixtures/DE-TH-WAK-2025.json
+++ b/test/fixtures/DE-TH-WAK-2025.json
@@ -293,7 +293,7 @@
     "start": "2025-12-31T13:00:00.000Z",
     "end": "2025-12-31T23:00:00.000Z",
     "name": "Silvester",
-    "type": "public",
+    "type": "bank",
     "rule": "12-31 14:00 if sunday then 00:00",
     "_weekday": "Wed"
   }


### PR DESCRIPTION
In DE-HB,DE-HE,DE-TH Dec. 31st was attributed as public holiday.
As this might only apply if that day falls on a Sunday this PR uses the
country wide rule now.
Fixes issue #321 