### PR TITLE
Improved support for public holidays in Luxembourg

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -182,6 +182,7 @@ https://fr.wikipedia.org/wiki/R%C3%A9publique_du_Congo
 https://fr.wikipedia.org/wiki/Seychelles
 https://id.wikipedia.org/wiki/Hari_libur_nasional_di_Indonesia
 https://ja.wikipedia.org/wiki/%E5%9B%BD%E6%B0%91%E3%81%AE%E7%A5%9D%E6%97%A5
+https://lb.wikipedia.org/wiki/Gesetzlech_Feierdeeg_zu_L%C3%ABtzebuerg
 https://nl.wikipedia.org/wiki/Feestdagen_in_Nederland
 https://pt.wikipedia.org/wiki/Cabo_Verde#Feriados
 https://pt.wikipedia.org/wiki/Feriados_em_Angola

--- a/data/countries/LU.yaml
+++ b/data/countries/LU.yaml
@@ -1,16 +1,31 @@
 holidays:
   # @source http://www.legilux.public.lu/leg/textescoordonnes/codes/code_travail/ - Art. L. 232-2.
+  # @source https://legilux.public.lu/eli/etat/leg/loi/1892/02/16/n2/jo
+  # @source https://legilux.public.lu/eli/etat/leg/agd/1946/04/23/n1/jo
+  # @source https://legilux.public.lu/eli/etat/leg/agd/1947/08/08/n1/jo
+  # @source https://legilux.public.lu/eli/etat/leg/agd/1961/12/23/n2/jo
+  # @attrib https://lb.wikipedia.org/wiki/Gesetzlech_Feierdeeg_zu_L%C3%ABtzebuerg
   LU:
     names:
       fr: Luxembourg
       en: Luxembourg
+      de: Luxemburg
+      lb: Lëtzebuerg
+      pt: Luxemburgo
     langs:
       - fr
+      - de
+      - lb
     zones:
       - Europe/Luxembourg
     days:
       01-01:
         _name: 01-01
+      01-23:
+        _name: National Holiday
+        active:
+          - from: "1947-08-08"
+            to: "1961-12-23"
       easter -2:
         _name: easter -2
         type: observance
@@ -19,10 +34,14 @@ holidays:
         type: observance
       easter 1:
         _name: easter 1
+        active:
+          - from: "1892-02-16"
       05-01:
         _name: 05-01
         name:
           fr: 1er mai
+        active:
+          - from: "1946-04-23"
       05-09:
         _name: 05-09
         active:
@@ -31,9 +50,12 @@ holidays:
         _name: easter 39
       easter 50:
         _name: easter 50
+        active:
+          - from: "1892-02-16"
       06-23:
-        name:
-          fr: L’anniversaire du Grand-Duc
+        _name: National Holiday
+        active:
+          - from: "1961-12-23"
       08-15:
         _name: 08-15
       11-01:
@@ -42,3 +64,5 @@ holidays:
         _name: 12-25
       12-26:
         _name: 12-26
+        active:
+          - from: "1892-02-16"

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -39,6 +39,7 @@ names:
       jp: 元日
       kl: ukiortaaq
       ko: 신정
+      lb: Neijoerschdag
       lt: Naujieji metai
       lv: Jaunais Gads
       mg: Taom-baovao
@@ -81,6 +82,7 @@ names:
       it: Befana
       # it: Epifania
       is: Þrettándinn
+      lb: Dräikinneksdag
       nl: Driekoningen
       mk: Богојавление
       pl: Święto Trzech Króli
@@ -93,6 +95,7 @@ names:
       en: Candlemas
       de: Lichtmess
       hu: Gyertyaszentelő Boldogasszony
+      lb: Liichtmëssdag
       nl: Lichtmis
       vi: Lễ Đức Mẹ dâng Chúa Giêsu trong đền thánh
   02-14:
@@ -101,6 +104,7 @@ names:
       de: Valentinstag
       fr: Saint-Valentin
       hu: Valentin nap
+      lb: Vältesdag
       nl: Valentijnsdag
       vi: Lễ tình nhân
   03-08:
@@ -114,6 +118,7 @@ names:
       ge: ქალთა საერთაშორისო დღე
       hu: Nemzetközi nőnap
       hy: Կանանց տոն
+      lb: Internationale Fraendag
       nl: Internationale Vrouwendag
       pt: Dia Internacional da Mulher
       ro: Ziua Internationala a Femeii
@@ -163,6 +168,7 @@ names:
       id: Hari Buruh Internasional
       it: Festa del Lavoro
       is: Hátíðisdagur Verkamanna
+      lb: Éischte Mee
       lt: Tarptautinė darbo diena
       lv: Darba svētki
       nl: Dag van de Arbeid
@@ -201,6 +207,7 @@ names:
       hr: Dan Europe
       hu: Európa-nap
       it: Festa dell'Europa
+      lb: Europadag
       ls: Dan Evrope
       lt: Europos diena
       lv: Eiropas diena
@@ -232,6 +239,7 @@ names:
       hr: Velika Gospa
       it: Ferragosto
       # it: Assunzione di Maria Virgine
+      lb: Léiffrawëschdag
       lt: Žolinė
       mg: Asompsiona
       mk: Успение на Пресвета Богородица
@@ -256,6 +264,7 @@ names:
       hu: Mindenszentek
       it: Ognissanti
       # it: Tutti i Santi
+      lb: Allerhellegen
       lt: Visų šventųjų diena
       mg: Fetin'ny olo-masina
       mk: Празникот на сите светци
@@ -277,6 +286,7 @@ names:
       fr: Fête des morts
       hr: Dušni dan
       hu: Halottak napja
+      lb: Allerséilen
       nl: Allerzielen
       pt: Dia de Finados
       vi: Lễ Các Đẳng
@@ -294,6 +304,7 @@ names:
       de: Sankt Nikolaus
       fr: Saint-Nicolas
       hu: Mikulás
+      lb: Niklosdag
       nl: Sinterklaas
       vi: Thánh Saint Nicholas
   12-08:
@@ -324,6 +335,7 @@ names:
       hu: Szenteste
       is: Aðfangadagur
       kl: juulliaraq
+      lb: Hellegowend
       lt: Šv. Kūčios
       lv: Ziemassvētku vakars
       ms: Hari Sebelum Krismas
@@ -365,6 +377,7 @@ names:
       jp: ノエル
       kl: juullerujussuaq
       ko: 기독탄신일
+      lb: Chrëschtdag
       lt: Šv. Kalėdos
       lv: Ziemassvētki
       mg: Krismasy
@@ -408,6 +421,7 @@ names:
       it: Santo Stefano
       is: Annar í jólum
       kl: juullip aappaa
+      lb: Stiefesdag
       lt: 2. Kalėdų diena
       lv: Otrie Ziemassvētki
       nl: Tweede kerstdag
@@ -434,6 +448,7 @@ names:
       is: Gamlársdagur
       it: Ultimo dell’anno
       jp: 大晦日
+      lb: Silvester
       lv: Vecgada vakars
       nl: Oudejaarsavond
       no: Nyttårsaften
@@ -449,6 +464,7 @@ names:
       de: Rosenmontag
       es: Carnaval
       fr: Lundi de Carnaval
+      lb: Fuesméindeg
       nl: Carnavalmaandag
       pap: Dialuna di Carnaval
       vi: Ngày thứ hai hoa hồng
@@ -472,6 +488,7 @@ names:
       hu: Hamvazószerda
       it: Ceneri
       is: Öskudagur
+      lb: Äschermëttwoch
       nl: Aswoensdag
       pt: Quarta-feira de Cinzas
       sw: Jumatano ya Majivu
@@ -484,6 +501,7 @@ names:
       hu: Virágvasárnap
       it: Domenica delle Palme
       is: Pálmasunnudagur
+      lb: Pällemsonndeg
       nl: Palmzondag
       no: Palmesøndag
       vi: Chúa nhật Lễ Lá
@@ -500,6 +518,7 @@ names:
       is: Skírdagur
       it: Giovedì santo
       kl: sisamanngortoq illernartoq
+      lb: Gréngen Donneschdeg
       nl: Witte donderdag
       no: Skjærtorsdag
       sv: Skärtorsdagen
@@ -527,6 +546,7 @@ names:
       it: Venerdì santo
       is: Föstudagurinn langi
       kl: tallimanngornersuaq
+      lb: Karfreideg
       lv: Lielā Piektdiena
       ms: Jumat Agung
       mt: Il-Ġimgħa l-Kbira
@@ -553,6 +573,7 @@ names:
       ge: დიდი შაბათი
       hu: Nagyszombat
       it: Sabado santo
+      lb: Karsamschdeg
       nl: Dag voor Pasen
       no: Påskeaften
       sv: Påskafton
@@ -580,6 +601,7 @@ names:
       it: Domenica di Pasqua
       is: Páskadagur
       kl: poorskip-ullua
+      lb: Ouschtersonndeg
       lt: Velykos
       lv: Lieldienas
       nl: Pasen
@@ -615,6 +637,7 @@ names:
       it: Lunedì dell’Angelo
       is: Annar í páskum
       kl: poorskip-aappaa
+      lb: Ouschterméindeg
       lt: Velykų pirmadienis
       lv: Otrās Lieldienas
       mg: Alatsinain'ny Paska
@@ -645,6 +668,7 @@ names:
       is: Uppstigningardagur
       kl: qilaliarfik
       mg: Andro niakarana
+      lb: Christi Himmelfaart
       nl: O.L.H. Hemelvaart
       no: Kristi himmelfartsdag
       pap: Dia di Asuncion
@@ -666,6 +690,7 @@ names:
       it: Pentecoste
       is: Hvítasunnudagur
       kl: piinsip ullua
+      lb: Päischtsonndeg
       nl: Pinksteren
       no: Første pinsedag
       mk: Духовден
@@ -689,6 +714,7 @@ names:
       it: Lunedì di Pentecoste
       kl: piinsip aappaa
       mg: Alatsinain'ny Pentekosta
+      lb: Péngschtméindeg
       nl: Tweede pinksterdag
       no: Andre pinsedag
       ro: A doua zi de Rusalii
@@ -1039,6 +1065,7 @@ names:
       fr: Fête nationale
       hu: Nemzeti ünnep
       el: εθνική επέτειος
+      lb: Nationalfeierdag
       nl: Nationale feestdag
       vi: Quốc Lễ
   Public Holiday:

--- a/test/fixtures/LU-2015.json
+++ b/test/fixtures/LU-2015.json
@@ -66,7 +66,7 @@
     "date": "2015-06-23 00:00:00",
     "start": "2015-06-22T22:00:00.000Z",
     "end": "2015-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Tue"

--- a/test/fixtures/LU-2016.json
+++ b/test/fixtures/LU-2016.json
@@ -66,7 +66,7 @@
     "date": "2016-06-23 00:00:00",
     "start": "2016-06-22T22:00:00.000Z",
     "end": "2016-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Thu"

--- a/test/fixtures/LU-2017.json
+++ b/test/fixtures/LU-2017.json
@@ -66,7 +66,7 @@
     "date": "2017-06-23 00:00:00",
     "start": "2017-06-22T22:00:00.000Z",
     "end": "2017-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Fri"

--- a/test/fixtures/LU-2018.json
+++ b/test/fixtures/LU-2018.json
@@ -66,7 +66,7 @@
     "date": "2018-06-23 00:00:00",
     "start": "2018-06-22T22:00:00.000Z",
     "end": "2018-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Sat"

--- a/test/fixtures/LU-2019.json
+++ b/test/fixtures/LU-2019.json
@@ -75,7 +75,7 @@
     "date": "2019-06-23 00:00:00",
     "start": "2019-06-22T22:00:00.000Z",
     "end": "2019-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Sun"

--- a/test/fixtures/LU-2020.json
+++ b/test/fixtures/LU-2020.json
@@ -75,7 +75,7 @@
     "date": "2020-06-23 00:00:00",
     "start": "2020-06-22T22:00:00.000Z",
     "end": "2020-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Tue"

--- a/test/fixtures/LU-2021.json
+++ b/test/fixtures/LU-2021.json
@@ -75,7 +75,7 @@
     "date": "2021-06-23 00:00:00",
     "start": "2021-06-22T22:00:00.000Z",
     "end": "2021-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Wed"

--- a/test/fixtures/LU-2022.json
+++ b/test/fixtures/LU-2022.json
@@ -75,7 +75,7 @@
     "date": "2022-06-23 00:00:00",
     "start": "2022-06-22T22:00:00.000Z",
     "end": "2022-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Thu"

--- a/test/fixtures/LU-2023.json
+++ b/test/fixtures/LU-2023.json
@@ -75,7 +75,7 @@
     "date": "2023-06-23 00:00:00",
     "start": "2023-06-22T22:00:00.000Z",
     "end": "2023-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Fri"

--- a/test/fixtures/LU-2024.json
+++ b/test/fixtures/LU-2024.json
@@ -75,7 +75,7 @@
     "date": "2024-06-23 00:00:00",
     "start": "2024-06-22T22:00:00.000Z",
     "end": "2024-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Sun"

--- a/test/fixtures/LU-2025.json
+++ b/test/fixtures/LU-2025.json
@@ -75,7 +75,7 @@
     "date": "2025-06-23 00:00:00",
     "start": "2025-06-22T22:00:00.000Z",
     "end": "2025-06-23T22:00:00.000Z",
-    "name": "L’anniversaire du Grand-Duc",
+    "name": "Fête nationale",
     "type": "public",
     "rule": "06-23",
     "_weekday": "Mon"


### PR DESCRIPTION
- added translations in Luxembourgish (lb)
- added active dates
- renamed 06-23 into National Holiday ("L'anniversaire du Grand-Duc" = the Grand Duke's birthday, it is not the official name, which is "Jour de la célébration de l'anniversaire du Grand-Duc" and the Grand Duke's birthday is currently the 16 April)