### PR TITLE
[TH] Fixing wrong translation for Songkran Day

### DIFF
--- a/data/countries/TH.yaml
+++ b/data/countries/TH.yaml
@@ -19,15 +19,15 @@ holidays:
       04-13:
         name:
           en: Songkran Festival
-          th: วันจักรี
+          th: วันสงกรานต์
       04-14:
         name:
           en: Songkran Festival
-          th: วันจักรี
+          th: วันสงกรานต์
       04-15:
         name:
           en: Songkran Festival
-          th: วันจักรี
+          th: วันสงกรานต์
       05-04:
         name:
           en: Coronation Day


### PR DESCRIPTION
This PR fixes the incorrect holidays translation for Thailand's Songkran Day, which has previously been labelled as `"Chakri Memorial Day"`.