### PR TITLE
fix(#168): cjs default export for typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ lib/
 .eslintcache
 .idea/
 .DS_Store
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -138,7 +138,9 @@
   },
   "scripts": {
     "all": "npm-run-all clean yaml build lint test doc:tree doc:attrib webpack",
-    "build": "rollup -c",
+    "build:rollup": "rollup -c",
+    "build:fixIndexCjs": "node ./scripts/postbuild.cjs",
+    "build": "npm-run-all build:rollup build:fixIndexCjs",
     "changelog": "contributors && node scripts/gitlog.cjs",
     "ci": "TEST_XXL=1 npm-run-all yaml build test",
     "clean": "rimraf lib dist src/data.js",

--- a/scripts/postbuild.cjs
+++ b/scripts/postbuild.cjs
@@ -1,0 +1,16 @@
+/**
+ * get rid of this script if module will be switched to pure ESM with only named
+ * exports
+ */
+
+const path = require('path')
+const fs = require('fs')
+
+const indexCjs = `
+var Holidays = require('./Holidays.cjs');
+
+module.exports = Holidays.Holidays;
+module.exports.default = Holidays.Holidays;
+`
+
+fs.writeFileSync(path.resolve(__dirname, '../lib/index.cjs'), indexCjs, 'utf8')

--- a/test/indexCjs.spec.cjs
+++ b/test/indexCjs.spec.cjs
@@ -1,0 +1,17 @@
+const assert = require('assert')
+
+describe('cjs', function () {
+  it('module.exports', function () {
+    const Holidays = require('../lib/index.cjs')
+    const hd = new Holidays()
+    const countries = hd.getCountries()
+    assert.ok(Object.keys(countries).length > 100)
+  })
+
+  it('exports.default', function () {
+    const Holidays = require('../lib/index.cjs').default
+    const hd = new Holidays()
+    const countries = hd.getCountries()
+    assert.ok(Object.keys(countries).length > 100)
+  })
+})


### PR DESCRIPTION
This fix adds a `exports.default` to lib/index.cjs to mitigate #168 

@akaSomix Could you please test this and let me know if this could be a potential fix for the issue?