### PR TITLE
Make Leopoldi-Tag optional , add notes and source

### DIFF
--- a/data/countries/AT.yaml
+++ b/data/countries/AT.yaml
@@ -81,9 +81,12 @@ holidays:
           de: Niederösterreich
           en: Lower Austria
         days:
+          # @source https://kurier.at/chronik/niederoesterreich/leopoldi-alle-feiern-nicht-alle-haben-frei/400673546
           11-15:
             name:
-              de-at: Leopold
+              de-at: Leopoldi-Tag
+            type: optional
+            note: In Niederösterreich haben nur Schüler und Beamten frei
       "4":
         names:
           de: Oberösterreich
@@ -124,6 +127,10 @@ holidays:
           de: Wien
           en: Vienna
         days:
+          # @source https://kurier.at/chronik/niederoesterreich/leopoldi-alle-feiern-nicht-alle-haben-frei/400673546
           11-15:
             name:
-              de-at: Leopold
+              de-at: Leopoldi-Tag
+              en:
+            type: optional
+            note: In Wien haben nur Schüler frei


### PR DESCRIPTION
Hi, thanks so much for this library, amazing!

A quick update to Leopoldi-Tag in Austria - this is a partial (optional) holiday, only for Schüler (students) and, in Niederösterreich, Beamten (government workers)