### PR TITLE
Add flag days and missing holidays norway

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -184,6 +184,8 @@ https://id.wikipedia.org/wiki/Hari_libur_nasional_di_Indonesia
 https://ja.wikipedia.org/wiki/%E5%9B%BD%E6%B0%91%E3%81%AE%E7%A5%9D%E6%97%A5
 https://lb.wikipedia.org/wiki/Gesetzlech_Feierdeeg_zu_L%C3%ABtzebuerg
 https://nl.wikipedia.org/wiki/Feestdagen_in_Nederland
+https://no.wikipedia.org/wiki/Allehelgensaften
+https://no.wikipedia.org/wiki/Norges_offisielle_flaggdager
 https://pt.wikipedia.org/wiki/Cabo_Verde#Feriados
 https://pt.wikipedia.org/wiki/Feriados_em_Angola
 https://pt.wikipedia.org/wiki/Feriados_no_Brasil

--- a/data/countries/NO.yaml
+++ b/data/countries/NO.yaml
@@ -3,6 +3,9 @@ holidays:
   # @source https://no.wikipedia.org/wiki/Arbeidernes_internasjonale_kampdag
   # @source https://no.wikipedia.org/wiki/17._mai_(grunnlovsdag)
   # @source https://no.wikipedia.org/wiki/P%C3%A5skeaften
+  # @source https://www.timeanddate.com/holidays/norway/2023
+  # @attrib https://no.wikipedia.org/wiki/Norges_offisielle_flaggdager
+  # @attrib https://no.wikipedia.org/wiki/Allehelgensaften
   NO:
     names:
       no: Norge
@@ -15,13 +18,36 @@ holidays:
     days:
       01-01:
         _name: 01-01
+      01-21:
+        name:
+          no: H.K.H. prinsesse Ingrid Alexandra
+          en: Birthday of Princess Ingrid Alexandra
+        type: observance
+      02-06:
+        name:
+          no: Samefolkets dag
+          en: Day of the Sami people
+        type: observance
       2nd sunday in February:
         _name: Mothers Day
         type: observance
+      02-14:
+        _name: 02-14
+        type: observance
+      02-21:
+        name:
+          no: H.M. kong Harald V
+          en: Birthday of King Harald V
       easter -49:
         name:
           no: Fastelavn
           en: Carnival
+        type: observance
+      easter -46:
+        _name: easter -46
+        type: observance
+      03-08:
+        _name: 03-08
         type: observance
       easter -7:
         _name: easter -7
@@ -34,6 +60,9 @@ holidays:
         _name: easter
       easter 1:
         _name: easter 1
+      04-01:
+        _name: 04-01
+        type: observance
       05-01:
         _name: 05-01
       05-08:
@@ -41,18 +70,46 @@ holidays:
         type: observance
       05-17:
         _name: Constitution Day
-        name:
-          no: 17. mai
       easter 39:
         _name: easter 39
       easter 49:
         _name: easter 49
       easter 50:
         _name: easter 50
+      06-07:
+        name:
+          no: Unionsoppløsningen
+          en: Union Dissolution Day
+        type: observance
       06-23:
         name:
           no: Sankthansaften
           en: Midsummar Eve
+        type: observance
+      07-04:
+        name:
+          no: H.M. dronning Sonja
+          en: Birthday of Queen Sonja
+        type: observance
+      07-20:
+        name:
+          no: H.K.H. kronprins Haakon Magnus
+          en: Birthday of Crown Prince Haakon Magnus
+        type: observance
+      07-29:
+        name:
+          no: Olsok
+          en: Olsok
+        type: optional
+      07-04:
+        name:
+          no: H.K.H. kronprinsesse Mette-Marit
+          en: Birthday of Crown Princess Mette-Marit
+        type: observance
+      1st sunday in November:
+        name:
+          no: Allehelgensaften
+          en: All Saints' Day
         type: observance
       2nd sunday in November:
         _name: Fathers Day

--- a/data/countries/NO.yaml
+++ b/data/countries/NO.yaml
@@ -101,7 +101,7 @@ holidays:
           no: Olsok
           en: Olsok
         type: optional
-      07-04:
+      08-19:
         name:
           no: H.K.H. kronprinsesse Mette-Marit
           en: Birthday of Crown Princess Mette-Marit

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -106,6 +106,7 @@ names:
       hu: Valentin nap
       lb: Vältesdag
       nl: Valentijnsdag
+      no: Valentinsdag
       vi: Lễ tình nhân
   03-08:
     name:
@@ -120,6 +121,7 @@ names:
       hy: Կանանց տոն
       lb: Internationale Fraendag
       nl: Internationale Vrouwendag
+      no: Kvinnedagen
       pt: Dia Internacional da Mulher
       ro: Ziua Internationala a Femeii
       ru: Международный женский день
@@ -143,6 +145,7 @@ names:
       en: April Fools' Day
       hu: Bolondok napja
       nl: 1 April
+      no: Aprilsnarr
       sq: Dita e Gënjeshtrave
       vi: Cá tháng tư
   05-01:
@@ -490,6 +493,7 @@ names:
       is: Öskudagur
       lb: Äschermëttwoch
       nl: Aswoensdag
+      no: Askeonsdag
       pt: Quarta-feira de Cinzas
       sw: Jumatano ya Majivu
       vi: Thứ tư Lễ Tro

--- a/test/fixtures/NO-2015.json
+++ b/test/fixtures/NO-2015.json
@@ -9,6 +9,24 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2015-01-21 00:00:00",
+    "start": "2015-01-20T23:00:00.000Z",
+    "end": "2015-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-02-06 00:00:00",
+    "start": "2015-02-05T23:00:00.000Z",
+    "end": "2015-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2015-02-08 00:00:00",
     "start": "2015-02-07T23:00:00.000Z",
     "end": "2015-02-08T23:00:00.000Z",
@@ -16,6 +34,15 @@
     "type": "observance",
     "rule": "2nd sunday in February",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2015-02-14 00:00:00",
+    "start": "2015-02-13T23:00:00.000Z",
+    "end": "2015-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Sat"
   },
   {
     "date": "2015-02-15 00:00:00",
@@ -27,6 +54,33 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-17T23:00:00.000Z",
+    "end": "2015-02-18T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-02-21 00:00:00",
+    "start": "2015-02-20T23:00:00.000Z",
+    "end": "2015-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-03-08 00:00:00",
+    "start": "2015-03-07T23:00:00.000Z",
+    "end": "2015-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-03-29 00:00:00",
     "start": "2015-03-28T23:00:00.000Z",
     "end": "2015-03-29T22:00:00.000Z",
@@ -34,6 +88,15 @@
     "type": "observance",
     "rule": "easter -7",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2015-04-01 00:00:00",
+    "start": "2015-03-31T22:00:00.000Z",
+    "end": "2015-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-02 00:00:00",
@@ -102,7 +165,7 @@
     "date": "2015-05-17 00:00:00",
     "start": "2015-05-16T22:00:00.000Z",
     "end": "2015-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Sun"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-07 00:00:00",
+    "start": "2015-06-06T22:00:00.000Z",
+    "end": "2015-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-06-23 00:00:00",
     "start": "2015-06-22T22:00:00.000Z",
     "end": "2015-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2015-07-04 00:00:00",
+    "start": "2015-07-03T22:00:00.000Z",
+    "end": "2015-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-07-20 00:00:00",
+    "start": "2015-07-19T22:00:00.000Z",
+    "end": "2015-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-07-29 00:00:00",
+    "start": "2015-07-28T22:00:00.000Z",
+    "end": "2015-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-08-19 00:00:00",
+    "start": "2015-08-18T22:00:00.000Z",
+    "end": "2015-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-10-31T23:00:00.000Z",
+    "end": "2015-11-01T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2015-11-08 00:00:00",

--- a/test/fixtures/NO-2016.json
+++ b/test/fixtures/NO-2016.json
@@ -9,6 +9,24 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2016-01-21 00:00:00",
+    "start": "2016-01-20T23:00:00.000Z",
+    "end": "2016-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T23:00:00.000Z",
+    "end": "2016-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-07 00:00:00",
     "start": "2016-02-06T23:00:00.000Z",
     "end": "2016-02-07T23:00:00.000Z",
@@ -18,6 +36,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-09T23:00:00.000Z",
+    "end": "2016-02-10T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2016-02-14 00:00:00",
     "start": "2016-02-13T23:00:00.000Z",
     "end": "2016-02-14T23:00:00.000Z",
@@ -25,6 +52,33 @@
     "type": "observance",
     "rule": "2nd sunday in February",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2016-02-14 00:00:00",
+    "start": "2016-02-13T23:00:00.000Z",
+    "end": "2016-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-02-21 00:00:00",
+    "start": "2016-02-20T23:00:00.000Z",
+    "end": "2016-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-03-08 00:00:00",
+    "start": "2016-03-07T23:00:00.000Z",
+    "end": "2016-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Tue"
   },
   {
     "date": "2016-03-20 00:00:00",
@@ -70,6 +124,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2016-04-01 00:00:00",
+    "start": "2016-03-31T22:00:00.000Z",
+    "end": "2016-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Fri"
   },
   {
     "date": "2016-05-01 00:00:00",
@@ -120,9 +183,18 @@
     "date": "2016-05-17 00:00:00",
     "start": "2016-05-16T22:00:00.000Z",
     "end": "2016-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-06-07 00:00:00",
+    "start": "2016-06-06T22:00:00.000Z",
+    "end": "2016-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
     "_weekday": "Tue"
   },
   {
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2016-07-04 00:00:00",
+    "start": "2016-07-03T22:00:00.000Z",
+    "end": "2016-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-07-20 00:00:00",
+    "start": "2016-07-19T22:00:00.000Z",
+    "end": "2016-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-07-29 00:00:00",
+    "start": "2016-07-28T22:00:00.000Z",
+    "end": "2016-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-08-19 00:00:00",
+    "start": "2016-08-18T22:00:00.000Z",
+    "end": "2016-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-11-06 00:00:00",
+    "start": "2016-11-05T23:00:00.000Z",
+    "end": "2016-11-06T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2016-11-13 00:00:00",

--- a/test/fixtures/NO-2017.json
+++ b/test/fixtures/NO-2017.json
@@ -9,6 +9,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2017-01-21 00:00:00",
+    "start": "2017-01-20T23:00:00.000Z",
+    "end": "2017-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-06 00:00:00",
+    "start": "2017-02-05T23:00:00.000Z",
+    "end": "2017-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2017-02-12 00:00:00",
     "start": "2017-02-11T23:00:00.000Z",
     "end": "2017-02-12T23:00:00.000Z",
@@ -18,6 +36,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2017-02-14 00:00:00",
+    "start": "2017-02-13T23:00:00.000Z",
+    "end": "2017-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-02-21 00:00:00",
+    "start": "2017-02-20T23:00:00.000Z",
+    "end": "2017-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2017-02-26 00:00:00",
     "start": "2017-02-25T23:00:00.000Z",
     "end": "2017-02-26T23:00:00.000Z",
@@ -25,6 +61,33 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-02-28T23:00:00.000Z",
+    "end": "2017-03-01T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-03-08 00:00:00",
+    "start": "2017-03-07T23:00:00.000Z",
+    "end": "2017-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-01 00:00:00",
+    "start": "2017-03-31T22:00:00.000Z",
+    "end": "2017-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Sat"
   },
   {
     "date": "2017-04-09 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2017-05-17 00:00:00",
     "start": "2017-05-16T22:00:00.000Z",
     "end": "2017-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Wed"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-07 00:00:00",
+    "start": "2017-06-06T22:00:00.000Z",
+    "end": "2017-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2017-06-23 00:00:00",
     "start": "2017-06-22T22:00:00.000Z",
     "end": "2017-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2017-07-04 00:00:00",
+    "start": "2017-07-03T22:00:00.000Z",
+    "end": "2017-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-07-20 00:00:00",
+    "start": "2017-07-19T22:00:00.000Z",
+    "end": "2017-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-07-29 00:00:00",
+    "start": "2017-07-28T22:00:00.000Z",
+    "end": "2017-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-08-19 00:00:00",
+    "start": "2017-08-18T22:00:00.000Z",
+    "end": "2017-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-11-05 00:00:00",
+    "start": "2017-11-04T23:00:00.000Z",
+    "end": "2017-11-05T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2017-11-12 00:00:00",

--- a/test/fixtures/NO-2018.json
+++ b/test/fixtures/NO-2018.json
@@ -9,6 +9,24 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-01-21 00:00:00",
+    "start": "2018-01-20T23:00:00.000Z",
+    "end": "2018-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-02-06 00:00:00",
+    "start": "2018-02-05T23:00:00.000Z",
+    "end": "2018-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2018-02-11 00:00:00",
     "start": "2018-02-10T23:00:00.000Z",
     "end": "2018-02-11T23:00:00.000Z",
@@ -25,6 +43,42 @@
     "type": "observance",
     "rule": "2nd sunday in February",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-13T23:00:00.000Z",
+    "end": "2018-02-14T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-13T23:00:00.000Z",
+    "end": "2018-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-02-21 00:00:00",
+    "start": "2018-02-20T23:00:00.000Z",
+    "end": "2018-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-03-08 00:00:00",
+    "start": "2018-03-07T23:00:00.000Z",
+    "end": "2018-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Thu"
   },
   {
     "date": "2018-03-25 00:00:00",
@@ -52,6 +106,15 @@
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-01 00:00:00",
+    "start": "2018-03-31T22:00:00.000Z",
+    "end": "2018-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Sun"
   },
   {
     "date": "2018-04-01 00:00:00",
@@ -102,7 +165,7 @@
     "date": "2018-05-17 00:00:00",
     "start": "2018-05-16T22:00:00.000Z",
     "end": "2018-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Thu"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-07 00:00:00",
+    "start": "2018-06-06T22:00:00.000Z",
+    "end": "2018-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2018-06-23 00:00:00",
     "start": "2018-06-22T22:00:00.000Z",
     "end": "2018-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2018-07-04 00:00:00",
+    "start": "2018-07-03T22:00:00.000Z",
+    "end": "2018-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-07-20 00:00:00",
+    "start": "2018-07-19T22:00:00.000Z",
+    "end": "2018-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-07-29 00:00:00",
+    "start": "2018-07-28T22:00:00.000Z",
+    "end": "2018-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-08-19 00:00:00",
+    "start": "2018-08-18T22:00:00.000Z",
+    "end": "2018-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-11-04 00:00:00",
+    "start": "2018-11-03T23:00:00.000Z",
+    "end": "2018-11-04T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2018-11-11 00:00:00",

--- a/test/fixtures/NO-2019.json
+++ b/test/fixtures/NO-2019.json
@@ -9,6 +9,24 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2019-01-21 00:00:00",
+    "start": "2019-01-20T23:00:00.000Z",
+    "end": "2019-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-02-06 00:00:00",
+    "start": "2019-02-05T23:00:00.000Z",
+    "end": "2019-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2019-02-10 00:00:00",
     "start": "2019-02-09T23:00:00.000Z",
     "end": "2019-02-10T23:00:00.000Z",
@@ -18,6 +36,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2019-02-14 00:00:00",
+    "start": "2019-02-13T23:00:00.000Z",
+    "end": "2019-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-02-21 00:00:00",
+    "start": "2019-02-20T23:00:00.000Z",
+    "end": "2019-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2019-03-03 00:00:00",
     "start": "2019-03-02T23:00:00.000Z",
     "end": "2019-03-03T23:00:00.000Z",
@@ -25,6 +61,33 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-05T23:00:00.000Z",
+    "end": "2019-03-06T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-03-08 00:00:00",
+    "start": "2019-03-07T23:00:00.000Z",
+    "end": "2019-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-01 00:00:00",
+    "start": "2019-03-31T22:00:00.000Z",
+    "end": "2019-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Mon"
   },
   {
     "date": "2019-04-14 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2019-05-17 00:00:00",
     "start": "2019-05-16T22:00:00.000Z",
     "end": "2019-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Fri"
@@ -106,6 +169,15 @@
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-07 00:00:00",
+    "start": "2019-06-06T22:00:00.000Z",
+    "end": "2019-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Fri"
   },
   {
     "date": "2019-06-09 00:00:00",
@@ -132,6 +204,51 @@
     "name": "Sankthansaften",
     "type": "observance",
     "rule": "06-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-07-04 00:00:00",
+    "start": "2019-07-03T22:00:00.000Z",
+    "end": "2019-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-07-20 00:00:00",
+    "start": "2019-07-19T22:00:00.000Z",
+    "end": "2019-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-07-29 00:00:00",
+    "start": "2019-07-28T22:00:00.000Z",
+    "end": "2019-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-08-19 00:00:00",
+    "start": "2019-08-18T22:00:00.000Z",
+    "end": "2019-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-11-03 00:00:00",
+    "start": "2019-11-02T23:00:00.000Z",
+    "end": "2019-11-03T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/NO-2020.json
+++ b/test/fixtures/NO-2020.json
@@ -9,6 +9,24 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2020-01-21 00:00:00",
+    "start": "2020-01-20T23:00:00.000Z",
+    "end": "2020-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-06 00:00:00",
+    "start": "2020-02-05T23:00:00.000Z",
+    "end": "2020-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2020-02-09 00:00:00",
     "start": "2020-02-08T23:00:00.000Z",
     "end": "2020-02-09T23:00:00.000Z",
@@ -18,6 +36,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2020-02-14 00:00:00",
+    "start": "2020-02-13T23:00:00.000Z",
+    "end": "2020-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-02-21 00:00:00",
+    "start": "2020-02-20T23:00:00.000Z",
+    "end": "2020-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2020-02-23 00:00:00",
     "start": "2020-02-22T23:00:00.000Z",
     "end": "2020-02-23T23:00:00.000Z",
@@ -25,6 +61,33 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-25T23:00:00.000Z",
+    "end": "2020-02-26T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-03-08 00:00:00",
+    "start": "2020-03-07T23:00:00.000Z",
+    "end": "2020-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-04-01 00:00:00",
+    "start": "2020-03-31T22:00:00.000Z",
+    "end": "2020-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-05 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2020-05-17 00:00:00",
     "start": "2020-05-16T22:00:00.000Z",
     "end": "2020-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Sun"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-07 00:00:00",
+    "start": "2020-06-06T22:00:00.000Z",
+    "end": "2020-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-06-23 00:00:00",
     "start": "2020-06-22T22:00:00.000Z",
     "end": "2020-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2020-07-04 00:00:00",
+    "start": "2020-07-03T22:00:00.000Z",
+    "end": "2020-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-07-20 00:00:00",
+    "start": "2020-07-19T22:00:00.000Z",
+    "end": "2020-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-07-29 00:00:00",
+    "start": "2020-07-28T22:00:00.000Z",
+    "end": "2020-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-08-19 00:00:00",
+    "start": "2020-08-18T22:00:00.000Z",
+    "end": "2020-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-10-31T23:00:00.000Z",
+    "end": "2020-11-01T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2020-11-08 00:00:00",

--- a/test/fixtures/NO-2021.json
+++ b/test/fixtures/NO-2021.json
@@ -9,6 +9,24 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2021-01-21 00:00:00",
+    "start": "2021-01-20T23:00:00.000Z",
+    "end": "2021-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-02-06 00:00:00",
+    "start": "2021-02-05T23:00:00.000Z",
+    "end": "2021-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2021-02-14 00:00:00",
     "start": "2021-02-13T23:00:00.000Z",
     "end": "2021-02-14T23:00:00.000Z",
@@ -27,6 +45,42 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-02-14 00:00:00",
+    "start": "2021-02-13T23:00:00.000Z",
+    "end": "2021-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-16T23:00:00.000Z",
+    "end": "2021-02-17T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-02-21 00:00:00",
+    "start": "2021-02-20T23:00:00.000Z",
+    "end": "2021-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-03-08 00:00:00",
+    "start": "2021-03-07T23:00:00.000Z",
+    "end": "2021-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-03-28 00:00:00",
     "start": "2021-03-27T23:00:00.000Z",
     "end": "2021-03-28T22:00:00.000Z",
@@ -34,6 +88,15 @@
     "type": "observance",
     "rule": "easter -7",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-03-31T22:00:00.000Z",
+    "end": "2021-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Thu"
   },
   {
     "date": "2021-04-01 00:00:00",
@@ -102,7 +165,7 @@
     "date": "2021-05-17 00:00:00",
     "start": "2021-05-16T22:00:00.000Z",
     "end": "2021-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Mon"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-07 00:00:00",
+    "start": "2021-06-06T22:00:00.000Z",
+    "end": "2021-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-06-23 00:00:00",
     "start": "2021-06-22T22:00:00.000Z",
     "end": "2021-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2021-07-04 00:00:00",
+    "start": "2021-07-03T22:00:00.000Z",
+    "end": "2021-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-07-20 00:00:00",
+    "start": "2021-07-19T22:00:00.000Z",
+    "end": "2021-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-07-29 00:00:00",
+    "start": "2021-07-28T22:00:00.000Z",
+    "end": "2021-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-08-19 00:00:00",
+    "start": "2021-08-18T22:00:00.000Z",
+    "end": "2021-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-11-07 00:00:00",
+    "start": "2021-11-06T23:00:00.000Z",
+    "end": "2021-11-07T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2021-11-14 00:00:00",

--- a/test/fixtures/NO-2022.json
+++ b/test/fixtures/NO-2022.json
@@ -9,6 +9,24 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2022-01-21 00:00:00",
+    "start": "2022-01-20T23:00:00.000Z",
+    "end": "2022-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-02-06 00:00:00",
+    "start": "2022-02-05T23:00:00.000Z",
+    "end": "2022-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-02-13 00:00:00",
     "start": "2022-02-12T23:00:00.000Z",
     "end": "2022-02-13T23:00:00.000Z",
@@ -18,6 +36,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2022-02-14 00:00:00",
+    "start": "2022-02-13T23:00:00.000Z",
+    "end": "2022-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-02-21 00:00:00",
+    "start": "2022-02-20T23:00:00.000Z",
+    "end": "2022-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-02-27 00:00:00",
     "start": "2022-02-26T23:00:00.000Z",
     "end": "2022-02-27T23:00:00.000Z",
@@ -25,6 +61,33 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-01T23:00:00.000Z",
+    "end": "2022-03-02T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-03-08 00:00:00",
+    "start": "2022-03-07T23:00:00.000Z",
+    "end": "2022-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-01 00:00:00",
+    "start": "2022-03-31T22:00:00.000Z",
+    "end": "2022-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Fri"
   },
   {
     "date": "2022-04-10 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2022-05-17 00:00:00",
     "start": "2022-05-16T22:00:00.000Z",
     "end": "2022-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Tue"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-06-07 00:00:00",
+    "start": "2022-06-06T22:00:00.000Z",
+    "end": "2022-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2022-06-23 00:00:00",
     "start": "2022-06-22T22:00:00.000Z",
     "end": "2022-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2022-07-04 00:00:00",
+    "start": "2022-07-03T22:00:00.000Z",
+    "end": "2022-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-07-20 00:00:00",
+    "start": "2022-07-19T22:00:00.000Z",
+    "end": "2022-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-07-29 00:00:00",
+    "start": "2022-07-28T22:00:00.000Z",
+    "end": "2022-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-08-19 00:00:00",
+    "start": "2022-08-18T22:00:00.000Z",
+    "end": "2022-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-11-06 00:00:00",
+    "start": "2022-11-05T23:00:00.000Z",
+    "end": "2022-11-06T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2022-11-13 00:00:00",

--- a/test/fixtures/NO-2023.json
+++ b/test/fixtures/NO-2023.json
@@ -9,6 +9,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2023-01-21 00:00:00",
+    "start": "2023-01-20T23:00:00.000Z",
+    "end": "2023-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-06 00:00:00",
+    "start": "2023-02-05T23:00:00.000Z",
+    "end": "2023-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-02-12 00:00:00",
     "start": "2023-02-11T23:00:00.000Z",
     "end": "2023-02-12T23:00:00.000Z",
@@ -18,6 +36,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2023-02-14 00:00:00",
+    "start": "2023-02-13T23:00:00.000Z",
+    "end": "2023-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2023-02-19 00:00:00",
     "start": "2023-02-18T23:00:00.000Z",
     "end": "2023-02-19T23:00:00.000Z",
@@ -25,6 +52,42 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-20T23:00:00.000Z",
+    "end": "2023-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-21T23:00:00.000Z",
+    "end": "2023-02-22T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-03-08 00:00:00",
+    "start": "2023-03-07T23:00:00.000Z",
+    "end": "2023-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-04-01 00:00:00",
+    "start": "2023-03-31T22:00:00.000Z",
+    "end": "2023-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Sat"
   },
   {
     "date": "2023-04-02 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2023-05-17 00:00:00",
     "start": "2023-05-16T22:00:00.000Z",
     "end": "2023-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Wed"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-07 00:00:00",
+    "start": "2023-06-06T22:00:00.000Z",
+    "end": "2023-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2023-06-23 00:00:00",
     "start": "2023-06-22T22:00:00.000Z",
     "end": "2023-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2023-07-04 00:00:00",
+    "start": "2023-07-03T22:00:00.000Z",
+    "end": "2023-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-07-20 00:00:00",
+    "start": "2023-07-19T22:00:00.000Z",
+    "end": "2023-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-07-29 00:00:00",
+    "start": "2023-07-28T22:00:00.000Z",
+    "end": "2023-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-08-19 00:00:00",
+    "start": "2023-08-18T22:00:00.000Z",
+    "end": "2023-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-11-05 00:00:00",
+    "start": "2023-11-04T23:00:00.000Z",
+    "end": "2023-11-05T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2023-11-12 00:00:00",

--- a/test/fixtures/NO-2024.json
+++ b/test/fixtures/NO-2024.json
@@ -9,6 +9,24 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-01-21 00:00:00",
+    "start": "2024-01-20T23:00:00.000Z",
+    "end": "2024-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-02-06 00:00:00",
+    "start": "2024-02-05T23:00:00.000Z",
+    "end": "2024-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2024-02-11 00:00:00",
     "start": "2024-02-10T23:00:00.000Z",
     "end": "2024-02-11T23:00:00.000Z",
@@ -25,6 +43,42 @@
     "type": "observance",
     "rule": "2nd sunday in February",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-13T23:00:00.000Z",
+    "end": "2024-02-14T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-13T23:00:00.000Z",
+    "end": "2024-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-02-21 00:00:00",
+    "start": "2024-02-20T23:00:00.000Z",
+    "end": "2024-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-03-08 00:00:00",
+    "start": "2024-03-07T23:00:00.000Z",
+    "end": "2024-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Fri"
   },
   {
     "date": "2024-03-24 00:00:00",
@@ -72,6 +126,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-04-01 00:00:00",
+    "start": "2024-03-31T22:00:00.000Z",
+    "end": "2024-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
@@ -102,7 +165,7 @@
     "date": "2024-05-17 00:00:00",
     "start": "2024-05-16T22:00:00.000Z",
     "end": "2024-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Fri"
@@ -126,12 +189,66 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-07 00:00:00",
+    "start": "2024-06-06T22:00:00.000Z",
+    "end": "2024-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2024-06-23 00:00:00",
     "start": "2024-06-22T22:00:00.000Z",
     "end": "2024-06-23T22:00:00.000Z",
     "name": "Sankthansaften",
     "type": "observance",
     "rule": "06-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-07-04 00:00:00",
+    "start": "2024-07-03T22:00:00.000Z",
+    "end": "2024-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-07-20 00:00:00",
+    "start": "2024-07-19T22:00:00.000Z",
+    "end": "2024-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-07-29 00:00:00",
+    "start": "2024-07-28T22:00:00.000Z",
+    "end": "2024-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-08-19 00:00:00",
+    "start": "2024-08-18T22:00:00.000Z",
+    "end": "2024-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-11-03 00:00:00",
+    "start": "2024-11-02T23:00:00.000Z",
+    "end": "2024-11-03T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/NO-2025.json
+++ b/test/fixtures/NO-2025.json
@@ -9,6 +9,24 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2025-01-21 00:00:00",
+    "start": "2025-01-20T23:00:00.000Z",
+    "end": "2025-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-02-06 00:00:00",
+    "start": "2025-02-05T23:00:00.000Z",
+    "end": "2025-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2025-02-09 00:00:00",
     "start": "2025-02-08T23:00:00.000Z",
     "end": "2025-02-09T23:00:00.000Z",
@@ -18,6 +36,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2025-02-14 00:00:00",
+    "start": "2025-02-13T23:00:00.000Z",
+    "end": "2025-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-02-21 00:00:00",
+    "start": "2025-02-20T23:00:00.000Z",
+    "end": "2025-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2025-03-02 00:00:00",
     "start": "2025-03-01T23:00:00.000Z",
     "end": "2025-03-02T23:00:00.000Z",
@@ -25,6 +61,33 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-04T23:00:00.000Z",
+    "end": "2025-03-05T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-08 00:00:00",
+    "start": "2025-03-07T23:00:00.000Z",
+    "end": "2025-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-01 00:00:00",
+    "start": "2025-03-31T22:00:00.000Z",
+    "end": "2025-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Tue"
   },
   {
     "date": "2025-04-13 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2025-05-17 00:00:00",
     "start": "2025-05-16T22:00:00.000Z",
     "end": "2025-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Sat"
@@ -106,6 +169,15 @@
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-07 00:00:00",
+    "start": "2025-06-06T22:00:00.000Z",
+    "end": "2025-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Sat"
   },
   {
     "date": "2025-06-08 00:00:00",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2025-07-04 00:00:00",
+    "start": "2025-07-03T22:00:00.000Z",
+    "end": "2025-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-07-20 00:00:00",
+    "start": "2025-07-19T22:00:00.000Z",
+    "end": "2025-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-07-29 00:00:00",
+    "start": "2025-07-28T22:00:00.000Z",
+    "end": "2025-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-08-19 00:00:00",
+    "start": "2025-08-18T22:00:00.000Z",
+    "end": "2025-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-01T23:00:00.000Z",
+    "end": "2025-11-02T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2025-11-09 00:00:00",

--- a/test/fixtures/SJ-2015.json
+++ b/test/fixtures/SJ-2015.json
@@ -9,6 +9,24 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2015-01-21 00:00:00",
+    "start": "2015-01-20T23:00:00.000Z",
+    "end": "2015-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-02-06 00:00:00",
+    "start": "2015-02-05T23:00:00.000Z",
+    "end": "2015-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2015-02-08 00:00:00",
     "start": "2015-02-07T23:00:00.000Z",
     "end": "2015-02-08T23:00:00.000Z",
@@ -16,6 +34,15 @@
     "type": "observance",
     "rule": "2nd sunday in February",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2015-02-14 00:00:00",
+    "start": "2015-02-13T23:00:00.000Z",
+    "end": "2015-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Sat"
   },
   {
     "date": "2015-02-15 00:00:00",
@@ -27,6 +54,33 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-17T23:00:00.000Z",
+    "end": "2015-02-18T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-02-21 00:00:00",
+    "start": "2015-02-20T23:00:00.000Z",
+    "end": "2015-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-03-08 00:00:00",
+    "start": "2015-03-07T23:00:00.000Z",
+    "end": "2015-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-03-29 00:00:00",
     "start": "2015-03-28T23:00:00.000Z",
     "end": "2015-03-29T22:00:00.000Z",
@@ -34,6 +88,15 @@
     "type": "observance",
     "rule": "easter -7",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2015-04-01 00:00:00",
+    "start": "2015-03-31T22:00:00.000Z",
+    "end": "2015-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-02 00:00:00",
@@ -102,7 +165,7 @@
     "date": "2015-05-17 00:00:00",
     "start": "2015-05-16T22:00:00.000Z",
     "end": "2015-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Sun"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-06-07 00:00:00",
+    "start": "2015-06-06T22:00:00.000Z",
+    "end": "2015-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-06-23 00:00:00",
     "start": "2015-06-22T22:00:00.000Z",
     "end": "2015-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2015-07-04 00:00:00",
+    "start": "2015-07-03T22:00:00.000Z",
+    "end": "2015-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-07-20 00:00:00",
+    "start": "2015-07-19T22:00:00.000Z",
+    "end": "2015-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-07-29 00:00:00",
+    "start": "2015-07-28T22:00:00.000Z",
+    "end": "2015-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-08-19 00:00:00",
+    "start": "2015-08-18T22:00:00.000Z",
+    "end": "2015-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-10-31T23:00:00.000Z",
+    "end": "2015-11-01T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2015-11-08 00:00:00",

--- a/test/fixtures/SJ-2016.json
+++ b/test/fixtures/SJ-2016.json
@@ -9,6 +9,24 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2016-01-21 00:00:00",
+    "start": "2016-01-20T23:00:00.000Z",
+    "end": "2016-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-05T23:00:00.000Z",
+    "end": "2016-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-02-07 00:00:00",
     "start": "2016-02-06T23:00:00.000Z",
     "end": "2016-02-07T23:00:00.000Z",
@@ -18,6 +36,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-09T23:00:00.000Z",
+    "end": "2016-02-10T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2016-02-14 00:00:00",
     "start": "2016-02-13T23:00:00.000Z",
     "end": "2016-02-14T23:00:00.000Z",
@@ -25,6 +52,33 @@
     "type": "observance",
     "rule": "2nd sunday in February",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2016-02-14 00:00:00",
+    "start": "2016-02-13T23:00:00.000Z",
+    "end": "2016-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-02-21 00:00:00",
+    "start": "2016-02-20T23:00:00.000Z",
+    "end": "2016-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-03-08 00:00:00",
+    "start": "2016-03-07T23:00:00.000Z",
+    "end": "2016-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Tue"
   },
   {
     "date": "2016-03-20 00:00:00",
@@ -70,6 +124,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2016-04-01 00:00:00",
+    "start": "2016-03-31T22:00:00.000Z",
+    "end": "2016-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Fri"
   },
   {
     "date": "2016-05-01 00:00:00",
@@ -120,9 +183,18 @@
     "date": "2016-05-17 00:00:00",
     "start": "2016-05-16T22:00:00.000Z",
     "end": "2016-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-06-07 00:00:00",
+    "start": "2016-06-06T22:00:00.000Z",
+    "end": "2016-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
     "_weekday": "Tue"
   },
   {
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2016-07-04 00:00:00",
+    "start": "2016-07-03T22:00:00.000Z",
+    "end": "2016-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-07-20 00:00:00",
+    "start": "2016-07-19T22:00:00.000Z",
+    "end": "2016-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-07-29 00:00:00",
+    "start": "2016-07-28T22:00:00.000Z",
+    "end": "2016-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-08-19 00:00:00",
+    "start": "2016-08-18T22:00:00.000Z",
+    "end": "2016-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-11-06 00:00:00",
+    "start": "2016-11-05T23:00:00.000Z",
+    "end": "2016-11-06T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2016-11-13 00:00:00",

--- a/test/fixtures/SJ-2017.json
+++ b/test/fixtures/SJ-2017.json
@@ -9,6 +9,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2017-01-21 00:00:00",
+    "start": "2017-01-20T23:00:00.000Z",
+    "end": "2017-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-06 00:00:00",
+    "start": "2017-02-05T23:00:00.000Z",
+    "end": "2017-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2017-02-12 00:00:00",
     "start": "2017-02-11T23:00:00.000Z",
     "end": "2017-02-12T23:00:00.000Z",
@@ -18,6 +36,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2017-02-14 00:00:00",
+    "start": "2017-02-13T23:00:00.000Z",
+    "end": "2017-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-02-21 00:00:00",
+    "start": "2017-02-20T23:00:00.000Z",
+    "end": "2017-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2017-02-26 00:00:00",
     "start": "2017-02-25T23:00:00.000Z",
     "end": "2017-02-26T23:00:00.000Z",
@@ -25,6 +61,33 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-02-28T23:00:00.000Z",
+    "end": "2017-03-01T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-03-08 00:00:00",
+    "start": "2017-03-07T23:00:00.000Z",
+    "end": "2017-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-01 00:00:00",
+    "start": "2017-03-31T22:00:00.000Z",
+    "end": "2017-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Sat"
   },
   {
     "date": "2017-04-09 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2017-05-17 00:00:00",
     "start": "2017-05-16T22:00:00.000Z",
     "end": "2017-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Wed"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-06-07 00:00:00",
+    "start": "2017-06-06T22:00:00.000Z",
+    "end": "2017-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2017-06-23 00:00:00",
     "start": "2017-06-22T22:00:00.000Z",
     "end": "2017-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2017-07-04 00:00:00",
+    "start": "2017-07-03T22:00:00.000Z",
+    "end": "2017-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-07-20 00:00:00",
+    "start": "2017-07-19T22:00:00.000Z",
+    "end": "2017-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-07-29 00:00:00",
+    "start": "2017-07-28T22:00:00.000Z",
+    "end": "2017-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-08-19 00:00:00",
+    "start": "2017-08-18T22:00:00.000Z",
+    "end": "2017-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-11-05 00:00:00",
+    "start": "2017-11-04T23:00:00.000Z",
+    "end": "2017-11-05T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2017-11-12 00:00:00",

--- a/test/fixtures/SJ-2018.json
+++ b/test/fixtures/SJ-2018.json
@@ -9,6 +9,24 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-01-21 00:00:00",
+    "start": "2018-01-20T23:00:00.000Z",
+    "end": "2018-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-02-06 00:00:00",
+    "start": "2018-02-05T23:00:00.000Z",
+    "end": "2018-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2018-02-11 00:00:00",
     "start": "2018-02-10T23:00:00.000Z",
     "end": "2018-02-11T23:00:00.000Z",
@@ -25,6 +43,42 @@
     "type": "observance",
     "rule": "2nd sunday in February",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-13T23:00:00.000Z",
+    "end": "2018-02-14T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-13T23:00:00.000Z",
+    "end": "2018-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-02-21 00:00:00",
+    "start": "2018-02-20T23:00:00.000Z",
+    "end": "2018-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-03-08 00:00:00",
+    "start": "2018-03-07T23:00:00.000Z",
+    "end": "2018-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Thu"
   },
   {
     "date": "2018-03-25 00:00:00",
@@ -52,6 +106,15 @@
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-01 00:00:00",
+    "start": "2018-03-31T22:00:00.000Z",
+    "end": "2018-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Sun"
   },
   {
     "date": "2018-04-01 00:00:00",
@@ -102,7 +165,7 @@
     "date": "2018-05-17 00:00:00",
     "start": "2018-05-16T22:00:00.000Z",
     "end": "2018-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Thu"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-06-07 00:00:00",
+    "start": "2018-06-06T22:00:00.000Z",
+    "end": "2018-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2018-06-23 00:00:00",
     "start": "2018-06-22T22:00:00.000Z",
     "end": "2018-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2018-07-04 00:00:00",
+    "start": "2018-07-03T22:00:00.000Z",
+    "end": "2018-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-07-20 00:00:00",
+    "start": "2018-07-19T22:00:00.000Z",
+    "end": "2018-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-07-29 00:00:00",
+    "start": "2018-07-28T22:00:00.000Z",
+    "end": "2018-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-08-19 00:00:00",
+    "start": "2018-08-18T22:00:00.000Z",
+    "end": "2018-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-11-04 00:00:00",
+    "start": "2018-11-03T23:00:00.000Z",
+    "end": "2018-11-04T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2018-11-11 00:00:00",

--- a/test/fixtures/SJ-2019.json
+++ b/test/fixtures/SJ-2019.json
@@ -9,6 +9,24 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2019-01-21 00:00:00",
+    "start": "2019-01-20T23:00:00.000Z",
+    "end": "2019-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-02-06 00:00:00",
+    "start": "2019-02-05T23:00:00.000Z",
+    "end": "2019-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2019-02-10 00:00:00",
     "start": "2019-02-09T23:00:00.000Z",
     "end": "2019-02-10T23:00:00.000Z",
@@ -18,6 +36,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2019-02-14 00:00:00",
+    "start": "2019-02-13T23:00:00.000Z",
+    "end": "2019-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-02-21 00:00:00",
+    "start": "2019-02-20T23:00:00.000Z",
+    "end": "2019-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2019-03-03 00:00:00",
     "start": "2019-03-02T23:00:00.000Z",
     "end": "2019-03-03T23:00:00.000Z",
@@ -25,6 +61,33 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-05T23:00:00.000Z",
+    "end": "2019-03-06T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-03-08 00:00:00",
+    "start": "2019-03-07T23:00:00.000Z",
+    "end": "2019-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-01 00:00:00",
+    "start": "2019-03-31T22:00:00.000Z",
+    "end": "2019-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Mon"
   },
   {
     "date": "2019-04-14 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2019-05-17 00:00:00",
     "start": "2019-05-16T22:00:00.000Z",
     "end": "2019-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Fri"
@@ -106,6 +169,15 @@
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-07 00:00:00",
+    "start": "2019-06-06T22:00:00.000Z",
+    "end": "2019-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Fri"
   },
   {
     "date": "2019-06-09 00:00:00",
@@ -132,6 +204,51 @@
     "name": "Sankthansaften",
     "type": "observance",
     "rule": "06-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-07-04 00:00:00",
+    "start": "2019-07-03T22:00:00.000Z",
+    "end": "2019-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-07-20 00:00:00",
+    "start": "2019-07-19T22:00:00.000Z",
+    "end": "2019-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-07-29 00:00:00",
+    "start": "2019-07-28T22:00:00.000Z",
+    "end": "2019-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-08-19 00:00:00",
+    "start": "2019-08-18T22:00:00.000Z",
+    "end": "2019-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-11-03 00:00:00",
+    "start": "2019-11-02T23:00:00.000Z",
+    "end": "2019-11-03T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/SJ-2020.json
+++ b/test/fixtures/SJ-2020.json
@@ -9,6 +9,24 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2020-01-21 00:00:00",
+    "start": "2020-01-20T23:00:00.000Z",
+    "end": "2020-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-06 00:00:00",
+    "start": "2020-02-05T23:00:00.000Z",
+    "end": "2020-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2020-02-09 00:00:00",
     "start": "2020-02-08T23:00:00.000Z",
     "end": "2020-02-09T23:00:00.000Z",
@@ -18,6 +36,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2020-02-14 00:00:00",
+    "start": "2020-02-13T23:00:00.000Z",
+    "end": "2020-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-02-21 00:00:00",
+    "start": "2020-02-20T23:00:00.000Z",
+    "end": "2020-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2020-02-23 00:00:00",
     "start": "2020-02-22T23:00:00.000Z",
     "end": "2020-02-23T23:00:00.000Z",
@@ -25,6 +61,33 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-25T23:00:00.000Z",
+    "end": "2020-02-26T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-03-08 00:00:00",
+    "start": "2020-03-07T23:00:00.000Z",
+    "end": "2020-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-04-01 00:00:00",
+    "start": "2020-03-31T22:00:00.000Z",
+    "end": "2020-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-05 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2020-05-17 00:00:00",
     "start": "2020-05-16T22:00:00.000Z",
     "end": "2020-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Sun"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-07 00:00:00",
+    "start": "2020-06-06T22:00:00.000Z",
+    "end": "2020-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-06-23 00:00:00",
     "start": "2020-06-22T22:00:00.000Z",
     "end": "2020-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2020-07-04 00:00:00",
+    "start": "2020-07-03T22:00:00.000Z",
+    "end": "2020-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-07-20 00:00:00",
+    "start": "2020-07-19T22:00:00.000Z",
+    "end": "2020-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-07-29 00:00:00",
+    "start": "2020-07-28T22:00:00.000Z",
+    "end": "2020-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-08-19 00:00:00",
+    "start": "2020-08-18T22:00:00.000Z",
+    "end": "2020-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-10-31T23:00:00.000Z",
+    "end": "2020-11-01T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2020-11-08 00:00:00",

--- a/test/fixtures/SJ-2021.json
+++ b/test/fixtures/SJ-2021.json
@@ -9,6 +9,24 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2021-01-21 00:00:00",
+    "start": "2021-01-20T23:00:00.000Z",
+    "end": "2021-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-02-06 00:00:00",
+    "start": "2021-02-05T23:00:00.000Z",
+    "end": "2021-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2021-02-14 00:00:00",
     "start": "2021-02-13T23:00:00.000Z",
     "end": "2021-02-14T23:00:00.000Z",
@@ -27,6 +45,42 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-02-14 00:00:00",
+    "start": "2021-02-13T23:00:00.000Z",
+    "end": "2021-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-16T23:00:00.000Z",
+    "end": "2021-02-17T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-02-21 00:00:00",
+    "start": "2021-02-20T23:00:00.000Z",
+    "end": "2021-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-03-08 00:00:00",
+    "start": "2021-03-07T23:00:00.000Z",
+    "end": "2021-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-03-28 00:00:00",
     "start": "2021-03-27T23:00:00.000Z",
     "end": "2021-03-28T22:00:00.000Z",
@@ -34,6 +88,15 @@
     "type": "observance",
     "rule": "easter -7",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-03-31T22:00:00.000Z",
+    "end": "2021-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Thu"
   },
   {
     "date": "2021-04-01 00:00:00",
@@ -102,7 +165,7 @@
     "date": "2021-05-17 00:00:00",
     "start": "2021-05-16T22:00:00.000Z",
     "end": "2021-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Mon"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-06-07 00:00:00",
+    "start": "2021-06-06T22:00:00.000Z",
+    "end": "2021-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-06-23 00:00:00",
     "start": "2021-06-22T22:00:00.000Z",
     "end": "2021-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2021-07-04 00:00:00",
+    "start": "2021-07-03T22:00:00.000Z",
+    "end": "2021-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-07-20 00:00:00",
+    "start": "2021-07-19T22:00:00.000Z",
+    "end": "2021-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-07-29 00:00:00",
+    "start": "2021-07-28T22:00:00.000Z",
+    "end": "2021-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-08-19 00:00:00",
+    "start": "2021-08-18T22:00:00.000Z",
+    "end": "2021-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-11-07 00:00:00",
+    "start": "2021-11-06T23:00:00.000Z",
+    "end": "2021-11-07T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2021-11-14 00:00:00",

--- a/test/fixtures/SJ-2022.json
+++ b/test/fixtures/SJ-2022.json
@@ -9,6 +9,24 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2022-01-21 00:00:00",
+    "start": "2022-01-20T23:00:00.000Z",
+    "end": "2022-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-02-06 00:00:00",
+    "start": "2022-02-05T23:00:00.000Z",
+    "end": "2022-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2022-02-13 00:00:00",
     "start": "2022-02-12T23:00:00.000Z",
     "end": "2022-02-13T23:00:00.000Z",
@@ -18,6 +36,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2022-02-14 00:00:00",
+    "start": "2022-02-13T23:00:00.000Z",
+    "end": "2022-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-02-21 00:00:00",
+    "start": "2022-02-20T23:00:00.000Z",
+    "end": "2022-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-02-27 00:00:00",
     "start": "2022-02-26T23:00:00.000Z",
     "end": "2022-02-27T23:00:00.000Z",
@@ -25,6 +61,33 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-01T23:00:00.000Z",
+    "end": "2022-03-02T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-03-08 00:00:00",
+    "start": "2022-03-07T23:00:00.000Z",
+    "end": "2022-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-01 00:00:00",
+    "start": "2022-03-31T22:00:00.000Z",
+    "end": "2022-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Fri"
   },
   {
     "date": "2022-04-10 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2022-05-17 00:00:00",
     "start": "2022-05-16T22:00:00.000Z",
     "end": "2022-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Tue"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-06-07 00:00:00",
+    "start": "2022-06-06T22:00:00.000Z",
+    "end": "2022-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2022-06-23 00:00:00",
     "start": "2022-06-22T22:00:00.000Z",
     "end": "2022-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2022-07-04 00:00:00",
+    "start": "2022-07-03T22:00:00.000Z",
+    "end": "2022-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-07-20 00:00:00",
+    "start": "2022-07-19T22:00:00.000Z",
+    "end": "2022-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-07-29 00:00:00",
+    "start": "2022-07-28T22:00:00.000Z",
+    "end": "2022-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-08-19 00:00:00",
+    "start": "2022-08-18T22:00:00.000Z",
+    "end": "2022-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-11-06 00:00:00",
+    "start": "2022-11-05T23:00:00.000Z",
+    "end": "2022-11-06T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2022-11-13 00:00:00",

--- a/test/fixtures/SJ-2023.json
+++ b/test/fixtures/SJ-2023.json
@@ -9,6 +9,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2023-01-21 00:00:00",
+    "start": "2023-01-20T23:00:00.000Z",
+    "end": "2023-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-06 00:00:00",
+    "start": "2023-02-05T23:00:00.000Z",
+    "end": "2023-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-02-12 00:00:00",
     "start": "2023-02-11T23:00:00.000Z",
     "end": "2023-02-12T23:00:00.000Z",
@@ -18,6 +36,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2023-02-14 00:00:00",
+    "start": "2023-02-13T23:00:00.000Z",
+    "end": "2023-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2023-02-19 00:00:00",
     "start": "2023-02-18T23:00:00.000Z",
     "end": "2023-02-19T23:00:00.000Z",
@@ -25,6 +52,42 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-20T23:00:00.000Z",
+    "end": "2023-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-21T23:00:00.000Z",
+    "end": "2023-02-22T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-03-08 00:00:00",
+    "start": "2023-03-07T23:00:00.000Z",
+    "end": "2023-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-04-01 00:00:00",
+    "start": "2023-03-31T22:00:00.000Z",
+    "end": "2023-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Sat"
   },
   {
     "date": "2023-04-02 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2023-05-17 00:00:00",
     "start": "2023-05-16T22:00:00.000Z",
     "end": "2023-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Wed"
@@ -126,6 +189,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-06-07 00:00:00",
+    "start": "2023-06-06T22:00:00.000Z",
+    "end": "2023-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2023-06-23 00:00:00",
     "start": "2023-06-22T22:00:00.000Z",
     "end": "2023-06-23T22:00:00.000Z",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2023-07-04 00:00:00",
+    "start": "2023-07-03T22:00:00.000Z",
+    "end": "2023-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-07-20 00:00:00",
+    "start": "2023-07-19T22:00:00.000Z",
+    "end": "2023-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-07-29 00:00:00",
+    "start": "2023-07-28T22:00:00.000Z",
+    "end": "2023-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-08-19 00:00:00",
+    "start": "2023-08-18T22:00:00.000Z",
+    "end": "2023-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-11-05 00:00:00",
+    "start": "2023-11-04T23:00:00.000Z",
+    "end": "2023-11-05T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2023-11-12 00:00:00",

--- a/test/fixtures/SJ-2024.json
+++ b/test/fixtures/SJ-2024.json
@@ -9,6 +9,24 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-01-21 00:00:00",
+    "start": "2024-01-20T23:00:00.000Z",
+    "end": "2024-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-02-06 00:00:00",
+    "start": "2024-02-05T23:00:00.000Z",
+    "end": "2024-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2024-02-11 00:00:00",
     "start": "2024-02-10T23:00:00.000Z",
     "end": "2024-02-11T23:00:00.000Z",
@@ -25,6 +43,42 @@
     "type": "observance",
     "rule": "2nd sunday in February",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-13T23:00:00.000Z",
+    "end": "2024-02-14T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-13T23:00:00.000Z",
+    "end": "2024-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-02-21 00:00:00",
+    "start": "2024-02-20T23:00:00.000Z",
+    "end": "2024-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-03-08 00:00:00",
+    "start": "2024-03-07T23:00:00.000Z",
+    "end": "2024-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Fri"
   },
   {
     "date": "2024-03-24 00:00:00",
@@ -72,6 +126,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-04-01 00:00:00",
+    "start": "2024-03-31T22:00:00.000Z",
+    "end": "2024-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
@@ -102,7 +165,7 @@
     "date": "2024-05-17 00:00:00",
     "start": "2024-05-16T22:00:00.000Z",
     "end": "2024-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Fri"
@@ -126,12 +189,66 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-06-07 00:00:00",
+    "start": "2024-06-06T22:00:00.000Z",
+    "end": "2024-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2024-06-23 00:00:00",
     "start": "2024-06-22T22:00:00.000Z",
     "end": "2024-06-23T22:00:00.000Z",
     "name": "Sankthansaften",
     "type": "observance",
     "rule": "06-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-07-04 00:00:00",
+    "start": "2024-07-03T22:00:00.000Z",
+    "end": "2024-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-07-20 00:00:00",
+    "start": "2024-07-19T22:00:00.000Z",
+    "end": "2024-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-07-29 00:00:00",
+    "start": "2024-07-28T22:00:00.000Z",
+    "end": "2024-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-08-19 00:00:00",
+    "start": "2024-08-18T22:00:00.000Z",
+    "end": "2024-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-11-03 00:00:00",
+    "start": "2024-11-02T23:00:00.000Z",
+    "end": "2024-11-03T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/SJ-2025.json
+++ b/test/fixtures/SJ-2025.json
@@ -9,6 +9,24 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2025-01-21 00:00:00",
+    "start": "2025-01-20T23:00:00.000Z",
+    "end": "2025-01-21T23:00:00.000Z",
+    "name": "H.K.H. prinsesse Ingrid Alexandra",
+    "type": "observance",
+    "rule": "01-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-02-06 00:00:00",
+    "start": "2025-02-05T23:00:00.000Z",
+    "end": "2025-02-06T23:00:00.000Z",
+    "name": "Samefolkets dag",
+    "type": "observance",
+    "rule": "02-06",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2025-02-09 00:00:00",
     "start": "2025-02-08T23:00:00.000Z",
     "end": "2025-02-09T23:00:00.000Z",
@@ -18,6 +36,24 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2025-02-14 00:00:00",
+    "start": "2025-02-13T23:00:00.000Z",
+    "end": "2025-02-14T23:00:00.000Z",
+    "name": "Valentinsdag",
+    "type": "observance",
+    "rule": "02-14",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-02-21 00:00:00",
+    "start": "2025-02-20T23:00:00.000Z",
+    "end": "2025-02-21T23:00:00.000Z",
+    "name": "H.M. kong Harald V",
+    "type": "public",
+    "rule": "02-21",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2025-03-02 00:00:00",
     "start": "2025-03-01T23:00:00.000Z",
     "end": "2025-03-02T23:00:00.000Z",
@@ -25,6 +61,33 @@
     "type": "observance",
     "rule": "easter -49",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-04T23:00:00.000Z",
+    "end": "2025-03-05T23:00:00.000Z",
+    "name": "Askeonsdag",
+    "type": "observance",
+    "rule": "easter -46",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-08 00:00:00",
+    "start": "2025-03-07T23:00:00.000Z",
+    "end": "2025-03-08T23:00:00.000Z",
+    "name": "Kvinnedagen",
+    "type": "observance",
+    "rule": "03-08",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-01 00:00:00",
+    "start": "2025-03-31T22:00:00.000Z",
+    "end": "2025-04-01T22:00:00.000Z",
+    "name": "Aprilsnarr",
+    "type": "observance",
+    "rule": "04-01",
+    "_weekday": "Tue"
   },
   {
     "date": "2025-04-13 00:00:00",
@@ -93,7 +156,7 @@
     "date": "2025-05-17 00:00:00",
     "start": "2025-05-16T22:00:00.000Z",
     "end": "2025-05-17T22:00:00.000Z",
-    "name": "17. mai",
+    "name": "Grunnlovsdagen",
     "type": "public",
     "rule": "05-17",
     "_weekday": "Sat"
@@ -106,6 +169,15 @@
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-07 00:00:00",
+    "start": "2025-06-06T22:00:00.000Z",
+    "end": "2025-06-07T22:00:00.000Z",
+    "name": "Unionsoppløsningen",
+    "type": "observance",
+    "rule": "06-07",
+    "_weekday": "Sat"
   },
   {
     "date": "2025-06-08 00:00:00",
@@ -133,6 +205,51 @@
     "type": "observance",
     "rule": "06-23",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2025-07-04 00:00:00",
+    "start": "2025-07-03T22:00:00.000Z",
+    "end": "2025-07-04T22:00:00.000Z",
+    "name": "H.M. dronning Sonja",
+    "type": "observance",
+    "rule": "07-04",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-07-20 00:00:00",
+    "start": "2025-07-19T22:00:00.000Z",
+    "end": "2025-07-20T22:00:00.000Z",
+    "name": "H.K.H. kronprins Haakon Magnus",
+    "type": "observance",
+    "rule": "07-20",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-07-29 00:00:00",
+    "start": "2025-07-28T22:00:00.000Z",
+    "end": "2025-07-29T22:00:00.000Z",
+    "name": "Olsok",
+    "type": "optional",
+    "rule": "07-29",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-08-19 00:00:00",
+    "start": "2025-08-18T22:00:00.000Z",
+    "end": "2025-08-19T22:00:00.000Z",
+    "name": "H.K.H. kronprinsesse Mette-Marit",
+    "type": "observance",
+    "rule": "08-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-01T23:00:00.000Z",
+    "end": "2025-11-02T23:00:00.000Z",
+    "name": "Allehelgensaften",
+    "type": "observance",
+    "rule": "1st sunday in November",
+    "_weekday": "Sun"
   },
   {
     "date": "2025-11-09 00:00:00",


### PR DESCRIPTION
Added flag days and other missing holidays and international days.

New additions are:
- All official flag days
- Valentines, International Women's Day, and April Fools
- Other minor holidays like Allehelgensaften, and Askeonsdag

Corrections:
Name of 17. may changed from "17. mai" to "Grunnlovsdagen", to name it like it is named as a flag day.