### PR TITLE
Modify holiday name for iowa

### DIFF
--- a/data/countries/US.yaml
+++ b/data/countries/US.yaml
@@ -447,7 +447,7 @@ holidays:
               - to: "2018-10-07"
           "2nd monday in October #1":
             name:
-              en: Indigenous Peoples Day
+              en: Indigenous Peoples' Day
             active:
               - from: "2018-10-08"
       KS:

--- a/data/countries/US.yaml
+++ b/data/countries/US.yaml
@@ -439,6 +439,7 @@ holidays:
           02-12:
             name:
               en: Lincoln's Birthday
+          # https://www.desmoinesregister.com/story/news/2018/10/08/iowa-indigenous-peoples-day-columbus-day-kim-reynolds/1565615002/
           2nd monday in October:
             name:
               en: Columbus Day
@@ -446,7 +447,7 @@ holidays:
               - to: "2018-10-07"
           "2nd monday in October #1":
             name:
-              en: Indigenous Peoples' Day
+              en: Indigenous Peoples Day
             active:
               - from: "2018-10-08"
       KS:

--- a/data/countries/US.yaml
+++ b/data/countries/US.yaml
@@ -439,6 +439,16 @@ holidays:
           02-12:
             name:
               en: Lincoln's Birthday
+          2nd monday in October:
+            name:
+              en: Columbus Day
+            active:
+              - to: "2018-10-07"
+          "2nd monday in October #1":
+            name:
+              en: Indigenous Peoples' Day
+            active:
+              - from: "2018-10-08"
       KS:
         name: Kansas
         zones:

--- a/test/fixtures/US-IA-2018.json
+++ b/test/fixtures/US-IA-2018.json
@@ -129,9 +129,9 @@
     "date": "2018-10-08 00:00:00",
     "start": "2018-10-08T05:00:00.000Z",
     "end": "2018-10-09T05:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-IA-2019.json
+++ b/test/fixtures/US-IA-2019.json
@@ -129,9 +129,9 @@
     "date": "2019-10-14 00:00:00",
     "start": "2019-10-14T05:00:00.000Z",
     "end": "2019-10-15T05:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-IA-2020.json
+++ b/test/fixtures/US-IA-2020.json
@@ -139,9 +139,9 @@
     "date": "2020-10-12 00:00:00",
     "start": "2020-10-12T05:00:00.000Z",
     "end": "2020-10-13T05:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-IA-2021.json
+++ b/test/fixtures/US-IA-2021.json
@@ -158,9 +158,9 @@
     "date": "2021-10-11 00:00:00",
     "start": "2021-10-11T05:00:00.000Z",
     "end": "2021-10-12T05:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-IA-2022.json
+++ b/test/fixtures/US-IA-2022.json
@@ -148,9 +148,9 @@
     "date": "2022-10-10 00:00:00",
     "start": "2022-10-10T05:00:00.000Z",
     "end": "2022-10-11T05:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-IA-2023.json
+++ b/test/fixtures/US-IA-2023.json
@@ -148,9 +148,9 @@
     "date": "2023-10-09 00:00:00",
     "start": "2023-10-09T05:00:00.000Z",
     "end": "2023-10-10T05:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-IA-2024.json
+++ b/test/fixtures/US-IA-2024.json
@@ -138,9 +138,9 @@
     "date": "2024-10-14 00:00:00",
     "start": "2024-10-14T05:00:00.000Z",
     "end": "2024-10-15T05:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-IA-2025.json
+++ b/test/fixtures/US-IA-2025.json
@@ -138,9 +138,9 @@
     "date": "2025-10-13 00:00:00",
     "start": "2025-10-13T05:00:00.000Z",
     "end": "2025-10-14T05:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-IA-2026.json
+++ b/test/fixtures/US-IA-2026.json
@@ -148,9 +148,9 @@
     "date": "2026-10-12 00:00:00",
     "start": "2026-10-12T05:00:00.000Z",
     "end": "2026-10-13T05:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-IA-2027.json
+++ b/test/fixtures/US-IA-2027.json
@@ -158,9 +158,9 @@
     "date": "2027-10-11 00:00:00",
     "start": "2027-10-11T05:00:00.000Z",
     "end": "2027-10-12T05:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {


### PR DESCRIPTION
Since 2018, Iowa (US.IA) has recognized the second Monday in October as `Indigenous Peoples Day`, not 'Columbus Day`. This PR updates US.yaml to reflect this and adds an explanatory source.