### PR TITLE
feat: remove service reduction day in US.MD

### DIFF
--- a/data/countries/US.yaml
+++ b/data/countries/US.yaml
@@ -496,7 +496,7 @@ holidays:
           3rd monday in February:
             name:
               en: President's Day
-          friday before 1st monday before 06-01 prior to 2016:
+          friday before 1st monday before 06-01 since 2009 and prior to 2016:
             name:
               en: Service Reduction Day
           friday after 4th thursday in November:

--- a/data/countries/US.yaml
+++ b/data/countries/US.yaml
@@ -496,6 +496,9 @@ holidays:
           3rd monday in February:
             name:
               en: President's Day
+          friday before 1st monday before 06-01 prior to 2016:
+            name:
+              en: Service Reduction Day
           friday after 4th thursday in November:
             name:
               en: Native American Heritage Day

--- a/data/countries/US.yaml
+++ b/data/countries/US.yaml
@@ -496,9 +496,6 @@ holidays:
           3rd monday in February:
             name:
               en: President's Day
-          friday before 1st monday before 06-01:
-            name:
-              en: Service Reduction Day
           friday after 4th thursday in November:
             name:
               en: Native American Heritage Day

--- a/test/fixtures/US-MD-2015.json
+++ b/test/fixtures/US-MD-2015.json
@@ -86,7 +86,7 @@
     "end": "2015-05-23T04:00:00.000Z",
     "name": "Service Reduction Day",
     "type": "public",
-    "rule": "friday before 1st monday before 06-01 prior to 2016",
+    "rule": "friday before 1st monday before 06-01 since 2009 and prior to 2016",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/US-MD-2015.json
+++ b/test/fixtures/US-MD-2015.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2015-05-22 00:00:00",
+    "start": "2015-05-22T04:00:00.000Z",
+    "end": "2015-05-23T04:00:00.000Z",
+    "name": "Service Reduction Day",
+    "type": "public",
+    "rule": "friday before 1st monday before 06-01 prior to 2016",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2015-05-25 00:00:00",
     "start": "2015-05-25T04:00:00.000Z",
     "end": "2015-05-26T04:00:00.000Z",

--- a/test/fixtures/US-MD-2015.json
+++ b/test/fixtures/US-MD-2015.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2015-05-22 00:00:00",
-    "start": "2015-05-22T04:00:00.000Z",
-    "end": "2015-05-23T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2015-05-25 00:00:00",
     "start": "2015-05-25T04:00:00.000Z",
     "end": "2015-05-26T04:00:00.000Z",

--- a/test/fixtures/US-MD-2016.json
+++ b/test/fixtures/US-MD-2016.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2016-05-27 00:00:00",
-    "start": "2016-05-27T04:00:00.000Z",
-    "end": "2016-05-28T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2016-05-30 00:00:00",
     "start": "2016-05-30T04:00:00.000Z",
     "end": "2016-05-31T04:00:00.000Z",

--- a/test/fixtures/US-MD-2017.json
+++ b/test/fixtures/US-MD-2017.json
@@ -91,15 +91,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2017-05-26 00:00:00",
-    "start": "2017-05-26T04:00:00.000Z",
-    "end": "2017-05-27T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2017-05-29 00:00:00",
     "start": "2017-05-29T04:00:00.000Z",
     "end": "2017-05-30T04:00:00.000Z",

--- a/test/fixtures/US-MD-2018.json
+++ b/test/fixtures/US-MD-2018.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2018-05-25 00:00:00",
-    "start": "2018-05-25T04:00:00.000Z",
-    "end": "2018-05-26T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2018-05-28 00:00:00",
     "start": "2018-05-28T04:00:00.000Z",
     "end": "2018-05-29T04:00:00.000Z",

--- a/test/fixtures/US-MD-2019.json
+++ b/test/fixtures/US-MD-2019.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2019-05-24 00:00:00",
-    "start": "2019-05-24T04:00:00.000Z",
-    "end": "2019-05-25T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2019-05-27 00:00:00",
     "start": "2019-05-27T04:00:00.000Z",
     "end": "2019-05-28T04:00:00.000Z",

--- a/test/fixtures/US-MD-2020.json
+++ b/test/fixtures/US-MD-2020.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2020-05-22 00:00:00",
-    "start": "2020-05-22T04:00:00.000Z",
-    "end": "2020-05-23T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2020-05-25 00:00:00",
     "start": "2020-05-25T04:00:00.000Z",
     "end": "2020-05-26T04:00:00.000Z",

--- a/test/fixtures/US-MD-2021.json
+++ b/test/fixtures/US-MD-2021.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2021-05-28 00:00:00",
-    "start": "2021-05-28T04:00:00.000Z",
-    "end": "2021-05-29T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2021-05-31 00:00:00",
     "start": "2021-05-31T04:00:00.000Z",
     "end": "2021-06-01T04:00:00.000Z",

--- a/test/fixtures/US-MD-2022.json
+++ b/test/fixtures/US-MD-2022.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2022-05-27 00:00:00",
-    "start": "2022-05-27T04:00:00.000Z",
-    "end": "2022-05-28T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2022-05-30 00:00:00",
     "start": "2022-05-30T04:00:00.000Z",
     "end": "2022-05-31T04:00:00.000Z",

--- a/test/fixtures/US-MD-2023.json
+++ b/test/fixtures/US-MD-2023.json
@@ -91,15 +91,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2023-05-26 00:00:00",
-    "start": "2023-05-26T04:00:00.000Z",
-    "end": "2023-05-27T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2023-05-29 00:00:00",
     "start": "2023-05-29T04:00:00.000Z",
     "end": "2023-05-30T04:00:00.000Z",

--- a/test/fixtures/US-MD-2024.json
+++ b/test/fixtures/US-MD-2024.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2024-05-24 00:00:00",
-    "start": "2024-05-24T04:00:00.000Z",
-    "end": "2024-05-25T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2024-05-27 00:00:00",
     "start": "2024-05-27T04:00:00.000Z",
     "end": "2024-05-28T04:00:00.000Z",

--- a/test/fixtures/US-MD-2025.json
+++ b/test/fixtures/US-MD-2025.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2025-05-23 00:00:00",
-    "start": "2025-05-23T04:00:00.000Z",
-    "end": "2025-05-24T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2025-05-26 00:00:00",
     "start": "2025-05-26T04:00:00.000Z",
     "end": "2025-05-27T04:00:00.000Z",

--- a/test/fixtures/US-MD-2026.json
+++ b/test/fixtures/US-MD-2026.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2026-05-22 00:00:00",
-    "start": "2026-05-22T04:00:00.000Z",
-    "end": "2026-05-23T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2026-05-25 00:00:00",
     "start": "2026-05-25T04:00:00.000Z",
     "end": "2026-05-26T04:00:00.000Z",

--- a/test/fixtures/US-MD-2027.json
+++ b/test/fixtures/US-MD-2027.json
@@ -81,15 +81,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2027-05-28 00:00:00",
-    "start": "2027-05-28T04:00:00.000Z",
-    "end": "2027-05-29T04:00:00.000Z",
-    "name": "Service Reduction Day",
-    "type": "public",
-    "rule": "friday before 1st monday before 06-01",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2027-05-31 00:00:00",
     "start": "2027-05-31T04:00:00.000Z",
     "end": "2027-06-01T04:00:00.000Z",


### PR DESCRIPTION
This is no longer a holiday in Maryland, as seen on this list of state holidays: https://dbm.maryland.gov/employees/Pages/StateHolidays2023.aspx