### PR TITLE
Mark "Frauentag" as a public holiday for Berlin

### DIFF
--- a/data/countries/DE.yaml
+++ b/data/countries/DE.yaml
@@ -123,8 +123,12 @@ holidays:
       BE:
         name: Berlin
         days:
-          03-08:
-            _name: 03-08
+          frauentag:
+            _name: Frauentag
+            type: public
+            name:
+              de: Frauentag
+              en: Women's Day
             active:
               - from: 2019-01-01
           easter:


### PR DESCRIPTION
After 2019, Frauentag is considered as a public holiday in Berlin