### PR TITLE
Issue #168 - Workaround for import errors when using typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
   },
   "scripts": {
     "all": "npm-run-all clean yaml build lint test doc:tree doc:attrib webpack",
-    "build": "rollup -c",
+    "build": "rollup -c && yarn postbuild",
+    "postbuild": "chmod +x ./scripts/postbuild && ./scripts/postbuild",
     "changelog": "contributors && node scripts/gitlog.cjs",
     "ci": "TEST_XXL=1 npm-run-all yaml build test",
     "clean": "rimraf lib dist src/data.js",
@@ -227,7 +228,7 @@
     "mocha": "^10.1.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.2",
-    "rollup": "^2.79.1",
+    "rollup": "^3.3.0",
     "typescript": "^4.9.3",
     "watch-run": "^1.2.5",
     "webpack": "^5.75.0",

--- a/scripts/postbuild
+++ b/scripts/postbuild
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# POSTBUILD SCRIPT
+# -----------------------------------------
+#
+# This Script will change the Holidays import from
+# date-holidays-parser, adding the ".default" that is
+# missing in the file bundled by rollup.js .
+#
+
+bugged_import="require('date-holidays-parser');"
+correct_import="require('date-holidays-parser').default;"
+
+sed -i "s/${bugged_import}/${correct_import}/" "${PWD}/lib/Holidays.cjs"

--- a/src/DumbFile.js
+++ b/src/DumbFile.js
@@ -1,0 +1,8 @@
+/**
+ * Just a Dumb Class to force rollup to treat "Holidays.js" as "default" export
+ */
+export class DumbClass {
+  constructor() {
+    this.name = 'DumbClass'
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export { Holidays as default } from './Holidays.js'
+export * from './DumbFile.js'


### PR DESCRIPTION
## Summary
I investigated a little the [Issue #168](https://github.com/commenthol/date-holidays/issues/168) because I am having the same problem and it is heavily slowing down my development.

It seems like the problem is mainly related to rollup.js and the decisions it makes while bundling the files.
My changes should be seen as a workaround more than a long term fix. 

### What I did change.

1) It seems like if you have a single export in index.js, rollup.js will bundle it like this:
```
module.exports = Holidays.Holidays;
```
While by adding a second export, even if it is unused, it will correctly translate as:
```
exports.default = Holidays.Holidays;
````
which is what i think you expected to happen when the code was originally written (just like it happens in the [date-holidays-parser](https://github.com/commenthol/date-holidays-parser) library.

Thus, I added a "DumbClass" that does absolutely nothing but since it's imported it will force rollup.js to behave as expected.

2) The second fix is actually about the date-holidays-parser library. In commonjs if you export something as:
```
exports.default = Holidays.Holidays;
```
Then it expects to be imported as
```
var HolidaysParser = require('date-holidays-parser').default;
```
instead of
```
var HolidaysParser = require('date-holidays-parser');
```

I could not figure out an elegant way of force rollup to do the import right, so i wrote a fast bash script that will do the postbuild and fix the import.


### How did I test the changes. 

I checked that the ```yarn test``` is still ok, so hopefully I did not introduced any breaking change for the JS users. 

Then, I created a second project in typescript with the same configuration as the [Issue #168](https://github.com/commenthol/date-holidays/issues/168) bug reporter, imported the library locally with npm and tested my changes.


## Conclusion

Please, reach out to me if this PR is not complete. I did not had time to fully read the documentation but for what i understood I should have done every required step. 

I know this is more of a workaround, but I need this to be fixed FAST as I am currently working with this library. 

In the future, i would suggest to deprectate these default exports and create a new major version with module exports only, that are easier to manage with this whole bundle-up / typing stuff.   
I would be happy to help with that!
