### PR TITLE
2nd of january and 27th of dec is a bank holiday

### DIFF
--- a/data/countries/IE.yaml
+++ b/data/countries/IE.yaml
@@ -16,6 +16,10 @@ holidays:
     days:
       01-01:
         _name: 01-01
+      1st monday in January:
+        name:
+          en: Bank Holiday
+        type: bank
       03-17:
         name:
           en: St. Patrick’s Day
@@ -59,10 +63,7 @@ holidays:
           en: St. Stephen's Day
         substitute: true
         type: bank
-      # Note that this is NOT "12-27 and if saturday..." (no and). This is
-      # becuase this is not a substitute for another holiday but a bank holiday
-      # in its own right which always falls on the work week.
-      12-27 if saturday then next monday if sunday then next tuesday:
+      12-27 and if saturday then next monday if sunday then next tuesday:
         name:
           en: Christmas Bank Holiday
         type: bank

--- a/test/fixtures/IE-2015.json
+++ b/test/fixtures/IE-2015.json
@@ -9,6 +9,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2015-01-05 00:00:00",
+    "start": "2015-01-05T00:00:00.000Z",
+    "end": "2015-01-06T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2015-03-15 00:00:00",
     "start": "2015-03-15T00:00:00.000Z",
     "end": "2015-03-16T00:00:00.000Z",
@@ -117,6 +126,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2015-12-27 00:00:00",
+    "start": "2015-12-27T00:00:00.000Z",
+    "end": "2015-12-28T00:00:00.000Z",
+    "name": "Christmas Bank Holiday",
+    "type": "bank",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-12-28 00:00:00",
     "start": "2015-12-28T00:00:00.000Z",
     "end": "2015-12-29T00:00:00.000Z",
@@ -132,7 +150,7 @@
     "end": "2015-12-30T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2016.json
+++ b/test/fixtures/IE-2016.json
@@ -9,6 +9,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2016-01-04 00:00:00",
+    "start": "2016-01-04T00:00:00.000Z",
+    "end": "2016-01-05T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2016-03-06 00:00:00",
     "start": "2016-03-06T00:00:00.000Z",
     "end": "2016-03-07T00:00:00.000Z",
@@ -122,7 +131,7 @@
     "end": "2016-12-28T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2017.json
+++ b/test/fixtures/IE-2017.json
@@ -9,6 +9,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T00:00:00.000Z",
+    "end": "2017-01-03T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2017-03-17 00:00:00",
     "start": "2017-03-17T00:00:00.000Z",
     "end": "2017-03-18T00:00:00.000Z",
@@ -122,7 +131,7 @@
     "end": "2017-12-28T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/IE-2018.json
+++ b/test/fixtures/IE-2018.json
@@ -3,6 +3,15 @@
     "date": "2018-01-01 00:00:00",
     "start": "2018-01-01T00:00:00.000Z",
     "end": "2018-01-02T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T00:00:00.000Z",
+    "end": "2018-01-02T00:00:00.000Z",
     "name": "New Year's Day",
     "type": "public",
     "rule": "01-01",
@@ -132,7 +141,7 @@
     "end": "2018-12-28T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/IE-2019.json
+++ b/test/fixtures/IE-2019.json
@@ -9,6 +9,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2019-01-07 00:00:00",
+    "start": "2019-01-07T00:00:00.000Z",
+    "end": "2019-01-08T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2019-03-17 00:00:00",
     "start": "2019-03-17T00:00:00.000Z",
     "end": "2019-03-18T00:00:00.000Z",
@@ -132,7 +141,7 @@
     "end": "2019-12-28T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/IE-2020.json
+++ b/test/fixtures/IE-2020.json
@@ -9,6 +9,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2020-01-06 00:00:00",
+    "start": "2020-01-06T00:00:00.000Z",
+    "end": "2020-01-07T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2020-03-17 00:00:00",
     "start": "2020-03-17T00:00:00.000Z",
     "end": "2020-03-18T00:00:00.000Z",
@@ -117,6 +126,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2020-12-27 00:00:00",
+    "start": "2020-12-27T00:00:00.000Z",
+    "end": "2020-12-28T00:00:00.000Z",
+    "name": "Christmas Bank Holiday",
+    "type": "bank",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-12-28 00:00:00",
     "start": "2020-12-28T00:00:00.000Z",
     "end": "2020-12-29T00:00:00.000Z",
@@ -132,7 +150,7 @@
     "end": "2020-12-30T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2021.json
+++ b/test/fixtures/IE-2021.json
@@ -9,6 +9,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2021-01-04 00:00:00",
+    "start": "2021-01-04T00:00:00.000Z",
+    "end": "2021-01-05T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-03-14 00:00:00",
     "start": "2021-03-14T00:00:00.000Z",
     "end": "2021-03-15T00:00:00.000Z",
@@ -122,7 +131,7 @@
     "end": "2021-12-28T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/IE-2022.json
+++ b/test/fixtures/IE-2022.json
@@ -9,6 +9,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2022-01-03 00:00:00",
+    "start": "2022-01-03T00:00:00.000Z",
+    "end": "2022-01-04T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-03-17 00:00:00",
     "start": "2022-03-17T00:00:00.000Z",
     "end": "2022-03-18T00:00:00.000Z",
@@ -122,7 +131,7 @@
     "end": "2022-12-28T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2023.json
+++ b/test/fixtures/IE-2023.json
@@ -9,6 +9,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T00:00:00.000Z",
+    "end": "2023-01-03T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-03-17 00:00:00",
     "start": "2023-03-17T00:00:00.000Z",
     "end": "2023-03-18T00:00:00.000Z",
@@ -122,7 +131,7 @@
     "end": "2023-12-28T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/IE-2024.json
+++ b/test/fixtures/IE-2024.json
@@ -3,6 +3,15 @@
     "date": "2024-01-01 00:00:00",
     "start": "2024-01-01T00:00:00.000Z",
     "end": "2024-01-02T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T00:00:00.000Z",
+    "end": "2024-01-02T00:00:00.000Z",
     "name": "New Year's Day",
     "type": "public",
     "rule": "01-01",
@@ -132,7 +141,7 @@
     "end": "2024-12-28T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/IE-2025.json
+++ b/test/fixtures/IE-2025.json
@@ -9,6 +9,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2025-01-06 00:00:00",
+    "start": "2025-01-06T00:00:00.000Z",
+    "end": "2025-01-07T00:00:00.000Z",
+    "name": "Bank Holiday",
+    "type": "bank",
+    "rule": "1st monday in January",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2025-03-17 00:00:00",
     "start": "2025-03-17T00:00:00.000Z",
     "end": "2025-03-18T00:00:00.000Z",
@@ -117,12 +126,21 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2025-12-27 00:00:00",
+    "start": "2025-12-27T00:00:00.000Z",
+    "end": "2025-12-28T00:00:00.000Z",
+    "name": "Christmas Bank Holiday",
+    "type": "bank",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2025-12-29 00:00:00",
     "start": "2025-12-29T00:00:00.000Z",
     "end": "2025-12-30T00:00:00.000Z",
     "name": "Christmas Bank Holiday",
     "type": "bank",
-    "rule": "12-27 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Mon"
   }
 ]


### PR DESCRIPTION
In December, even if its a week day, its a bank holiday, so the and is the correct version of the 27th.