### PR TITLE
Add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "Wayne Parrott <wayne.parrott@reblcorp.com>",
     "Wésley Queiroz <wesleycoder@gmail.com>",
     "westn <westn89@gmail.com>",
+    "Will Bamford <w.bamford@gmail.com>",
     "William Santos <william@MacBook-Pro-de-William-2.local>",
     "Yannick <yannick.franssen@outlook.com>",
     "Yoshio HANAWA <y@hnw.jp>",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
   "exports": {
     ".": {
       "import": "./src/index.js",
-      "require": "./lib/index.cjs"
+      "require": "./lib/index.cjs",
+      "types": "./types/index.d.ts"
     },
     "./data": {
       "import": "./src/data.js",


### PR DESCRIPTION
I was receiving the following after upgrading to TS 4.7 and setting `"moduleResolution": "Node16"` in `tsconfig.json`:

> error TS7016: Could not find a declaration file for module 'date-holidays'. '/.../node_modules/date-holidays/lib/index.cjs' implicitly has an 'any' type.
> Try `npm i --save-dev @types/date-holidays` if it exists or add a new declaration (.d.ts) file containing `declare module 'date-holidays';`

Adding `types` to the `exports` field seems to fix this.
