### PR TITLE
feat(UA): Update ukrainian holidays

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,3 +24,4 @@
   - write test case
 - [x] split project in source and data
 - [ ] New Feature: Calculus for Diwali (KE, SU, IN)
+- [ ] fix: https://en.wikipedia.org/wiki/Revised_Julian_calendars

--- a/data/countries/UA.yaml
+++ b/data/countries/UA.yaml
@@ -23,7 +23,7 @@ holidays:
         name:
           en: New Year
         substitute: true
-      julian 12-25 and if saturday, sunday then next monday:
+      julian 12-25 and if saturday, sunday then next monday prior to 2023:
         _name: julian 12-25
         substitute: true
       03-08 and if saturday, sunday then next monday:
@@ -35,7 +35,7 @@ holidays:
       05-01 and if saturday, sunday then next tuesday:
         _name: 05-01
         substitute: true
-      05-02 and if saturday, sunday then next monday:
+      05-02 and if saturday, sunday then next monday prior to 2018:
         _name: 05-01
         substitute: true
       05-09 and if saturday, sunday then next monday:
@@ -46,16 +46,29 @@ holidays:
       06-28 and if saturday, sunday then next monday:
         _name: Constitution Day
         substitute: true
+      07-15 and if saturday, sunday then next monday since 2023:
+        name:
+          en: Statehood Day
+          uk: День Української Державності
+      07-28 and if saturday, sunday then next monday prior to 2023:
+        name:
+          en: Statehood Day
+          uk: День Української Державності
       08-24 and if saturday, sunday then next monday:
         _name: Independence Day
         substitute: true
-      10-14 and if saturday, sunday then next monday:
+      10-14 and if saturday, sunday then next monday since 2015 and prior to 2023:
         name:
           uk: День захисника України
-          en: Defender of Ukraine Day
+          en: Defenders of Ukraine Day
         substitute: true
-        active:
-          - from: "2015-03-05"
+      10-01 and if saturday, sunday then next monday since 2023:
+        name:
+          uk: День захисників і захисниць України
+          en: Defenders of Ukraine Day
+        substitute: true
+      12-25 and if saturday, sunday then next monday since 2017:
+        _name: 12-25
     # states:
     # '05':
     #   name: Vinnychchyna

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -405,8 +405,9 @@ names:
       sr: Католички Божић
       sv: Juldagen
       sw: Krismasi
-      vi: Lễ Giáng Sinh
       ti: ልደት
+      uk: Різдво Христове
+      vi: Lễ Giáng Sinh
       zh: 聖誕節
   12-26:
     name:

--- a/test/fixtures/UA-2015.json
+++ b/test/fixtures/UA-2015.json
@@ -23,7 +23,7 @@
     "end": "2015-01-07T22:00:00.000Z",
     "name": "Різдво",
     "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
+    "rule": "julian 12-25 and if saturday, sunday then next monday prior to 2023",
     "_weekday": "Wed"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2015-05-02T21:00:00.000Z",
     "name": "День міжнародної солідарності трудящих",
     "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
+    "rule": "05-02 and if saturday, sunday then next monday prior to 2018",
     "_weekday": "Sat"
   },
   {
@@ -87,7 +87,7 @@
     "name": "День міжнародної солідарності трудящих (замінити день)",
     "type": "public",
     "substitute": true,
-    "rule": "05-02 and if saturday, sunday then next monday",
+    "rule": "05-02 and if saturday, sunday then next monday prior to 2018",
     "_weekday": "Mon"
   },
   {
@@ -147,6 +147,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-07-28 00:00:00",
+    "start": "2015-07-27T21:00:00.000Z",
+    "end": "2015-07-28T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-28 and if saturday, sunday then next monday prior to 2023",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2015-08-24 00:00:00",
     "start": "2015-08-23T21:00:00.000Z",
     "end": "2015-08-24T21:00:00.000Z",
@@ -161,7 +170,7 @@
     "end": "2015-10-14T21:00:00.000Z",
     "name": "День захисника України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-14 and if saturday, sunday then next monday since 2015 and prior to 2023",
     "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/UA-2016.json
+++ b/test/fixtures/UA-2016.json
@@ -33,7 +33,7 @@
     "end": "2016-01-07T22:00:00.000Z",
     "name": "Різдво",
     "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
+    "rule": "julian 12-25 and if saturday, sunday then next monday prior to 2023",
     "_weekday": "Thu"
   },
   {
@@ -78,7 +78,7 @@
     "end": "2016-05-02T21:00:00.000Z",
     "name": "День міжнародної солідарності трудящих",
     "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
+    "rule": "05-02 and if saturday, sunday then next monday prior to 2018",
     "_weekday": "Mon"
   },
   {
@@ -128,6 +128,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2016-07-28 00:00:00",
+    "start": "2016-07-27T21:00:00.000Z",
+    "end": "2016-07-28T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-28 and if saturday, sunday then next monday prior to 2023",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2016-08-24 00:00:00",
     "start": "2016-08-23T21:00:00.000Z",
     "end": "2016-08-24T21:00:00.000Z",
@@ -142,7 +151,7 @@
     "end": "2016-10-14T21:00:00.000Z",
     "name": "День захисника України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-14 and if saturday, sunday then next monday since 2015 and prior to 2023",
     "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/UA-2017.json
+++ b/test/fixtures/UA-2017.json
@@ -33,7 +33,7 @@
     "end": "2017-01-07T22:00:00.000Z",
     "name": "Різдво",
     "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
+    "rule": "julian 12-25 and if saturday, sunday then next monday prior to 2023",
     "_weekday": "Sat"
   },
   {
@@ -43,7 +43,7 @@
     "name": "Різдво (замінити день)",
     "type": "public",
     "substitute": true,
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
+    "rule": "julian 12-25 and if saturday, sunday then next monday prior to 2023",
     "_weekday": "Mon"
   },
   {
@@ -88,7 +88,7 @@
     "end": "2017-05-02T21:00:00.000Z",
     "name": "День міжнародної солідарності трудящих",
     "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
+    "rule": "05-02 and if saturday, sunday then next monday prior to 2018",
     "_weekday": "Tue"
   },
   {
@@ -128,6 +128,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2017-07-28 00:00:00",
+    "start": "2017-07-27T21:00:00.000Z",
+    "end": "2017-07-28T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-28 and if saturday, sunday then next monday prior to 2023",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2017-08-24 00:00:00",
     "start": "2017-08-23T21:00:00.000Z",
     "end": "2017-08-24T21:00:00.000Z",
@@ -142,7 +151,7 @@
     "end": "2017-10-14T21:00:00.000Z",
     "name": "День захисника України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-14 and if saturday, sunday then next monday since 2015 and prior to 2023",
     "_weekday": "Sat"
   },
   {
@@ -152,7 +161,16 @@
     "name": "День захисника України (замінити день)",
     "type": "public",
     "substitute": true,
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-14 and if saturday, sunday then next monday since 2015 and prior to 2023",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-24T22:00:00.000Z",
+    "end": "2017-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
     "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/UA-2018.json
+++ b/test/fixtures/UA-2018.json
@@ -23,7 +23,7 @@
     "end": "2018-01-07T22:00:00.000Z",
     "name": "Різдво",
     "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
+    "rule": "julian 12-25 and if saturday, sunday then next monday prior to 2023",
     "_weekday": "Sun"
   },
   {
@@ -33,7 +33,7 @@
     "name": "Різдво (замінити день)",
     "type": "public",
     "substitute": true,
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
+    "rule": "julian 12-25 and if saturday, sunday then next monday prior to 2023",
     "_weekday": "Mon"
   },
   {
@@ -73,15 +73,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2018-05-02 00:00:00",
-    "start": "2018-05-01T21:00:00.000Z",
-    "end": "2018-05-02T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих",
-    "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Wed"
-  },
-  {
     "date": "2018-05-09 00:00:00",
     "start": "2018-05-08T21:00:00.000Z",
     "end": "2018-05-09T21:00:00.000Z",
@@ -118,6 +109,24 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2018-07-28 00:00:00",
+    "start": "2018-07-27T21:00:00.000Z",
+    "end": "2018-07-28T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-28 and if saturday, sunday then next monday prior to 2023",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-07-30 00:00:00",
+    "start": "2018-07-29T21:00:00.000Z",
+    "end": "2018-07-30T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-28 and if saturday, sunday then next monday prior to 2023",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2018-08-24 00:00:00",
     "start": "2018-08-23T21:00:00.000Z",
     "end": "2018-08-24T21:00:00.000Z",
@@ -132,7 +141,7 @@
     "end": "2018-10-14T21:00:00.000Z",
     "name": "День захисника України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-14 and if saturday, sunday then next monday since 2015 and prior to 2023",
     "_weekday": "Sun"
   },
   {
@@ -142,7 +151,16 @@
     "name": "День захисника України (замінити день)",
     "type": "public",
     "substitute": true,
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-14 and if saturday, sunday then next monday since 2015 and prior to 2023",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-24T22:00:00.000Z",
+    "end": "2018-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/UA-2019.json
+++ b/test/fixtures/UA-2019.json
@@ -23,7 +23,7 @@
     "end": "2019-01-07T22:00:00.000Z",
     "name": "Різдво",
     "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
+    "rule": "julian 12-25 and if saturday, sunday then next monday prior to 2023",
     "_weekday": "Mon"
   },
   {
@@ -63,15 +63,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2019-05-02 00:00:00",
-    "start": "2019-05-01T21:00:00.000Z",
-    "end": "2019-05-02T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих",
-    "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Thu"
-  },
-  {
     "date": "2019-05-09 00:00:00",
     "start": "2019-05-08T21:00:00.000Z",
     "end": "2019-05-09T21:00:00.000Z",
@@ -108,6 +99,24 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2019-07-28 00:00:00",
+    "start": "2019-07-27T21:00:00.000Z",
+    "end": "2019-07-28T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-28 and if saturday, sunday then next monday prior to 2023",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-07-29 00:00:00",
+    "start": "2019-07-28T21:00:00.000Z",
+    "end": "2019-07-29T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-28 and if saturday, sunday then next monday prior to 2023",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2019-08-24 00:00:00",
     "start": "2019-08-23T21:00:00.000Z",
     "end": "2019-08-24T21:00:00.000Z",
@@ -132,7 +141,16 @@
     "end": "2019-10-14T21:00:00.000Z",
     "name": "День захисника України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-14 and if saturday, sunday then next monday since 2015 and prior to 2023",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-24T22:00:00.000Z",
+    "end": "2019-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/UA-2020.json
+++ b/test/fixtures/UA-2020.json
@@ -23,7 +23,7 @@
     "end": "2020-01-07T22:00:00.000Z",
     "name": "Різдво",
     "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
+    "rule": "julian 12-25 and if saturday, sunday then next monday prior to 2023",
     "_weekday": "Tue"
   },
   {
@@ -70,25 +70,6 @@
     "type": "public",
     "rule": "05-01 and if saturday, sunday then next tuesday",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-05-02 00:00:00",
-    "start": "2020-05-01T21:00:00.000Z",
-    "end": "2020-05-02T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих",
-    "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Sat"
-  },
-  {
-    "date": "2020-05-04 00:00:00",
-    "start": "2020-05-03T21:00:00.000Z",
-    "end": "2020-05-04T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих (замінити день)",
-    "type": "public",
-    "substitute": true,
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2020-05-09 00:00:00",
@@ -147,6 +128,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-07-28 00:00:00",
+    "start": "2020-07-27T21:00:00.000Z",
+    "end": "2020-07-28T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-28 and if saturday, sunday then next monday prior to 2023",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2020-08-24 00:00:00",
     "start": "2020-08-23T21:00:00.000Z",
     "end": "2020-08-24T21:00:00.000Z",
@@ -161,7 +151,16 @@
     "end": "2020-10-14T21:00:00.000Z",
     "name": "День захисника України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-14 and if saturday, sunday then next monday since 2015 and prior to 2023",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-24T22:00:00.000Z",
+    "end": "2020-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/UA-2021.json
+++ b/test/fixtures/UA-2021.json
@@ -33,7 +33,7 @@
     "end": "2021-01-07T22:00:00.000Z",
     "name": "Різдво",
     "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
+    "rule": "julian 12-25 and if saturday, sunday then next monday prior to 2023",
     "_weekday": "Thu"
   },
   {
@@ -64,31 +64,12 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2021-05-02 00:00:00",
-    "start": "2021-05-01T21:00:00.000Z",
-    "end": "2021-05-02T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих",
-    "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-05-03 00:00:00",
     "start": "2021-05-02T21:00:00.000Z",
     "end": "2021-05-03T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
     "rule": "orthodox and if sunday then next monday",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2021-05-03 00:00:00",
-    "start": "2021-05-02T21:00:00.000Z",
-    "end": "2021-05-03T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих (замінити день)",
-    "type": "public",
-    "substitute": true,
-    "rule": "05-02 and if saturday, sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -148,6 +129,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-07-28 00:00:00",
+    "start": "2021-07-27T21:00:00.000Z",
+    "end": "2021-07-28T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-28 and if saturday, sunday then next monday prior to 2023",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2021-08-24 00:00:00",
     "start": "2021-08-23T21:00:00.000Z",
     "end": "2021-08-24T21:00:00.000Z",
@@ -162,7 +152,25 @@
     "end": "2021-10-14T21:00:00.000Z",
     "name": "День захисника України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-14 and if saturday, sunday then next monday since 2015 and prior to 2023",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-24T22:00:00.000Z",
+    "end": "2021-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-12-27 00:00:00",
+    "start": "2021-12-26T22:00:00.000Z",
+    "end": "2021-12-27T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/UA-2022.json
+++ b/test/fixtures/UA-2022.json
@@ -43,7 +43,7 @@
     "end": "2022-01-07T22:00:00.000Z",
     "name": "Різдво",
     "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
+    "rule": "julian 12-25 and if saturday, sunday then next monday prior to 2023",
     "_weekday": "Fri"
   },
   {
@@ -81,15 +81,6 @@
     "type": "public",
     "rule": "05-01 and if saturday, sunday then next tuesday",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-05-02 00:00:00",
-    "start": "2022-05-01T21:00:00.000Z",
-    "end": "2022-05-02T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих",
-    "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-05-03 00:00:00",
@@ -138,6 +129,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2022-07-28 00:00:00",
+    "start": "2022-07-27T21:00:00.000Z",
+    "end": "2022-07-28T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-28 and if saturday, sunday then next monday prior to 2023",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2022-08-24 00:00:00",
     "start": "2022-08-23T21:00:00.000Z",
     "end": "2022-08-24T21:00:00.000Z",
@@ -152,7 +152,25 @@
     "end": "2022-10-14T21:00:00.000Z",
     "name": "День захисника України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-14 and if saturday, sunday then next monday since 2015 and prior to 2023",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-24T22:00:00.000Z",
+    "end": "2022-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-25T22:00:00.000Z",
+    "end": "2022-12-26T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/UA-2023.json
+++ b/test/fixtures/UA-2023.json
@@ -28,25 +28,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2023-01-07 00:00:00",
-    "start": "2023-01-06T22:00:00.000Z",
-    "end": "2023-01-07T22:00:00.000Z",
-    "name": "Різдво",
-    "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
-    "_weekday": "Sat"
-  },
-  {
-    "date": "2023-01-09 00:00:00",
-    "start": "2023-01-08T22:00:00.000Z",
-    "end": "2023-01-09T22:00:00.000Z",
-    "name": "Різдво (замінити день)",
-    "type": "public",
-    "substitute": true,
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2023-03-08 00:00:00",
     "start": "2023-03-07T22:00:00.000Z",
     "end": "2023-03-08T22:00:00.000Z",
@@ -81,15 +62,6 @@
     "type": "public",
     "rule": "05-01 and if saturday, sunday then next tuesday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-05-02 00:00:00",
-    "start": "2023-05-01T21:00:00.000Z",
-    "end": "2023-05-02T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих",
-    "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Tue"
   },
   {
     "date": "2023-05-09 00:00:00",
@@ -128,6 +100,24 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2023-07-15 00:00:00",
+    "start": "2023-07-14T21:00:00.000Z",
+    "end": "2023-07-15T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-15 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-07-17 00:00:00",
+    "start": "2023-07-16T21:00:00.000Z",
+    "end": "2023-07-17T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-15 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-08-24 00:00:00",
     "start": "2023-08-23T21:00:00.000Z",
     "end": "2023-08-24T21:00:00.000Z",
@@ -137,22 +127,31 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2023-10-14 00:00:00",
-    "start": "2023-10-13T21:00:00.000Z",
-    "end": "2023-10-14T21:00:00.000Z",
-    "name": "День захисника України",
+    "date": "2023-10-01 00:00:00",
+    "start": "2023-09-30T21:00:00.000Z",
+    "end": "2023-10-01T21:00:00.000Z",
+    "name": "День захисників і захисниць України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
-    "_weekday": "Sat"
+    "rule": "10-01 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Sun"
   },
   {
-    "date": "2023-10-16 00:00:00",
-    "start": "2023-10-15T21:00:00.000Z",
-    "end": "2023-10-16T21:00:00.000Z",
-    "name": "День захисника України (замінити день)",
+    "date": "2023-10-02 00:00:00",
+    "start": "2023-10-01T21:00:00.000Z",
+    "end": "2023-10-02T21:00:00.000Z",
+    "name": "День захисників і захисниць України (замінити день)",
     "type": "public",
     "substitute": true,
-    "rule": "10-14 and if saturday, sunday then next monday",
+    "rule": "10-01 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-24T22:00:00.000Z",
+    "end": "2023-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
     "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/UA-2024.json
+++ b/test/fixtures/UA-2024.json
@@ -18,25 +18,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2024-01-07 00:00:00",
-    "start": "2024-01-06T22:00:00.000Z",
-    "end": "2024-01-07T22:00:00.000Z",
-    "name": "Різдво",
-    "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
-    "_weekday": "Sun"
-  },
-  {
-    "date": "2024-01-08 00:00:00",
-    "start": "2024-01-07T22:00:00.000Z",
-    "end": "2024-01-08T22:00:00.000Z",
-    "name": "Різдво (замінити день)",
-    "type": "public",
-    "substitute": true,
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2024-03-08 00:00:00",
     "start": "2024-03-07T22:00:00.000Z",
     "end": "2024-03-08T22:00:00.000Z",
@@ -53,15 +34,6 @@
     "type": "public",
     "rule": "05-01 and if saturday, sunday then next tuesday",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-05-02 00:00:00",
-    "start": "2024-05-01T21:00:00.000Z",
-    "end": "2024-05-02T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих",
-    "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Thu"
   },
   {
     "date": "2024-05-05 00:00:00",
@@ -118,6 +90,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2024-07-15 00:00:00",
+    "start": "2024-07-14T21:00:00.000Z",
+    "end": "2024-07-15T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-15 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-08-24 00:00:00",
     "start": "2024-08-23T21:00:00.000Z",
     "end": "2024-08-24T21:00:00.000Z",
@@ -137,12 +118,21 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2024-10-14 00:00:00",
-    "start": "2024-10-13T21:00:00.000Z",
-    "end": "2024-10-14T21:00:00.000Z",
-    "name": "День захисника України",
+    "date": "2024-10-01 00:00:00",
+    "start": "2024-09-30T21:00:00.000Z",
+    "end": "2024-10-01T21:00:00.000Z",
+    "name": "День захисників і захисниць України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
-    "_weekday": "Mon"
+    "rule": "10-01 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-24T22:00:00.000Z",
+    "end": "2024-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/UA-2025.json
+++ b/test/fixtures/UA-2025.json
@@ -18,15 +18,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2025-01-07 00:00:00",
-    "start": "2025-01-06T22:00:00.000Z",
-    "end": "2025-01-07T22:00:00.000Z",
-    "name": "Різдво",
-    "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
-    "_weekday": "Tue"
-  },
-  {
     "date": "2025-03-08 00:00:00",
     "start": "2025-03-07T22:00:00.000Z",
     "end": "2025-03-08T22:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "public",
     "rule": "05-01 and if saturday, sunday then next tuesday",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-05-02 00:00:00",
-    "start": "2025-05-01T21:00:00.000Z",
-    "end": "2025-05-02T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих",
-    "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Fri"
   },
   {
     "date": "2025-05-09 00:00:00",
@@ -127,6 +109,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-07-15 00:00:00",
+    "start": "2025-07-14T21:00:00.000Z",
+    "end": "2025-07-15T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-15 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2025-08-24 00:00:00",
     "start": "2025-08-23T21:00:00.000Z",
     "end": "2025-08-24T21:00:00.000Z",
@@ -146,12 +137,21 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2025-10-14 00:00:00",
-    "start": "2025-10-13T21:00:00.000Z",
-    "end": "2025-10-14T21:00:00.000Z",
-    "name": "День захисника України",
+    "date": "2025-10-01 00:00:00",
+    "start": "2025-09-30T21:00:00.000Z",
+    "end": "2025-10-01T21:00:00.000Z",
+    "name": "День захисників і захисниць України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
-    "_weekday": "Tue"
+    "rule": "10-01 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-24T22:00:00.000Z",
+    "end": "2025-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/UA-2026.json
+++ b/test/fixtures/UA-2026.json
@@ -18,15 +18,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-01-07 00:00:00",
-    "start": "2026-01-06T22:00:00.000Z",
-    "end": "2026-01-07T22:00:00.000Z",
-    "name": "Різдво",
-    "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
-    "_weekday": "Wed"
-  },
-  {
     "date": "2026-03-08 00:00:00",
     "start": "2026-03-07T22:00:00.000Z",
     "end": "2026-03-08T22:00:00.000Z",
@@ -70,25 +61,6 @@
     "type": "public",
     "rule": "05-01 and if saturday, sunday then next tuesday",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-05-02 00:00:00",
-    "start": "2026-05-01T21:00:00.000Z",
-    "end": "2026-05-02T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих",
-    "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Sat"
-  },
-  {
-    "date": "2026-05-04 00:00:00",
-    "start": "2026-05-03T21:00:00.000Z",
-    "end": "2026-05-04T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих (замінити день)",
-    "type": "public",
-    "substitute": true,
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-05-09 00:00:00",
@@ -147,6 +119,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2026-07-15 00:00:00",
+    "start": "2026-07-14T21:00:00.000Z",
+    "end": "2026-07-15T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-15 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2026-08-24 00:00:00",
     "start": "2026-08-23T21:00:00.000Z",
     "end": "2026-08-24T21:00:00.000Z",
@@ -156,12 +137,21 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2026-10-14 00:00:00",
-    "start": "2026-10-13T21:00:00.000Z",
-    "end": "2026-10-14T21:00:00.000Z",
-    "name": "День захисника України",
+    "date": "2026-10-01 00:00:00",
+    "start": "2026-09-30T21:00:00.000Z",
+    "end": "2026-10-01T21:00:00.000Z",
+    "name": "День захисників і захисниць України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
-    "_weekday": "Wed"
+    "rule": "10-01 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-24T22:00:00.000Z",
+    "end": "2026-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/UA-2027.json
+++ b/test/fixtures/UA-2027.json
@@ -28,15 +28,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2027-01-07 00:00:00",
-    "start": "2027-01-06T22:00:00.000Z",
-    "end": "2027-01-07T22:00:00.000Z",
-    "name": "Різдво",
-    "type": "public",
-    "rule": "julian 12-25 and if saturday, sunday then next monday",
-    "_weekday": "Thu"
-  },
-  {
     "date": "2027-03-08 00:00:00",
     "start": "2027-03-07T22:00:00.000Z",
     "end": "2027-03-08T22:00:00.000Z",
@@ -64,31 +55,12 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2027-05-02 00:00:00",
-    "start": "2027-05-01T21:00:00.000Z",
-    "end": "2027-05-02T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих",
-    "type": "public",
-    "rule": "05-02 and if saturday, sunday then next monday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-05-03 00:00:00",
     "start": "2027-05-02T21:00:00.000Z",
     "end": "2027-05-03T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
     "rule": "orthodox and if sunday then next monday",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2027-05-03 00:00:00",
-    "start": "2027-05-02T21:00:00.000Z",
-    "end": "2027-05-03T21:00:00.000Z",
-    "name": "День міжнародної солідарності трудящих (замінити день)",
-    "type": "public",
-    "substitute": true,
-    "rule": "05-02 and if saturday, sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -148,6 +120,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2027-07-15 00:00:00",
+    "start": "2027-07-14T21:00:00.000Z",
+    "end": "2027-07-15T21:00:00.000Z",
+    "name": "День Української Державності",
+    "type": "public",
+    "rule": "07-15 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2027-08-24 00:00:00",
     "start": "2027-08-23T21:00:00.000Z",
     "end": "2027-08-24T21:00:00.000Z",
@@ -157,12 +138,30 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2027-10-14 00:00:00",
-    "start": "2027-10-13T21:00:00.000Z",
-    "end": "2027-10-14T21:00:00.000Z",
-    "name": "День захисника України",
+    "date": "2027-10-01 00:00:00",
+    "start": "2027-09-30T21:00:00.000Z",
+    "end": "2027-10-01T21:00:00.000Z",
+    "name": "День захисників і захисниць України",
     "type": "public",
-    "rule": "10-14 and if saturday, sunday then next monday",
-    "_weekday": "Thu"
+    "rule": "10-01 and if saturday, sunday then next monday since 2023",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-24T22:00:00.000Z",
+    "end": "2027-12-25T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-27 00:00:00",
+    "start": "2027-12-26T22:00:00.000Z",
+    "end": "2027-12-27T22:00:00.000Z",
+    "name": "Різдво Христове",
+    "type": "public",
+    "rule": "12-25 and if saturday, sunday then next monday since 2017",
+    "_weekday": "Mon"
   }
 ]


### PR DESCRIPTION
See https://www.kyivpost.com/post/18846

- Christmas be celebrated on December 25 instead of January 7.
- July 15 as the new date for the celebration of the Day of Ukrainian Statehood, replacing the previous date of the 28th
- Day of Defenders moved from October 14 to October 1.
- Corrected 05-02 as not being celebrated since 2018