### PR TITLE
11-15 is not Holidy in Japan ( Seven-Five-Three Festival, Shichigosan)

### DIFF
--- a/data/countries/JP.yaml
+++ b/data/countries/JP.yaml
@@ -314,11 +314,6 @@ holidays:
         name:
           en: Official Enthronement Ceremony of Emperor Heisei (Akihito)
           jp: 即位礼正殿の儀
-      11-15:
-        name:
-          en: Seven-Five-Three Festival
-          jp: 七五三
-        type: observance
       11-23:
         name:
           en: Labor Thanksgiving Day


### PR DESCRIPTION
Dear date-holidays's developpers,

Hi, I like this module and thanks a lot to develop this.

I use this module in my project and notice that 11-15 is ordinary day.
However, this module recognizes the day as a holiday.

Could you modify 11-15 of JP?

Best regards, Minami