### PR TITLE
fix: modify `Queen's Birthday` to `King's Birthday` in Australia

### DIFF
--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -80,6 +80,13 @@ holidays:
           2nd monday in June:
             name:
               en: Queen's Birthday
+            active:
+              - to: "2022-09-08"
+          "2nd monday in June #1":
+            name:
+              en: King's Birthday
+            active:
+              - from: "2022-09-09"
           1st monday in October:
             name:
               en: Labour Day
@@ -92,6 +99,13 @@ holidays:
           2nd monday in June:
             name:
               en: Queen's Birthday
+            active:
+              - to: "2022-09-08"
+          "2nd monday in June #1":
+            name:
+              en: King's Birthday
+            active:
+              - from: "2022-09-09"
           1st monday in August:
             name:
               en: Bank Holiday
@@ -117,6 +131,13 @@ holidays:
           2nd monday in June:
             name:
               en: Queen's Birthday
+            active:
+              - to: "2022-09-08"
+          "2nd monday in June #1":
+            name:
+              en: King's Birthday
+            active:
+              - from: "2022-09-09"
           1st monday in August:
             name:
               en: Picnic Day
@@ -152,6 +173,12 @@ holidays:
           1st monday in October:
             name:
               en: Queen's Birthday
+            active:
+              - to: "2022-09-08"
+          "1st monday in October #1":
+            name: King's Birthday
+            active:
+              - from: "2022-09-09"
           12-24 18:00:
             _name: 12-24
       # @source https://www.legislation.sa.gov.au/LZ/C/A/HOLIDAYS%20ACT%201910.aspx
@@ -167,6 +194,13 @@ holidays:
           2nd monday in June:
             name:
               en: Queen's Birthday
+            active:
+              - to: "2022-09-08"
+          "2nd monday in June #1":
+            name:
+              en: King's Birthday
+            active:
+              - from: "2022-09-09"
           1st monday in October:
             name:
               en: Labour Day
@@ -204,6 +238,13 @@ holidays:
           2nd monday in June:
             name:
               en: Queen's Birthday
+            active:
+              - to: "2022-09-08"
+          "2nd monday in June #1":
+            name:
+              en: King's Birthday
+            active:
+              - from: "2022-09-09"
           1st monday in October: false
           12-26 and if saturday then next monday if sunday then next tuesday: false
           12-26 if saturday then next monday if sunday then next tuesday:
@@ -221,6 +262,13 @@ holidays:
           2nd monday in June:
             name:
               en: Queen's Birthday
+            active:
+              - to: "2022-09-08"
+          "2nd monday in June #1":
+            name:
+              en: King's Birthday
+            active:
+              - from: "2022-09-09"
           1st monday in October: false
           # introduced in 2015-08
           # @source http://www.gazette.vic.gov.au/gazette/Gazettes2015
@@ -256,4 +304,12 @@ holidays:
             name:
               en: Queen's Birthday
             note: Might be on a different day; is proclaimed by Governor
+            active:
+              - to: "2022-09-08"
+          "monday before October #1":
+            name:
+              en: King's Birthday
+            note: Might be on a different day; is proclaimed by Governor
+            active:
+              - from: "2022-09-09"
           1st monday in October: false

--- a/test/fixtures/AU-ACT-2023.json
+++ b/test/fixtures/AU-ACT-2023.json
@@ -102,9 +102,9 @@
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:00:00.000Z",
     "end": "2023-06-12T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-ACT-2024.json
+++ b/test/fixtures/AU-ACT-2024.json
@@ -93,9 +93,9 @@
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:00:00.000Z",
     "end": "2024-06-10T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-ACT-2025.json
+++ b/test/fixtures/AU-ACT-2025.json
@@ -93,9 +93,9 @@
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:00:00.000Z",
     "end": "2025-06-09T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-ACT-2026.json
+++ b/test/fixtures/AU-ACT-2026.json
@@ -93,9 +93,9 @@
     "date": "2026-06-08 00:00:00",
     "start": "2026-06-07T14:00:00.000Z",
     "end": "2026-06-08T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-ACT-2027.json
+++ b/test/fixtures/AU-ACT-2027.json
@@ -93,9 +93,9 @@
     "date": "2027-06-14 00:00:00",
     "start": "2027-06-13T14:00:00.000Z",
     "end": "2027-06-14T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NSW-2023.json
+++ b/test/fixtures/AU-NSW-2023.json
@@ -84,9 +84,9 @@
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:00:00.000Z",
     "end": "2023-06-12T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NSW-2024.json
+++ b/test/fixtures/AU-NSW-2024.json
@@ -75,9 +75,9 @@
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:00:00.000Z",
     "end": "2024-06-10T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NSW-2025.json
+++ b/test/fixtures/AU-NSW-2025.json
@@ -75,9 +75,9 @@
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:00:00.000Z",
     "end": "2025-06-09T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NSW-2026.json
+++ b/test/fixtures/AU-NSW-2026.json
@@ -75,9 +75,9 @@
     "date": "2026-06-08 00:00:00",
     "start": "2026-06-07T14:00:00.000Z",
     "end": "2026-06-08T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NSW-2027.json
+++ b/test/fixtures/AU-NSW-2027.json
@@ -75,9 +75,9 @@
     "date": "2027-06-14 00:00:00",
     "start": "2027-06-13T14:00:00.000Z",
     "end": "2027-06-14T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NT-2023.json
+++ b/test/fixtures/AU-NT-2023.json
@@ -84,9 +84,9 @@
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:30:00.000Z",
     "end": "2023-06-12T14:30:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NT-2024.json
+++ b/test/fixtures/AU-NT-2024.json
@@ -75,9 +75,9 @@
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:30:00.000Z",
     "end": "2024-06-10T14:30:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NT-2025.json
+++ b/test/fixtures/AU-NT-2025.json
@@ -75,9 +75,9 @@
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:30:00.000Z",
     "end": "2025-06-09T14:30:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NT-2026.json
+++ b/test/fixtures/AU-NT-2026.json
@@ -75,9 +75,9 @@
     "date": "2026-06-08 00:00:00",
     "start": "2026-06-07T14:30:00.000Z",
     "end": "2026-06-08T14:30:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NT-2027.json
+++ b/test/fixtures/AU-NT-2027.json
@@ -75,9 +75,9 @@
     "date": "2027-06-14 00:00:00",
     "start": "2027-06-13T14:30:00.000Z",
     "end": "2027-06-14T14:30:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-QLD-2022.json
+++ b/test/fixtures/AU-QLD-2022.json
@@ -111,9 +111,9 @@
     "date": "2022-10-03 00:00:00",
     "start": "2022-10-02T14:00:00.000Z",
     "end": "2022-10-03T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "1st monday in October",
+    "rule": "1st monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-QLD-2023.json
+++ b/test/fixtures/AU-QLD-2023.json
@@ -102,9 +102,9 @@
     "date": "2023-10-02 00:00:00",
     "start": "2023-10-01T14:00:00.000Z",
     "end": "2023-10-02T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "1st monday in October",
+    "rule": "1st monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-QLD-2024.json
+++ b/test/fixtures/AU-QLD-2024.json
@@ -93,9 +93,9 @@
     "date": "2024-10-07 00:00:00",
     "start": "2024-10-06T14:00:00.000Z",
     "end": "2024-10-07T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "1st monday in October",
+    "rule": "1st monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-QLD-2025.json
+++ b/test/fixtures/AU-QLD-2025.json
@@ -93,9 +93,9 @@
     "date": "2025-10-06 00:00:00",
     "start": "2025-10-05T14:00:00.000Z",
     "end": "2025-10-06T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "1st monday in October",
+    "rule": "1st monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-QLD-2026.json
+++ b/test/fixtures/AU-QLD-2026.json
@@ -93,9 +93,9 @@
     "date": "2026-10-05 00:00:00",
     "start": "2026-10-04T14:00:00.000Z",
     "end": "2026-10-05T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "1st monday in October",
+    "rule": "1st monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-QLD-2027.json
+++ b/test/fixtures/AU-QLD-2027.json
@@ -93,9 +93,9 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T14:00:00.000Z",
     "end": "2027-10-04T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "1st monday in October",
+    "rule": "1st monday in October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-SA-2023.json
+++ b/test/fixtures/AU-SA-2023.json
@@ -84,9 +84,9 @@
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:30:00.000Z",
     "end": "2023-06-12T14:30:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-SA-2024.json
+++ b/test/fixtures/AU-SA-2024.json
@@ -75,9 +75,9 @@
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:30:00.000Z",
     "end": "2024-06-10T14:30:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-SA-2025.json
+++ b/test/fixtures/AU-SA-2025.json
@@ -75,9 +75,9 @@
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:30:00.000Z",
     "end": "2025-06-09T14:30:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-SA-2026.json
+++ b/test/fixtures/AU-SA-2026.json
@@ -75,9 +75,9 @@
     "date": "2026-06-08 00:00:00",
     "start": "2026-06-07T14:30:00.000Z",
     "end": "2026-06-08T14:30:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-SA-2027.json
+++ b/test/fixtures/AU-SA-2027.json
@@ -75,9 +75,9 @@
     "date": "2027-06-14 00:00:00",
     "start": "2027-06-13T14:30:00.000Z",
     "end": "2027-06-14T14:30:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-TAS-2023.json
+++ b/test/fixtures/AU-TAS-2023.json
@@ -76,9 +76,9 @@
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:00:00.000Z",
     "end": "2023-06-12T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-TAS-2024.json
+++ b/test/fixtures/AU-TAS-2024.json
@@ -76,9 +76,9 @@
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:00:00.000Z",
     "end": "2024-06-10T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-TAS-2025.json
+++ b/test/fixtures/AU-TAS-2025.json
@@ -76,9 +76,9 @@
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:00:00.000Z",
     "end": "2025-06-09T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-TAS-2026.json
+++ b/test/fixtures/AU-TAS-2026.json
@@ -76,9 +76,9 @@
     "date": "2026-06-08 00:00:00",
     "start": "2026-06-07T14:00:00.000Z",
     "end": "2026-06-08T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-TAS-2027.json
+++ b/test/fixtures/AU-TAS-2027.json
@@ -76,9 +76,9 @@
     "date": "2027-06-14 00:00:00",
     "start": "2027-06-13T14:00:00.000Z",
     "end": "2027-06-14T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-VIC-2023.json
+++ b/test/fixtures/AU-VIC-2023.json
@@ -93,9 +93,9 @@
     "date": "2023-06-12 00:00:00",
     "start": "2023-06-11T14:00:00.000Z",
     "end": "2023-06-12T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-VIC-2024.json
+++ b/test/fixtures/AU-VIC-2024.json
@@ -84,9 +84,9 @@
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T14:00:00.000Z",
     "end": "2024-06-10T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-VIC-2025.json
+++ b/test/fixtures/AU-VIC-2025.json
@@ -84,9 +84,9 @@
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T14:00:00.000Z",
     "end": "2025-06-09T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-VIC-2026.json
+++ b/test/fixtures/AU-VIC-2026.json
@@ -84,9 +84,9 @@
     "date": "2026-06-08 00:00:00",
     "start": "2026-06-07T14:00:00.000Z",
     "end": "2026-06-08T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-VIC-2027.json
+++ b/test/fixtures/AU-VIC-2027.json
@@ -84,9 +84,9 @@
     "date": "2027-06-14 00:00:00",
     "start": "2027-06-13T14:00:00.000Z",
     "end": "2027-06-14T14:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
-    "rule": "2nd monday in June",
+    "rule": "2nd monday in June #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-WA-2022.json
+++ b/test/fixtures/AU-WA-2022.json
@@ -102,10 +102,10 @@
     "date": "2022-09-26 00:00:00",
     "start": "2022-09-25T16:00:00.000Z",
     "end": "2022-09-26T16:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
     "note": "Might be on a different day; is proclaimed by Governor",
-    "rule": "monday before October",
+    "rule": "monday before October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-WA-2023.json
+++ b/test/fixtures/AU-WA-2023.json
@@ -93,10 +93,10 @@
     "date": "2023-09-25 00:00:00",
     "start": "2023-09-24T16:00:00.000Z",
     "end": "2023-09-25T16:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
     "note": "Might be on a different day; is proclaimed by Governor",
-    "rule": "monday before October",
+    "rule": "monday before October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-WA-2024.json
+++ b/test/fixtures/AU-WA-2024.json
@@ -84,10 +84,10 @@
     "date": "2024-09-30 00:00:00",
     "start": "2024-09-29T16:00:00.000Z",
     "end": "2024-09-30T16:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
     "note": "Might be on a different day; is proclaimed by Governor",
-    "rule": "monday before October",
+    "rule": "monday before October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-WA-2025.json
+++ b/test/fixtures/AU-WA-2025.json
@@ -84,10 +84,10 @@
     "date": "2025-09-29 00:00:00",
     "start": "2025-09-28T16:00:00.000Z",
     "end": "2025-09-29T16:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
     "note": "Might be on a different day; is proclaimed by Governor",
-    "rule": "monday before October",
+    "rule": "monday before October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-WA-2026.json
+++ b/test/fixtures/AU-WA-2026.json
@@ -94,10 +94,10 @@
     "date": "2026-09-28 00:00:00",
     "start": "2026-09-27T16:00:00.000Z",
     "end": "2026-09-28T16:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
     "note": "Might be on a different day; is proclaimed by Governor",
-    "rule": "monday before October",
+    "rule": "monday before October #1",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-WA-2027.json
+++ b/test/fixtures/AU-WA-2027.json
@@ -94,10 +94,10 @@
     "date": "2027-09-27 00:00:00",
     "start": "2027-09-26T16:00:00.000Z",
     "end": "2027-09-27T16:00:00.000Z",
-    "name": "Queen's Birthday",
+    "name": "King's Birthday",
     "type": "public",
     "note": "Might be on a different day; is proclaimed by Governor",
-    "rule": "monday before October",
+    "rule": "monday before October #1",
     "_weekday": "Mon"
   },
   {


### PR DESCRIPTION
The Queen died in 2022, Australia now celebrates the King's Birthday