### PR TITLE
fix(BE-VLG,#424): add boxing day as observance

### DIFF
--- a/data/countries/BE.yaml
+++ b/data/countries/BE.yaml
@@ -101,6 +101,21 @@ holidays:
               fr: Fête de la Région wallonne
               nl: Feestdag van de Vlaamse Gemeenschap
             type: observance
+          11-02:
+            _name: 11-02
+            type: observance
+            note: day-off for employees of the flemish government
+          11-15:
+            name:
+              nl: Koningsdag
+              fr: Fête du Roi
+              de: Festtag des Königs
+            type: observance
+            note: day-off for employees of the flemish government
+          12-26:
+            _name: 12-26
+            type: observance
+            note: day-off for employees of the flemish government
         # regions:
         # VAN:
         #   name: Antwerp

--- a/test/fixtures/BE-VLG-2015.json
+++ b/test/fixtures/BE-VLG-2015.json
@@ -131,6 +131,7 @@
     "end": "2015-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Mon"
   },
@@ -149,6 +150,7 @@
     "end": "2015-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Sun"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2015-12-26 00:00:00",
+    "start": "2015-12-25T23:00:00.000Z",
+    "end": "2015-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/BE-VLG-2016.json
+++ b/test/fixtures/BE-VLG-2016.json
@@ -131,6 +131,7 @@
     "end": "2016-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Wed"
   },
@@ -149,6 +150,7 @@
     "end": "2016-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Tue"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-25T23:00:00.000Z",
+    "end": "2016-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/BE-VLG-2017.json
+++ b/test/fixtures/BE-VLG-2017.json
@@ -131,6 +131,7 @@
     "end": "2017-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Thu"
   },
@@ -149,6 +150,7 @@
     "end": "2017-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Wed"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2017-12-26 00:00:00",
+    "start": "2017-12-25T23:00:00.000Z",
+    "end": "2017-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/BE-VLG-2018.json
+++ b/test/fixtures/BE-VLG-2018.json
@@ -131,6 +131,7 @@
     "end": "2018-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Fri"
   },
@@ -149,6 +150,7 @@
     "end": "2018-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Thu"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2018-12-26 00:00:00",
+    "start": "2018-12-25T23:00:00.000Z",
+    "end": "2018-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/BE-VLG-2019.json
+++ b/test/fixtures/BE-VLG-2019.json
@@ -131,6 +131,7 @@
     "end": "2019-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Sat"
   },
@@ -149,6 +150,7 @@
     "end": "2019-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Fri"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2019-12-26 00:00:00",
+    "start": "2019-12-25T23:00:00.000Z",
+    "end": "2019-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/BE-VLG-2020.json
+++ b/test/fixtures/BE-VLG-2020.json
@@ -131,6 +131,7 @@
     "end": "2020-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Mon"
   },
@@ -149,6 +150,7 @@
     "end": "2020-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Sun"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2020-12-26 00:00:00",
+    "start": "2020-12-25T23:00:00.000Z",
+    "end": "2020-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/BE-VLG-2021.json
+++ b/test/fixtures/BE-VLG-2021.json
@@ -131,6 +131,7 @@
     "end": "2021-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Tue"
   },
@@ -149,6 +150,7 @@
     "end": "2021-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Mon"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2021-12-26 00:00:00",
+    "start": "2021-12-25T23:00:00.000Z",
+    "end": "2021-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/BE-VLG-2022.json
+++ b/test/fixtures/BE-VLG-2022.json
@@ -131,6 +131,7 @@
     "end": "2022-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Wed"
   },
@@ -149,6 +150,7 @@
     "end": "2022-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Tue"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-25T23:00:00.000Z",
+    "end": "2022-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/BE-VLG-2023.json
+++ b/test/fixtures/BE-VLG-2023.json
@@ -131,6 +131,7 @@
     "end": "2023-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Thu"
   },
@@ -149,6 +150,7 @@
     "end": "2023-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Wed"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2023-12-26 00:00:00",
+    "start": "2023-12-25T23:00:00.000Z",
+    "end": "2023-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/BE-VLG-2024.json
+++ b/test/fixtures/BE-VLG-2024.json
@@ -131,6 +131,7 @@
     "end": "2024-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Sat"
   },
@@ -149,6 +150,7 @@
     "end": "2024-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Fri"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2024-12-26 00:00:00",
+    "start": "2024-12-25T23:00:00.000Z",
+    "end": "2024-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/BE-VLG-2025.json
+++ b/test/fixtures/BE-VLG-2025.json
@@ -131,6 +131,7 @@
     "end": "2025-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Sun"
   },
@@ -149,6 +150,7 @@
     "end": "2025-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Sat"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2025-12-26 00:00:00",
+    "start": "2025-12-25T23:00:00.000Z",
+    "end": "2025-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/BE-VLG-2026.json
+++ b/test/fixtures/BE-VLG-2026.json
@@ -131,6 +131,7 @@
     "end": "2026-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Mon"
   },
@@ -149,6 +150,7 @@
     "end": "2026-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Sun"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2026-12-26 00:00:00",
+    "start": "2026-12-25T23:00:00.000Z",
+    "end": "2026-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/BE-VLG-2027.json
+++ b/test/fixtures/BE-VLG-2027.json
@@ -131,6 +131,7 @@
     "end": "2027-11-02T23:00:00.000Z",
     "name": "Allerzielen",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-02",
     "_weekday": "Tue"
   },
@@ -149,6 +150,7 @@
     "end": "2027-11-15T23:00:00.000Z",
     "name": "Koningsdag",
     "type": "observance",
+    "note": "day-off for employees of the flemish government",
     "rule": "11-15",
     "_weekday": "Mon"
   },
@@ -169,5 +171,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-26 00:00:00",
+    "start": "2027-12-25T23:00:00.000Z",
+    "end": "2027-12-26T23:00:00.000Z",
+    "name": "Tweede kerstdag",
+    "type": "observance",
+    "note": "day-off for employees of the flemish government",
+    "rule": "12-26",
+    "_weekday": "Sun"
   }
 ]


### PR DESCRIPTION
with note on 11-02, 11-15, 12-26 that employees of the Flemish government celebrate a day-off

Fixes #424 