### PR TITLE
Update Ireland to show the correct October holiday

### DIFF
--- a/data/countries/IE.yaml
+++ b/data/countries/IE.yaml
@@ -43,7 +43,7 @@ holidays:
       1st monday in August:
         name:
           en: First Monday in August
-      1st monday before 10-31:
+      1st Monday before 11-01:
         name:
           en: October Bank Holiday
           type: bank


### PR DESCRIPTION
https://github.com/commenthol/date-holidays/issues/362

This is to address that issue, with the proposed fix on October bank holiday which actually Falls on Halloween.