### PR TITLE
fix(US.CA): Presidents' Day name

### DIFF
--- a/data/countries/US.yaml
+++ b/data/countries/US.yaml
@@ -217,7 +217,7 @@ holidays:
         days:
           3rd monday in February:
             name:
-              en: The third Monday in February
+              en: Presidents' Day
           2nd monday in October: false
           02-15:
             type: observance

--- a/test/fixtures/US-CA-2015.json
+++ b/test/fixtures/US-CA-2015.json
@@ -39,7 +39,7 @@
     "date": "2015-02-16 00:00:00",
     "start": "2015-02-16T08:00:00.000Z",
     "end": "2015-02-17T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-2016.json
+++ b/test/fixtures/US-CA-2016.json
@@ -39,7 +39,7 @@
     "date": "2016-02-15 00:00:00",
     "start": "2016-02-15T08:00:00.000Z",
     "end": "2016-02-16T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-2017.json
+++ b/test/fixtures/US-CA-2017.json
@@ -49,7 +49,7 @@
     "date": "2017-02-20 00:00:00",
     "start": "2017-02-20T08:00:00.000Z",
     "end": "2017-02-21T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-2018.json
+++ b/test/fixtures/US-CA-2018.json
@@ -39,7 +39,7 @@
     "date": "2018-02-19 00:00:00",
     "start": "2018-02-19T08:00:00.000Z",
     "end": "2018-02-20T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-2019.json
+++ b/test/fixtures/US-CA-2019.json
@@ -39,7 +39,7 @@
     "date": "2019-02-18 00:00:00",
     "start": "2019-02-18T08:00:00.000Z",
     "end": "2019-02-19T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-2020.json
+++ b/test/fixtures/US-CA-2020.json
@@ -39,7 +39,7 @@
     "date": "2020-02-17 00:00:00",
     "start": "2020-02-17T08:00:00.000Z",
     "end": "2020-02-18T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-2021.json
+++ b/test/fixtures/US-CA-2021.json
@@ -39,7 +39,7 @@
     "date": "2021-02-15 00:00:00",
     "start": "2021-02-15T08:00:00.000Z",
     "end": "2021-02-16T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-2022.json
+++ b/test/fixtures/US-CA-2022.json
@@ -39,7 +39,7 @@
     "date": "2022-02-21 00:00:00",
     "start": "2022-02-21T08:00:00.000Z",
     "end": "2022-02-22T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-2023.json
+++ b/test/fixtures/US-CA-2023.json
@@ -49,7 +49,7 @@
     "date": "2023-02-20 00:00:00",
     "start": "2023-02-20T08:00:00.000Z",
     "end": "2023-02-21T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-2024.json
+++ b/test/fixtures/US-CA-2024.json
@@ -39,7 +39,7 @@
     "date": "2024-02-19 00:00:00",
     "start": "2024-02-19T08:00:00.000Z",
     "end": "2024-02-20T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-2025.json
+++ b/test/fixtures/US-CA-2025.json
@@ -39,7 +39,7 @@
     "date": "2025-02-17 00:00:00",
     "start": "2025-02-17T08:00:00.000Z",
     "end": "2025-02-18T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2015.json
+++ b/test/fixtures/US-CA-LA-2015.json
@@ -39,7 +39,7 @@
     "date": "2015-02-16 00:00:00",
     "start": "2015-02-16T08:00:00.000Z",
     "end": "2015-02-17T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2016.json
+++ b/test/fixtures/US-CA-LA-2016.json
@@ -39,7 +39,7 @@
     "date": "2016-02-15 00:00:00",
     "start": "2016-02-15T08:00:00.000Z",
     "end": "2016-02-16T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2017.json
+++ b/test/fixtures/US-CA-LA-2017.json
@@ -49,7 +49,7 @@
     "date": "2017-02-20 00:00:00",
     "start": "2017-02-20T08:00:00.000Z",
     "end": "2017-02-21T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2018.json
+++ b/test/fixtures/US-CA-LA-2018.json
@@ -39,7 +39,7 @@
     "date": "2018-02-19 00:00:00",
     "start": "2018-02-19T08:00:00.000Z",
     "end": "2018-02-20T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2019.json
+++ b/test/fixtures/US-CA-LA-2019.json
@@ -39,7 +39,7 @@
     "date": "2019-02-18 00:00:00",
     "start": "2019-02-18T08:00:00.000Z",
     "end": "2019-02-19T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2020.json
+++ b/test/fixtures/US-CA-LA-2020.json
@@ -39,7 +39,7 @@
     "date": "2020-02-17 00:00:00",
     "start": "2020-02-17T08:00:00.000Z",
     "end": "2020-02-18T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2021.json
+++ b/test/fixtures/US-CA-LA-2021.json
@@ -39,7 +39,7 @@
     "date": "2021-02-15 00:00:00",
     "start": "2021-02-15T08:00:00.000Z",
     "end": "2021-02-16T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2022.json
+++ b/test/fixtures/US-CA-LA-2022.json
@@ -39,7 +39,7 @@
     "date": "2022-02-21 00:00:00",
     "start": "2022-02-21T08:00:00.000Z",
     "end": "2022-02-22T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2023.json
+++ b/test/fixtures/US-CA-LA-2023.json
@@ -49,7 +49,7 @@
     "date": "2023-02-20 00:00:00",
     "start": "2023-02-20T08:00:00.000Z",
     "end": "2023-02-21T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2024.json
+++ b/test/fixtures/US-CA-LA-2024.json
@@ -39,7 +39,7 @@
     "date": "2024-02-19 00:00:00",
     "start": "2024-02-19T08:00:00.000Z",
     "end": "2024-02-20T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"

--- a/test/fixtures/US-CA-LA-2025.json
+++ b/test/fixtures/US-CA-LA-2025.json
@@ -39,7 +39,7 @@
     "date": "2025-02-17 00:00:00",
     "start": "2025-02-17T08:00:00.000Z",
     "end": "2025-02-18T08:00:00.000Z",
-    "name": "The third Monday in February",
+    "name": "Presidents' Day",
     "type": "public",
     "rule": "3rd monday in February",
     "_weekday": "Mon"


### PR DESCRIPTION
Modified the name to "Presidents' Day" from "The third Monday in February". Used the source https://www.calhr.ca.gov/employees/pages/state-holidays.aspx to confirm the name.