### PR TITLE
Add indigenous peoples day for some US states

### DIFF
--- a/data/countries/US.yaml
+++ b/data/countries/US.yaml
@@ -543,7 +543,7 @@ holidays:
               - to: "2017-01-01"
           "2nd monday in October #1":
             name:
-              en: Indigenous Peoples’ Day
+              en: Indigenous Peoples' Day
             active:
               - from: "2017-01-01"
       MS:

--- a/data/countries/US.yaml
+++ b/data/countries/US.yaml
@@ -291,6 +291,17 @@ holidays:
           04-16:
             name:
               en: Emancipation Day
+          2nd monday in October:
+            name:
+              en: Columbus Day
+            active:
+              - to: "2019-10-08"
+            #https://www.cnn.com/2021/10/11/us/indigenous-peoples-day-2021-states-trnd/index.html
+          "2nd monday in October #1":
+            name:
+              en: Indigenous Peoples' Day
+            active:
+              - from: "2019-10-09"
       FL:
         name: Florida
         days:
@@ -488,6 +499,12 @@ holidays:
           3rd monday in April:
             name:
               en: Patriots' Day
+          #https://www.maine.gov/governor/mills/news/governor-mills-recognizes-indigenous-peoples-day-2021-10-11
+          "2nd monday in October #1":
+            name:
+              en: Indigenous Peoples' Day
+            active:
+              - from: "2019-04-26"
       MD:
         name: Maryland
         zones:
@@ -661,6 +678,12 @@ holidays:
           3rd monday in February:
             name:
               en: Presidents' Day
+          #https://www.governor.state.nm.us/2020/10/12/gov-issues-statement-as-new-mexico-celebrates-indigenous-peoples-day/
+          "2nd monday in October #1":
+            name:
+              en: Indigenous Peoples' Day
+            active:
+              - from: "2019-04-01"
           friday after 4th thursday in November:
             name:
               en: Day after Thanksgiving

--- a/test/fixtures/US-DC-2019.json
+++ b/test/fixtures/US-DC-2019.json
@@ -129,9 +129,9 @@
     "date": "2019-10-14 00:00:00",
     "start": "2019-10-14T04:00:00.000Z",
     "end": "2019-10-15T04:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-DC-2020.json
+++ b/test/fixtures/US-DC-2020.json
@@ -139,9 +139,9 @@
     "date": "2020-10-12 00:00:00",
     "start": "2020-10-12T04:00:00.000Z",
     "end": "2020-10-13T04:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-DC-2021.json
+++ b/test/fixtures/US-DC-2021.json
@@ -158,9 +158,9 @@
     "date": "2021-10-11 00:00:00",
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-DC-2022.json
+++ b/test/fixtures/US-DC-2022.json
@@ -148,9 +148,9 @@
     "date": "2022-10-10 00:00:00",
     "start": "2022-10-10T04:00:00.000Z",
     "end": "2022-10-11T04:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-DC-2023.json
+++ b/test/fixtures/US-DC-2023.json
@@ -148,9 +148,9 @@
     "date": "2023-10-09 00:00:00",
     "start": "2023-10-09T04:00:00.000Z",
     "end": "2023-10-10T04:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-DC-2024.json
+++ b/test/fixtures/US-DC-2024.json
@@ -138,9 +138,9 @@
     "date": "2024-10-14 00:00:00",
     "start": "2024-10-14T04:00:00.000Z",
     "end": "2024-10-15T04:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-DC-2025.json
+++ b/test/fixtures/US-DC-2025.json
@@ -138,9 +138,9 @@
     "date": "2025-10-13 00:00:00",
     "start": "2025-10-13T04:00:00.000Z",
     "end": "2025-10-14T04:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-DC-2026.json
+++ b/test/fixtures/US-DC-2026.json
@@ -148,9 +148,9 @@
     "date": "2026-10-12 00:00:00",
     "start": "2026-10-12T04:00:00.000Z",
     "end": "2026-10-13T04:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-DC-2027.json
+++ b/test/fixtures/US-DC-2027.json
@@ -158,9 +158,9 @@
     "date": "2027-10-11 00:00:00",
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
-    "name": "Columbus Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
-    "rule": "2nd monday in October",
+    "rule": "2nd monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/US-ME-2019.json
+++ b/test/fixtures/US-ME-2019.json
@@ -135,6 +135,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-10-14 00:00:00",
+    "start": "2019-10-14T04:00:00.000Z",
+    "end": "2019-10-15T04:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2019-10-31 18:00:00",
     "start": "2019-10-31T22:00:00.000Z",
     "end": "2019-11-01T04:00:00.000Z",

--- a/test/fixtures/US-ME-2020.json
+++ b/test/fixtures/US-ME-2020.json
@@ -145,6 +145,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-10-12 00:00:00",
+    "start": "2020-10-12T04:00:00.000Z",
+    "end": "2020-10-13T04:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2020-10-31 18:00:00",
     "start": "2020-10-31T22:00:00.000Z",
     "end": "2020-11-01T04:00:00.000Z",

--- a/test/fixtures/US-ME-2021.json
+++ b/test/fixtures/US-ME-2021.json
@@ -164,6 +164,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-10-31 18:00:00",
     "start": "2021-10-31T22:00:00.000Z",
     "end": "2021-11-01T04:00:00.000Z",

--- a/test/fixtures/US-ME-2022.json
+++ b/test/fixtures/US-ME-2022.json
@@ -154,6 +154,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-10-10 00:00:00",
+    "start": "2022-10-10T04:00:00.000Z",
+    "end": "2022-10-11T04:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-10-31 18:00:00",
     "start": "2022-10-31T22:00:00.000Z",
     "end": "2022-11-01T04:00:00.000Z",

--- a/test/fixtures/US-ME-2023.json
+++ b/test/fixtures/US-ME-2023.json
@@ -154,6 +154,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-10-09 00:00:00",
+    "start": "2023-10-09T04:00:00.000Z",
+    "end": "2023-10-10T04:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-10-31 18:00:00",
     "start": "2023-10-31T22:00:00.000Z",
     "end": "2023-11-01T04:00:00.000Z",

--- a/test/fixtures/US-ME-2024.json
+++ b/test/fixtures/US-ME-2024.json
@@ -144,6 +144,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-10-14 00:00:00",
+    "start": "2024-10-14T04:00:00.000Z",
+    "end": "2024-10-15T04:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-10-31 18:00:00",
     "start": "2024-10-31T22:00:00.000Z",
     "end": "2024-11-01T04:00:00.000Z",

--- a/test/fixtures/US-ME-2025.json
+++ b/test/fixtures/US-ME-2025.json
@@ -144,6 +144,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-10-13 00:00:00",
+    "start": "2025-10-13T04:00:00.000Z",
+    "end": "2025-10-14T04:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2025-10-31 18:00:00",
     "start": "2025-10-31T22:00:00.000Z",
     "end": "2025-11-01T04:00:00.000Z",

--- a/test/fixtures/US-ME-2026.json
+++ b/test/fixtures/US-ME-2026.json
@@ -154,6 +154,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2026-10-12 00:00:00",
+    "start": "2026-10-12T04:00:00.000Z",
+    "end": "2026-10-13T04:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-10-31 18:00:00",
     "start": "2026-10-31T22:00:00.000Z",
     "end": "2026-11-01T04:00:00.000Z",

--- a/test/fixtures/US-ME-2027.json
+++ b/test/fixtures/US-ME-2027.json
@@ -164,6 +164,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-10-31 18:00:00",
     "start": "2027-10-31T22:00:00.000Z",
     "end": "2027-11-01T04:00:00.000Z",

--- a/test/fixtures/US-MN-2017.json
+++ b/test/fixtures/US-MN-2017.json
@@ -130,7 +130,7 @@
     "date": "2017-10-09 00:00:00",
     "start": "2017-10-09T05:00:00.000Z",
     "end": "2017-10-10T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-MN-2018.json
+++ b/test/fixtures/US-MN-2018.json
@@ -120,7 +120,7 @@
     "date": "2018-10-08 00:00:00",
     "start": "2018-10-08T05:00:00.000Z",
     "end": "2018-10-09T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-MN-2019.json
+++ b/test/fixtures/US-MN-2019.json
@@ -120,7 +120,7 @@
     "date": "2019-10-14 00:00:00",
     "start": "2019-10-14T05:00:00.000Z",
     "end": "2019-10-15T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-MN-2020.json
+++ b/test/fixtures/US-MN-2020.json
@@ -130,7 +130,7 @@
     "date": "2020-10-12 00:00:00",
     "start": "2020-10-12T05:00:00.000Z",
     "end": "2020-10-13T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-MN-2021.json
+++ b/test/fixtures/US-MN-2021.json
@@ -149,7 +149,7 @@
     "date": "2021-10-11 00:00:00",
     "start": "2021-10-11T05:00:00.000Z",
     "end": "2021-10-12T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-MN-2022.json
+++ b/test/fixtures/US-MN-2022.json
@@ -139,7 +139,7 @@
     "date": "2022-10-10 00:00:00",
     "start": "2022-10-10T05:00:00.000Z",
     "end": "2022-10-11T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-MN-2023.json
+++ b/test/fixtures/US-MN-2023.json
@@ -139,7 +139,7 @@
     "date": "2023-10-09 00:00:00",
     "start": "2023-10-09T05:00:00.000Z",
     "end": "2023-10-10T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-MN-2024.json
+++ b/test/fixtures/US-MN-2024.json
@@ -129,7 +129,7 @@
     "date": "2024-10-14 00:00:00",
     "start": "2024-10-14T05:00:00.000Z",
     "end": "2024-10-15T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-MN-2025.json
+++ b/test/fixtures/US-MN-2025.json
@@ -129,7 +129,7 @@
     "date": "2025-10-13 00:00:00",
     "start": "2025-10-13T05:00:00.000Z",
     "end": "2025-10-14T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-MN-2026.json
+++ b/test/fixtures/US-MN-2026.json
@@ -139,7 +139,7 @@
     "date": "2026-10-12 00:00:00",
     "start": "2026-10-12T05:00:00.000Z",
     "end": "2026-10-13T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-MN-2027.json
+++ b/test/fixtures/US-MN-2027.json
@@ -149,7 +149,7 @@
     "date": "2027-10-11 00:00:00",
     "start": "2027-10-11T05:00:00.000Z",
     "end": "2027-10-12T05:00:00.000Z",
-    "name": "Indigenous Peoples’ Day",
+    "name": "Indigenous Peoples' Day",
     "type": "public",
     "rule": "2nd monday in October #1",
     "_weekday": "Mon"

--- a/test/fixtures/US-NM-2019.json
+++ b/test/fixtures/US-NM-2019.json
@@ -126,6 +126,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-10-14 00:00:00",
+    "start": "2019-10-14T06:00:00.000Z",
+    "end": "2019-10-15T06:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2019-10-31 18:00:00",
     "start": "2019-11-01T00:00:00.000Z",
     "end": "2019-11-01T06:00:00.000Z",

--- a/test/fixtures/US-NM-2020.json
+++ b/test/fixtures/US-NM-2020.json
@@ -136,6 +136,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-10-12 00:00:00",
+    "start": "2020-10-12T06:00:00.000Z",
+    "end": "2020-10-13T06:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2020-10-31 18:00:00",
     "start": "2020-11-01T00:00:00.000Z",
     "end": "2020-11-01T06:00:00.000Z",

--- a/test/fixtures/US-NM-2021.json
+++ b/test/fixtures/US-NM-2021.json
@@ -155,6 +155,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T06:00:00.000Z",
+    "end": "2021-10-12T06:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-10-31 18:00:00",
     "start": "2021-11-01T00:00:00.000Z",
     "end": "2021-11-01T06:00:00.000Z",

--- a/test/fixtures/US-NM-2022.json
+++ b/test/fixtures/US-NM-2022.json
@@ -145,6 +145,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-10-10 00:00:00",
+    "start": "2022-10-10T06:00:00.000Z",
+    "end": "2022-10-11T06:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-10-31 18:00:00",
     "start": "2022-11-01T00:00:00.000Z",
     "end": "2022-11-01T06:00:00.000Z",

--- a/test/fixtures/US-NM-2023.json
+++ b/test/fixtures/US-NM-2023.json
@@ -145,6 +145,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-10-09 00:00:00",
+    "start": "2023-10-09T06:00:00.000Z",
+    "end": "2023-10-10T06:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-10-31 18:00:00",
     "start": "2023-11-01T00:00:00.000Z",
     "end": "2023-11-01T06:00:00.000Z",

--- a/test/fixtures/US-NM-2024.json
+++ b/test/fixtures/US-NM-2024.json
@@ -135,6 +135,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-10-14 00:00:00",
+    "start": "2024-10-14T06:00:00.000Z",
+    "end": "2024-10-15T06:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-10-31 18:00:00",
     "start": "2024-11-01T00:00:00.000Z",
     "end": "2024-11-01T06:00:00.000Z",

--- a/test/fixtures/US-NM-2025.json
+++ b/test/fixtures/US-NM-2025.json
@@ -135,6 +135,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-10-13 00:00:00",
+    "start": "2025-10-13T06:00:00.000Z",
+    "end": "2025-10-14T06:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2025-10-31 18:00:00",
     "start": "2025-11-01T00:00:00.000Z",
     "end": "2025-11-01T06:00:00.000Z",

--- a/test/fixtures/US-NM-2026.json
+++ b/test/fixtures/US-NM-2026.json
@@ -145,6 +145,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2026-10-12 00:00:00",
+    "start": "2026-10-12T06:00:00.000Z",
+    "end": "2026-10-13T06:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-10-31 18:00:00",
     "start": "2026-11-01T00:00:00.000Z",
     "end": "2026-11-01T06:00:00.000Z",

--- a/test/fixtures/US-NM-2027.json
+++ b/test/fixtures/US-NM-2027.json
@@ -155,6 +155,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T06:00:00.000Z",
+    "end": "2027-10-12T06:00:00.000Z",
+    "name": "Indigenous Peoples' Day",
+    "type": "public",
+    "rule": "2nd monday in October #1",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-10-31 18:00:00",
     "start": "2027-11-01T00:00:00.000Z",
     "end": "2027-11-01T06:00:00.000Z",


### PR DESCRIPTION
This PR modifies `Columbus Day` -> `Indigenous Peoples Day` for Washington DC, Maine, and New Mexico. `Active from` dates and sources are included.

Also, fixes a bad character in the holiday name for MN