### PR TITLE
Mark Pentecost and Regional days as observance

### DIFF
--- a/data/countries/BE.yaml
+++ b/data/countries/BE.yaml
@@ -39,6 +39,7 @@ holidays:
         _name: easter 39
       easter 49:
         _name: easter 49
+        type: observance
       easter 50:
         _name: easter 50
       07-21:
@@ -77,6 +78,7 @@ holidays:
             name:
               nl: Feest van de Iris
               fr: Fête de l'Iris
+            type: observance
       DE:
         name: Deutschsprachige Gemeinschaft
         langs:
@@ -87,6 +89,7 @@ holidays:
               de: Tag der Deutschsprachigen Gemeinschaft
               fr: Jour de la Communauté Germanophone
               nl: Feestdag van de Duitstalige Gemeenschap
+            type: observance
       VLG:
         name: Vlaamse Gemeenschap
         langs:
@@ -97,6 +100,7 @@ holidays:
               de: Festtag der Wallonischen Region
               fr: Fête de la Région wallonne
               nl: Feestdag van de Vlaamse Gemeenschap
+            type: observance
         # regions:
         # VAN:
         #   name: Antwerp
@@ -118,6 +122,7 @@ holidays:
               de: Tag der Französischsprachigen Gemeinschaft
               fr: La fête de la communauté française
               nl: Feestdag van de Franse Gemeenschap
+            type: observance
         # regions:
         # WBR:
         #   name: Walloon Brabant

--- a/test/fixtures/BE-2015.json
+++ b/test/fixtures/BE-2015.json
@@ -76,7 +76,7 @@
     "start": "2015-05-23T22:00:00.000Z",
     "end": "2015-05-24T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BE-2016.json
+++ b/test/fixtures/BE-2016.json
@@ -76,7 +76,7 @@
     "start": "2016-05-14T22:00:00.000Z",
     "end": "2016-05-15T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BE-2017.json
+++ b/test/fixtures/BE-2017.json
@@ -76,7 +76,7 @@
     "start": "2017-06-03T22:00:00.000Z",
     "end": "2017-06-04T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BE-2018.json
+++ b/test/fixtures/BE-2018.json
@@ -76,7 +76,7 @@
     "start": "2018-05-19T22:00:00.000Z",
     "end": "2018-05-20T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BE-2019.json
+++ b/test/fixtures/BE-2019.json
@@ -76,7 +76,7 @@
     "start": "2019-06-08T22:00:00.000Z",
     "end": "2019-06-09T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BE-2020.json
+++ b/test/fixtures/BE-2020.json
@@ -76,7 +76,7 @@
     "start": "2020-05-30T22:00:00.000Z",
     "end": "2020-05-31T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BE-2021.json
+++ b/test/fixtures/BE-2021.json
@@ -76,7 +76,7 @@
     "start": "2021-05-22T22:00:00.000Z",
     "end": "2021-05-23T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BE-2022.json
+++ b/test/fixtures/BE-2022.json
@@ -76,7 +76,7 @@
     "start": "2022-06-04T22:00:00.000Z",
     "end": "2022-06-05T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BE-2023.json
+++ b/test/fixtures/BE-2023.json
@@ -76,7 +76,7 @@
     "start": "2023-05-27T22:00:00.000Z",
     "end": "2023-05-28T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BE-2024.json
+++ b/test/fixtures/BE-2024.json
@@ -76,7 +76,7 @@
     "start": "2024-05-18T22:00:00.000Z",
     "end": "2024-05-19T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BE-2025.json
+++ b/test/fixtures/BE-2025.json
@@ -76,7 +76,7 @@
     "start": "2025-06-07T22:00:00.000Z",
     "end": "2025-06-08T22:00:00.000Z",
     "name": "Pentecôte",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },


### PR DESCRIPTION
Pentecost and the various regional community holidays aren't public holidays.