### PR TITLE
feat: Updated for Bolivian holidays

### DIFF
--- a/data/countries/BO.yaml
+++ b/data/countries/BO.yaml
@@ -1,5 +1,7 @@
 holidays:
-  # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Bolivia
+  # @attrib https://www.timeanddate.com/holidays/bolivia/
+  # @attrib http://gacetaoficialdebolivia.gob.bo/normas/buscar/5019
+  # @attrib https://www.embajadadebolivia.es/informacion-general/
   BO:
     names:
       es: Bolivia
@@ -14,57 +16,215 @@ holidays:
     days:
       01-01:
         _name: 01-01
+      substitutes 01-01 if sunday then next monday:
+        name:
+          en: New Year's Day (substitutes)
+          es: Año Nuevo (substituto)
+      01-22:
+        name:
+          en: Plurinational State Foundation Day
+          es: Día de la Creación del Estado Plurinacional de Bolivia
+      substitutes 01-22 if sunday then next monday:
+        name:
+          en: Plurinational State Foundation Day (substitutes)
+          es: Día de la Creación del Estado Plurinacional de Bolivia (substituto)
       02-02:
         name:
           en: Feast of the Virgin of Candelaria
           qu: Mamacha Candelaria
           es: Fiesta de la Virgen de Candelaria
+        type: observance
       easter -48:
+        _name: easter -48
         name:
-          en: Carnival
-          es: Carnaval
+          es: Lunes de Carnaval
       easter -47:
         _name: easter -47
+        name:
+          es: Martes de Carnaval
+      03-19:
+        name:
+          en: Father's Day
+          es: Día del Padre
+        type: observance
+      03-23:
+        name:
+          en: Day of the Sea
+          es: Día del Mar
+        type: observance
+      easter -3:
+        _name: easter -3
+        type: observance
       easter -2:
         _name: easter -2
-      easter:
-        _name: easter
+      04-12:
+        name:
+          en: Children's Day
+          es: Día del Niño
         type: observance
-      easter 39:
-        _name: easter 39
+      05-01:
+        _name: 05-01
+      substitutes 05-01 if sunday then next monday:
+        _name: 05-01
+        name:
+          en: Labour Day (substitutes)
+          es: Día del Trabajo (substituto)
+      05-27:
+        name:
+          en: Mother's Day
+          es: Día de la Madre
+        type: observance
+      06-06:
+        name:
+          en: Teacher's Day
+          es: Día del Maestro
+        type: observance
+      easter 60:
+        _name: easter 60
       06-21:
         name:
-          en: Andean New Year
+          en: Andean Amazonian Chaqueño New Year
           ay: Willkakuti
-          es: Año Nuevo Andino
-      08-02:
+          es: Año Nuevo Andino Amazónico Chaqueño
+      substitutes 06-21 if sunday then next monday:
         name:
-          en: Agrarian Reform Day
-          es: Día de la Revolución Agraria, Productiva y Comunitaria
+          en: Andean Amazonic Chacoan New Year (substitutes)
+          ay: Willkakuti (substituto)
+          es: Año Nuevo Andino Amazónico Chaqueño (substituto)
       08-06:
         _name: Independence Day
+      substitutes 08-06 if sunday then next monday:
         name:
-          es: Día de la Patria
+          en: Independence Day (substitutes)
+          es: Día de la Independencia (substituto)
+      08-17:
+        name:
+          en: Flag Day
+          es: Día de la Bandera
+        type: observance
+      09-21:
+        name:
+          en: Student's Day
+          es: Día del Estudiante
+        type: observance
+      10-11:
+        name:
+          es: Día de la Mujer Boliviana
+          en: Bolivian Woman's Day
+          type: observance
+      11-01:
+        _name: 11-01
+        name:
+          es: Todos Santos
+        type: observance
       11-02:
         _name: 11-02
+        name:
+          es: Todos Santos
       12-25:
         _name: 12-25
-    # states:
-    # B:
-    #   name: Beni
-    # C:
-    #   name: Cochabamba
-    # H:
-    #   name: Chuquisaca
-    # L:
-    #   name: La Paz
-    # 'N':
-    #   name: Pando
-    # O:
-    #   name: Oruro
-    # P:
-    #   name: Potosí
-    # S:
-    #   name: Santa Cruz
-    # T:
-    #   name: Tarija
+      substitutes 12-25 if sunday then next monday:
+        _name: 12-25
+        name:
+          en: Christmas Day (substitutes)
+          es: Navidad (substituto)
+    states:
+      B:
+        name: Beni
+        days:
+          11-18:
+            name:
+              es: Efemérides del Beni
+              en: Beni Day
+          substitutes 11-18 if sunday then next monday:
+            name:
+              es: Efemérides del Beni (substituto)
+              en: Beni Day (substitutes)
+      C:
+        name: Cochabamba
+        days:
+          09-14:
+            name:
+              es: Efemérides de Cochabamba
+              en: Cochabamba Day
+          substitutes 09-14 if sunday then next monday:
+            name:
+              es: Efemérides de Cochabamba (substituto)
+              en: Cochabamba Day (substitutes)
+      H:
+        name: Chuquisaca
+        days:
+          05-25:
+            name:
+              es: Efemérides de Chuquisaca
+              en: Chuquisaca Day
+          substitutes 05-25 if sunday then next monday:
+            name:
+              es: Efemérides de Chuquisaca (substituto)
+              en: Chuquisaca Day (substitutes)
+      L:
+        name: La Paz
+        days:
+          07-16:
+            name:
+              es: Efemérides de La Paz
+              en: La Paz Day
+          substitutes 07-16 if sunday then next monday:
+            name:
+              es: Efemérides de La Paz (substituto)
+              en: La Paz Day (substitutes)
+      'N':
+        name: Pando
+        days:
+          09-24:
+            name:
+              es: Efemérides de Pando
+              en: Pando Day
+          substitutes 09-24 if sunday then next monday:
+            name:
+              es: Efemérides de Pando (substituto)
+              en: Pando Day (substitutes)
+      O:
+        name: Oruro
+        days:
+          02-10:
+            name:
+              es: Efemérides de Oruro
+              en: Oruro Day
+          substitutes 02-10 if sunday then next monday:
+            name:
+              es: Efemérides de Oruro (substituto)
+              en: Oruro Day (substitutes)
+      P:
+        name: Potosí
+        days:
+          11-10:
+            name:
+              es: Efemérides de Potosí
+              en: Potosí Day
+          substitutes 11-10 if sunday then next monday:
+            name:
+              es: Efemérides de Potosí (substituto)
+              en: Potosí Day (substitutes)
+      S:
+        name: Santa Cruz
+        days:
+          09-24:
+            name:
+              es: Efemérides de Santa Cruz
+              en: Santa Cruz Day
+          substitutes 09-24 if sunday then next monday:
+            name:
+              es: Efemérides de Santa Cruz (substituto)
+              en: Santa Cruz Day (substitutes)
+      T:
+        name: Tarija
+        days:
+          04-15:
+            name:
+              es: Efemérides de Tarija
+              en: Tarija Day
+          substitutes 04-15 if sunday then next monday:
+            name:
+              es: Efemérides de Tarija (substituto)
+              en: Tarija Day (substitutes)

--- a/test/fixtures/BO-2015.json
+++ b/test/fixtures/BO-2015.json
@@ -9,11 +9,20 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2015-01-22 00:00:00",
+    "start": "2015-01-22T04:00:00.000Z",
+    "end": "2015-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2015-02-02 00:00:00",
     "start": "2015-02-02T04:00:00.000Z",
     "end": "2015-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Mon"
   },
@@ -21,7 +30,7 @@
     "date": "2015-02-16 00:00:00",
     "start": "2015-02-16T04:00:00.000Z",
     "end": "2015-02-17T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,37 @@
     "date": "2015-02-17 00:00:00",
     "start": "2015-02-17T04:00:00.000Z",
     "end": "2015-02-18T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2015-03-19 00:00:00",
+    "start": "2015-03-19T04:00:00.000Z",
+    "end": "2015-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-03-23 00:00:00",
+    "start": "2015-03-23T04:00:00.000Z",
+    "end": "2015-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-02 00:00:00",
+    "start": "2015-04-02T04:00:00.000Z",
+    "end": "2015-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -45,55 +81,118 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T04:00:00.000Z",
-    "end": "2015-04-06T04:00:00.000Z",
-    "name": "Pascua",
+    "date": "2015-04-12 00:00:00",
+    "start": "2015-04-12T04:00:00.000Z",
+    "end": "2015-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
     "type": "observance",
-    "rule": "easter",
+    "rule": "04-12",
     "_weekday": "Sun"
   },
   {
-    "date": "2015-05-14 00:00:00",
-    "start": "2015-05-14T04:00:00.000Z",
-    "end": "2015-05-15T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T04:00:00.000Z",
+    "end": "2015-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-27 00:00:00",
+    "start": "2015-05-27T04:00:00.000Z",
+    "end": "2015-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T04:00:00.000Z",
+    "end": "2015-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-06 00:00:00",
+    "start": "2015-06-06T04:00:00.000Z",
+    "end": "2015-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
   },
   {
     "date": "2015-06-21 00:00:00",
     "start": "2015-06-21T04:00:00.000Z",
     "end": "2015-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
     "_weekday": "Sun"
   },
   {
-    "date": "2015-08-02 00:00:00",
-    "start": "2015-08-02T04:00:00.000Z",
-    "end": "2015-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
+    "date": "2015-06-22 00:00:00",
+    "start": "2015-06-22T04:00:00.000Z",
+    "end": "2015-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
     "type": "public",
-    "rule": "08-02",
-    "_weekday": "Sun"
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2015-08-06 00:00:00",
     "start": "2015-08-06T04:00:00.000Z",
     "end": "2015-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Thu"
   },
   {
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-17T04:00:00.000Z",
+    "end": "2015-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-21 00:00:00",
+    "start": "2015-09-21T04:00:00.000Z",
+    "end": "2015-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-11 00:00:00",
+    "start": "2015-10-11T04:00:00.000Z",
+    "end": "2015-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-11-01T04:00:00.000Z",
+    "end": "2015-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2015-11-02 00:00:00",
     "start": "2015-11-02T04:00:00.000Z",
     "end": "2015-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Mon"

--- a/test/fixtures/BO-2016.json
+++ b/test/fixtures/BO-2016.json
@@ -9,11 +9,20 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2016-01-22 00:00:00",
+    "start": "2016-01-22T04:00:00.000Z",
+    "end": "2016-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2016-02-02 00:00:00",
     "start": "2016-02-02T04:00:00.000Z",
     "end": "2016-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Tue"
   },
@@ -21,7 +30,7 @@
     "date": "2016-02-08 00:00:00",
     "start": "2016-02-08T04:00:00.000Z",
     "end": "2016-02-09T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,37 @@
     "date": "2016-02-09 00:00:00",
     "start": "2016-02-09T04:00:00.000Z",
     "end": "2016-02-10T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2016-03-19 00:00:00",
+    "start": "2016-03-19T04:00:00.000Z",
+    "end": "2016-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-03-23 00:00:00",
+    "start": "2016-03-23T04:00:00.000Z",
+    "end": "2016-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-24 00:00:00",
+    "start": "2016-03-24T04:00:00.000Z",
+    "end": "2016-03-25T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -45,55 +81,118 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T04:00:00.000Z",
-    "end": "2016-03-28T04:00:00.000Z",
-    "name": "Pascua",
+    "date": "2016-04-12 00:00:00",
+    "start": "2016-04-12T04:00:00.000Z",
+    "end": "2016-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
     "type": "observance",
-    "rule": "easter",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T04:00:00.000Z",
+    "end": "2016-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
     "_weekday": "Sun"
   },
   {
-    "date": "2016-05-05 00:00:00",
-    "start": "2016-05-05T04:00:00.000Z",
-    "end": "2016-05-06T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2016-05-02 00:00:00",
+    "start": "2016-05-02T04:00:00.000Z",
+    "end": "2016-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T04:00:00.000Z",
+    "end": "2016-05-27T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-27 00:00:00",
+    "start": "2016-05-27T04:00:00.000Z",
+    "end": "2016-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-06-06 00:00:00",
+    "start": "2016-06-06T04:00:00.000Z",
+    "end": "2016-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
   },
   {
     "date": "2016-06-21 00:00:00",
     "start": "2016-06-21T04:00:00.000Z",
     "end": "2016-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
-    "_weekday": "Tue"
-  },
-  {
-    "date": "2016-08-02 00:00:00",
-    "start": "2016-08-02T04:00:00.000Z",
-    "end": "2016-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
-    "type": "public",
-    "rule": "08-02",
     "_weekday": "Tue"
   },
   {
     "date": "2016-08-06 00:00:00",
     "start": "2016-08-06T04:00:00.000Z",
     "end": "2016-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Sat"
   },
   {
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-17T04:00:00.000Z",
+    "end": "2016-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-21 00:00:00",
+    "start": "2016-09-21T04:00:00.000Z",
+    "end": "2016-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-11 00:00:00",
+    "start": "2016-10-11T04:00:00.000Z",
+    "end": "2016-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-11-01T04:00:00.000Z",
+    "end": "2016-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2016-11-02 00:00:00",
     "start": "2016-11-02T04:00:00.000Z",
     "end": "2016-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Wed"
@@ -106,5 +205,14 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-26T04:00:00.000Z",
+    "end": "2016-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/BO-2017.json
+++ b/test/fixtures/BO-2017.json
@@ -9,11 +9,38 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T04:00:00.000Z",
+    "end": "2017-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-01-22 00:00:00",
+    "start": "2017-01-22T04:00:00.000Z",
+    "end": "2017-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-23 00:00:00",
+    "start": "2017-01-23T04:00:00.000Z",
+    "end": "2017-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2017-02-02 00:00:00",
     "start": "2017-02-02T04:00:00.000Z",
     "end": "2017-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Thu"
   },
@@ -21,7 +48,7 @@
     "date": "2017-02-27 00:00:00",
     "start": "2017-02-27T04:00:00.000Z",
     "end": "2017-02-28T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +57,46 @@
     "date": "2017-02-28 00:00:00",
     "start": "2017-02-28T04:00:00.000Z",
     "end": "2017-03-01T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-19 00:00:00",
+    "start": "2017-03-19T04:00:00.000Z",
+    "end": "2017-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-23 00:00:00",
+    "start": "2017-03-23T04:00:00.000Z",
+    "end": "2017-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-12 00:00:00",
+    "start": "2017-04-12T04:00:00.000Z",
+    "end": "2017-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-13 00:00:00",
+    "start": "2017-04-13T04:00:00.000Z",
+    "end": "2017-04-14T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -45,55 +108,109 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T04:00:00.000Z",
-    "end": "2017-04-17T04:00:00.000Z",
-    "name": "Pascua",
-    "type": "observance",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T04:00:00.000Z",
+    "end": "2017-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
   },
   {
-    "date": "2017-05-25 00:00:00",
-    "start": "2017-05-25T04:00:00.000Z",
-    "end": "2017-05-26T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2017-05-27 00:00:00",
+    "start": "2017-05-27T04:00:00.000Z",
+    "end": "2017-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-06-06 00:00:00",
+    "start": "2017-06-06T04:00:00.000Z",
+    "end": "2017-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T04:00:00.000Z",
+    "end": "2017-06-16T04:00:00.000Z",
+    "name": "Corpus Christi",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "easter 60",
     "_weekday": "Thu"
   },
   {
     "date": "2017-06-21 00:00:00",
     "start": "2017-06-21T04:00:00.000Z",
     "end": "2017-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
-    "_weekday": "Wed"
-  },
-  {
-    "date": "2017-08-02 00:00:00",
-    "start": "2017-08-02T04:00:00.000Z",
-    "end": "2017-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
-    "type": "public",
-    "rule": "08-02",
     "_weekday": "Wed"
   },
   {
     "date": "2017-08-06 00:00:00",
     "start": "2017-08-06T04:00:00.000Z",
     "end": "2017-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Sun"
   },
   {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-17T04:00:00.000Z",
+    "end": "2017-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-21 00:00:00",
+    "start": "2017-09-21T04:00:00.000Z",
+    "end": "2017-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-11 00:00:00",
+    "start": "2017-10-11T04:00:00.000Z",
+    "end": "2017-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-11-01T04:00:00.000Z",
+    "end": "2017-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2017-11-02 00:00:00",
     "start": "2017-11-02T04:00:00.000Z",
     "end": "2017-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Thu"

--- a/test/fixtures/BO-2018.json
+++ b/test/fixtures/BO-2018.json
@@ -9,11 +9,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-01-22 00:00:00",
+    "start": "2018-01-22T04:00:00.000Z",
+    "end": "2018-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2018-02-02 00:00:00",
     "start": "2018-02-02T04:00:00.000Z",
     "end": "2018-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Fri"
   },
@@ -21,7 +30,7 @@
     "date": "2018-02-12 00:00:00",
     "start": "2018-02-12T04:00:00.000Z",
     "end": "2018-02-13T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,37 @@
     "date": "2018-02-13 00:00:00",
     "start": "2018-02-13T04:00:00.000Z",
     "end": "2018-02-14T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T04:00:00.000Z",
+    "end": "2018-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-03-23 00:00:00",
+    "start": "2018-03-23T04:00:00.000Z",
+    "end": "2018-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-03-29 00:00:00",
+    "start": "2018-03-29T04:00:00.000Z",
+    "end": "2018-03-30T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -45,55 +81,109 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T04:00:00.000Z",
-    "end": "2018-04-02T04:00:00.000Z",
-    "name": "Pascua",
+    "date": "2018-04-12 00:00:00",
+    "start": "2018-04-12T04:00:00.000Z",
+    "end": "2018-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
     "type": "observance",
-    "rule": "easter",
+    "rule": "04-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T04:00:00.000Z",
+    "end": "2018-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-27T04:00:00.000Z",
+    "end": "2018-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
     "_weekday": "Sun"
   },
   {
-    "date": "2018-05-10 00:00:00",
-    "start": "2018-05-10T04:00:00.000Z",
-    "end": "2018-05-11T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T04:00:00.000Z",
+    "end": "2018-06-01T04:00:00.000Z",
+    "name": "Corpus Christi",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "easter 60",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-06 00:00:00",
+    "start": "2018-06-06T04:00:00.000Z",
+    "end": "2018-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-06-21 00:00:00",
     "start": "2018-06-21T04:00:00.000Z",
     "end": "2018-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
-    "_weekday": "Thu"
-  },
-  {
-    "date": "2018-08-02 00:00:00",
-    "start": "2018-08-02T04:00:00.000Z",
-    "end": "2018-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
-    "type": "public",
-    "rule": "08-02",
     "_weekday": "Thu"
   },
   {
     "date": "2018-08-06 00:00:00",
     "start": "2018-08-06T04:00:00.000Z",
     "end": "2018-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Mon"
   },
   {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-17T04:00:00.000Z",
+    "end": "2018-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-21 00:00:00",
+    "start": "2018-09-21T04:00:00.000Z",
+    "end": "2018-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-11 00:00:00",
+    "start": "2018-10-11T04:00:00.000Z",
+    "end": "2018-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-11-01T04:00:00.000Z",
+    "end": "2018-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2018-11-02 00:00:00",
     "start": "2018-11-02T04:00:00.000Z",
     "end": "2018-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Fri"

--- a/test/fixtures/BO-2019.json
+++ b/test/fixtures/BO-2019.json
@@ -9,11 +9,20 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2019-01-22 00:00:00",
+    "start": "2019-01-22T04:00:00.000Z",
+    "end": "2019-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2019-02-02 00:00:00",
     "start": "2019-02-02T04:00:00.000Z",
     "end": "2019-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Sat"
   },
@@ -21,7 +30,7 @@
     "date": "2019-03-04 00:00:00",
     "start": "2019-03-04T04:00:00.000Z",
     "end": "2019-03-05T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,46 @@
     "date": "2019-03-05 00:00:00",
     "start": "2019-03-05T04:00:00.000Z",
     "end": "2019-03-06T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-19 00:00:00",
+    "start": "2019-03-19T04:00:00.000Z",
+    "end": "2019-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-23 00:00:00",
+    "start": "2019-03-23T04:00:00.000Z",
+    "end": "2019-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-04-12 00:00:00",
+    "start": "2019-04-12T04:00:00.000Z",
+    "end": "2019-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-18 00:00:00",
+    "start": "2019-04-18T04:00:00.000Z",
+    "end": "2019-04-19T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -45,55 +90,100 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T04:00:00.000Z",
-    "end": "2019-04-22T04:00:00.000Z",
-    "name": "Pascua",
-    "type": "observance",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T04:00:00.000Z",
+    "end": "2019-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
   },
   {
-    "date": "2019-05-30 00:00:00",
-    "start": "2019-05-30T04:00:00.000Z",
-    "end": "2019-05-31T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2019-05-27 00:00:00",
+    "start": "2019-05-27T04:00:00.000Z",
+    "end": "2019-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-06-06 00:00:00",
+    "start": "2019-06-06T04:00:00.000Z",
+    "end": "2019-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T04:00:00.000Z",
+    "end": "2019-06-21T04:00:00.000Z",
+    "name": "Corpus Christi",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "easter 60",
     "_weekday": "Thu"
   },
   {
     "date": "2019-06-21 00:00:00",
     "start": "2019-06-21T04:00:00.000Z",
     "end": "2019-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
-    "_weekday": "Fri"
-  },
-  {
-    "date": "2019-08-02 00:00:00",
-    "start": "2019-08-02T04:00:00.000Z",
-    "end": "2019-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
-    "type": "public",
-    "rule": "08-02",
     "_weekday": "Fri"
   },
   {
     "date": "2019-08-06 00:00:00",
     "start": "2019-08-06T04:00:00.000Z",
     "end": "2019-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Tue"
   },
   {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T04:00:00.000Z",
+    "end": "2019-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-21 00:00:00",
+    "start": "2019-09-21T04:00:00.000Z",
+    "end": "2019-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-11 00:00:00",
+    "start": "2019-10-11T04:00:00.000Z",
+    "end": "2019-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-11-01T04:00:00.000Z",
+    "end": "2019-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2019-11-02 00:00:00",
     "start": "2019-11-02T04:00:00.000Z",
     "end": "2019-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Sat"

--- a/test/fixtures/BO-2020.json
+++ b/test/fixtures/BO-2020.json
@@ -9,11 +9,20 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2020-01-22 00:00:00",
+    "start": "2020-01-22T04:00:00.000Z",
+    "end": "2020-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2020-02-02 00:00:00",
     "start": "2020-02-02T04:00:00.000Z",
     "end": "2020-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Sun"
   },
@@ -21,7 +30,7 @@
     "date": "2020-02-24 00:00:00",
     "start": "2020-02-24T04:00:00.000Z",
     "end": "2020-02-25T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,37 @@
     "date": "2020-02-25 00:00:00",
     "start": "2020-02-25T04:00:00.000Z",
     "end": "2020-02-26T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2020-03-19 00:00:00",
+    "start": "2020-03-19T04:00:00.000Z",
+    "end": "2020-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-03-23 00:00:00",
+    "start": "2020-03-23T04:00:00.000Z",
+    "end": "2020-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-09 00:00:00",
+    "start": "2020-04-09T04:00:00.000Z",
+    "end": "2020-04-10T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -48,52 +84,115 @@
     "date": "2020-04-12 00:00:00",
     "start": "2020-04-12T04:00:00.000Z",
     "end": "2020-04-13T04:00:00.000Z",
-    "name": "Pascua",
+    "name": "Día del Niño",
     "type": "observance",
-    "rule": "easter",
+    "rule": "04-12",
     "_weekday": "Sun"
   },
   {
-    "date": "2020-05-21 00:00:00",
-    "start": "2020-05-21T04:00:00.000Z",
-    "end": "2020-05-22T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T04:00:00.000Z",
+    "end": "2020-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-27 00:00:00",
+    "start": "2020-05-27T04:00:00.000Z",
+    "end": "2020-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-06-06 00:00:00",
+    "start": "2020-06-06T04:00:00.000Z",
+    "end": "2020-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T04:00:00.000Z",
+    "end": "2020-06-12T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
     "_weekday": "Thu"
   },
   {
     "date": "2020-06-21 00:00:00",
     "start": "2020-06-21T04:00:00.000Z",
     "end": "2020-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
     "_weekday": "Sun"
   },
   {
-    "date": "2020-08-02 00:00:00",
-    "start": "2020-08-02T04:00:00.000Z",
-    "end": "2020-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
+    "date": "2020-06-22 00:00:00",
+    "start": "2020-06-22T04:00:00.000Z",
+    "end": "2020-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
     "type": "public",
-    "rule": "08-02",
-    "_weekday": "Sun"
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2020-08-06 00:00:00",
     "start": "2020-08-06T04:00:00.000Z",
     "end": "2020-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Thu"
   },
   {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-17T04:00:00.000Z",
+    "end": "2020-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-21 00:00:00",
+    "start": "2020-09-21T04:00:00.000Z",
+    "end": "2020-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-11 00:00:00",
+    "start": "2020-10-11T04:00:00.000Z",
+    "end": "2020-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-11-01T04:00:00.000Z",
+    "end": "2020-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-11-02 00:00:00",
     "start": "2020-11-02T04:00:00.000Z",
     "end": "2020-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Mon"

--- a/test/fixtures/BO-2021.json
+++ b/test/fixtures/BO-2021.json
@@ -9,11 +9,20 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2021-01-22 00:00:00",
+    "start": "2021-01-22T04:00:00.000Z",
+    "end": "2021-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2021-02-02 00:00:00",
     "start": "2021-02-02T04:00:00.000Z",
     "end": "2021-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Tue"
   },
@@ -21,7 +30,7 @@
     "date": "2021-02-15 00:00:00",
     "start": "2021-02-15T04:00:00.000Z",
     "end": "2021-02-16T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,37 @@
     "date": "2021-02-16 00:00:00",
     "start": "2021-02-16T04:00:00.000Z",
     "end": "2021-02-17T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2021-03-19 00:00:00",
+    "start": "2021-03-19T04:00:00.000Z",
+    "end": "2021-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-03-23 00:00:00",
+    "start": "2021-03-23T04:00:00.000Z",
+    "end": "2021-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-04-01T04:00:00.000Z",
+    "end": "2021-04-02T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -45,55 +81,109 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T04:00:00.000Z",
-    "end": "2021-04-05T04:00:00.000Z",
-    "name": "Pascua",
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T04:00:00.000Z",
+    "end": "2021-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
     "type": "observance",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "04-12",
+    "_weekday": "Mon"
   },
   {
-    "date": "2021-05-13 00:00:00",
-    "start": "2021-05-13T04:00:00.000Z",
-    "end": "2021-05-14T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T04:00:00.000Z",
+    "end": "2021-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-27 00:00:00",
+    "start": "2021-05-27T04:00:00.000Z",
+    "end": "2021-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T04:00:00.000Z",
+    "end": "2021-06-04T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-06 00:00:00",
+    "start": "2021-06-06T04:00:00.000Z",
+    "end": "2021-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
   },
   {
     "date": "2021-06-21 00:00:00",
     "start": "2021-06-21T04:00:00.000Z",
     "end": "2021-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2021-08-02 00:00:00",
-    "start": "2021-08-02T04:00:00.000Z",
-    "end": "2021-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
-    "type": "public",
-    "rule": "08-02",
     "_weekday": "Mon"
   },
   {
     "date": "2021-08-06 00:00:00",
     "start": "2021-08-06T04:00:00.000Z",
     "end": "2021-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Fri"
   },
   {
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-17T04:00:00.000Z",
+    "end": "2021-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-21 00:00:00",
+    "start": "2021-09-21T04:00:00.000Z",
+    "end": "2021-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-11-01T04:00:00.000Z",
+    "end": "2021-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-11-02 00:00:00",
     "start": "2021-11-02T04:00:00.000Z",
     "end": "2021-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Tue"

--- a/test/fixtures/BO-2022.json
+++ b/test/fixtures/BO-2022.json
@@ -9,11 +9,20 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2022-01-22 00:00:00",
+    "start": "2022-01-22T04:00:00.000Z",
+    "end": "2022-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2022-02-02 00:00:00",
     "start": "2022-02-02T04:00:00.000Z",
     "end": "2022-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Wed"
   },
@@ -21,7 +30,7 @@
     "date": "2022-02-28 00:00:00",
     "start": "2022-02-28T04:00:00.000Z",
     "end": "2022-03-01T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,46 @@
     "date": "2022-03-01 00:00:00",
     "start": "2022-03-01T04:00:00.000Z",
     "end": "2022-03-02T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-19 00:00:00",
+    "start": "2022-03-19T04:00:00.000Z",
+    "end": "2022-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-03-23 00:00:00",
+    "start": "2022-03-23T04:00:00.000Z",
+    "end": "2022-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-12 00:00:00",
+    "start": "2022-04-12T04:00:00.000Z",
+    "end": "2022-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-14 00:00:00",
+    "start": "2022-04-14T04:00:00.000Z",
+    "end": "2022-04-15T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -45,55 +90,109 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T04:00:00.000Z",
-    "end": "2022-04-18T04:00:00.000Z",
-    "name": "Pascua",
-    "type": "observance",
-    "rule": "easter",
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T04:00:00.000Z",
+    "end": "2022-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
     "_weekday": "Sun"
   },
   {
-    "date": "2022-05-26 00:00:00",
-    "start": "2022-05-26T04:00:00.000Z",
-    "end": "2022-05-27T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-02T04:00:00.000Z",
+    "end": "2022-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-27 00:00:00",
+    "start": "2022-05-27T04:00:00.000Z",
+    "end": "2022-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-06-06 00:00:00",
+    "start": "2022-06-06T04:00:00.000Z",
+    "end": "2022-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T04:00:00.000Z",
+    "end": "2022-06-17T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
     "_weekday": "Thu"
   },
   {
     "date": "2022-06-21 00:00:00",
     "start": "2022-06-21T04:00:00.000Z",
     "end": "2022-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
-    "_weekday": "Tue"
-  },
-  {
-    "date": "2022-08-02 00:00:00",
-    "start": "2022-08-02T04:00:00.000Z",
-    "end": "2022-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
-    "type": "public",
-    "rule": "08-02",
     "_weekday": "Tue"
   },
   {
     "date": "2022-08-06 00:00:00",
     "start": "2022-08-06T04:00:00.000Z",
     "end": "2022-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Sat"
   },
   {
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-17T04:00:00.000Z",
+    "end": "2022-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-21 00:00:00",
+    "start": "2022-09-21T04:00:00.000Z",
+    "end": "2022-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-11 00:00:00",
+    "start": "2022-10-11T04:00:00.000Z",
+    "end": "2022-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-11-01T04:00:00.000Z",
+    "end": "2022-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2022-11-02 00:00:00",
     "start": "2022-11-02T04:00:00.000Z",
     "end": "2022-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Wed"
@@ -106,5 +205,14 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-26T04:00:00.000Z",
+    "end": "2022-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/BO-2023.json
+++ b/test/fixtures/BO-2023.json
@@ -9,11 +9,38 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T04:00:00.000Z",
+    "end": "2023-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-01-22 00:00:00",
+    "start": "2023-01-22T04:00:00.000Z",
+    "end": "2023-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-23 00:00:00",
+    "start": "2023-01-23T04:00:00.000Z",
+    "end": "2023-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-02-02 00:00:00",
     "start": "2023-02-02T04:00:00.000Z",
     "end": "2023-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Thu"
   },
@@ -21,7 +48,7 @@
     "date": "2023-02-20 00:00:00",
     "start": "2023-02-20T04:00:00.000Z",
     "end": "2023-02-21T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +57,37 @@
     "date": "2023-02-21 00:00:00",
     "start": "2023-02-21T04:00:00.000Z",
     "end": "2023-02-22T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2023-03-19 00:00:00",
+    "start": "2023-03-19T04:00:00.000Z",
+    "end": "2023-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-03-23 00:00:00",
+    "start": "2023-03-23T04:00:00.000Z",
+    "end": "2023-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-06 00:00:00",
+    "start": "2023-04-06T04:00:00.000Z",
+    "end": "2023-04-07T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -45,55 +99,118 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T04:00:00.000Z",
-    "end": "2023-04-10T04:00:00.000Z",
-    "name": "Pascua",
+    "date": "2023-04-12 00:00:00",
+    "start": "2023-04-12T04:00:00.000Z",
+    "end": "2023-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
     "type": "observance",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "04-12",
+    "_weekday": "Wed"
   },
   {
-    "date": "2023-05-18 00:00:00",
-    "start": "2023-05-18T04:00:00.000Z",
-    "end": "2023-05-19T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T04:00:00.000Z",
+    "end": "2023-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-27 00:00:00",
+    "start": "2023-05-27T04:00:00.000Z",
+    "end": "2023-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-06-06 00:00:00",
+    "start": "2023-06-06T04:00:00.000Z",
+    "end": "2023-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T04:00:00.000Z",
+    "end": "2023-06-09T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
     "_weekday": "Thu"
   },
   {
     "date": "2023-06-21 00:00:00",
     "start": "2023-06-21T04:00:00.000Z",
     "end": "2023-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
-    "_weekday": "Wed"
-  },
-  {
-    "date": "2023-08-02 00:00:00",
-    "start": "2023-08-02T04:00:00.000Z",
-    "end": "2023-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
-    "type": "public",
-    "rule": "08-02",
     "_weekday": "Wed"
   },
   {
     "date": "2023-08-06 00:00:00",
     "start": "2023-08-06T04:00:00.000Z",
     "end": "2023-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Sun"
   },
   {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-17T04:00:00.000Z",
+    "end": "2023-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-21 00:00:00",
+    "start": "2023-09-21T04:00:00.000Z",
+    "end": "2023-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-11 00:00:00",
+    "start": "2023-10-11T04:00:00.000Z",
+    "end": "2023-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-11-01T04:00:00.000Z",
+    "end": "2023-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2023-11-02 00:00:00",
     "start": "2023-11-02T04:00:00.000Z",
     "end": "2023-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Thu"

--- a/test/fixtures/BO-2024.json
+++ b/test/fixtures/BO-2024.json
@@ -9,11 +9,20 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-01-22 00:00:00",
+    "start": "2024-01-22T04:00:00.000Z",
+    "end": "2024-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-02-02 00:00:00",
     "start": "2024-02-02T04:00:00.000Z",
     "end": "2024-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Fri"
   },
@@ -21,7 +30,7 @@
     "date": "2024-02-12 00:00:00",
     "start": "2024-02-12T04:00:00.000Z",
     "end": "2024-02-13T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,37 @@
     "date": "2024-02-13 00:00:00",
     "start": "2024-02-13T04:00:00.000Z",
     "end": "2024-02-14T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-19 00:00:00",
+    "start": "2024-03-19T04:00:00.000Z",
+    "end": "2024-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-23 00:00:00",
+    "start": "2024-03-23T04:00:00.000Z",
+    "end": "2024-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-28 00:00:00",
+    "start": "2024-03-28T04:00:00.000Z",
+    "end": "2024-03-29T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -45,55 +81,109 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T04:00:00.000Z",
-    "end": "2024-04-01T04:00:00.000Z",
-    "name": "Pascua",
+    "date": "2024-04-12 00:00:00",
+    "start": "2024-04-12T04:00:00.000Z",
+    "end": "2024-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
     "type": "observance",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "04-12",
+    "_weekday": "Fri"
   },
   {
-    "date": "2024-05-09 00:00:00",
-    "start": "2024-05-09T04:00:00.000Z",
-    "end": "2024-05-10T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T04:00:00.000Z",
+    "end": "2024-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-27 00:00:00",
+    "start": "2024-05-27T04:00:00.000Z",
+    "end": "2024-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T04:00:00.000Z",
+    "end": "2024-05-31T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-06 00:00:00",
+    "start": "2024-06-06T04:00:00.000Z",
+    "end": "2024-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
     "_weekday": "Thu"
   },
   {
     "date": "2024-06-21 00:00:00",
     "start": "2024-06-21T04:00:00.000Z",
     "end": "2024-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
-    "_weekday": "Fri"
-  },
-  {
-    "date": "2024-08-02 00:00:00",
-    "start": "2024-08-02T04:00:00.000Z",
-    "end": "2024-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
-    "type": "public",
-    "rule": "08-02",
     "_weekday": "Fri"
   },
   {
     "date": "2024-08-06 00:00:00",
     "start": "2024-08-06T04:00:00.000Z",
     "end": "2024-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Tue"
   },
   {
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T04:00:00.000Z",
+    "end": "2024-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-21 00:00:00",
+    "start": "2024-09-21T04:00:00.000Z",
+    "end": "2024-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T04:00:00.000Z",
+    "end": "2024-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-11-01T04:00:00.000Z",
+    "end": "2024-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2024-11-02 00:00:00",
     "start": "2024-11-02T04:00:00.000Z",
     "end": "2024-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Sat"

--- a/test/fixtures/BO-2025.json
+++ b/test/fixtures/BO-2025.json
@@ -9,11 +9,20 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2025-01-22 00:00:00",
+    "start": "2025-01-22T04:00:00.000Z",
+    "end": "2025-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2025-02-02 00:00:00",
     "start": "2025-02-02T04:00:00.000Z",
     "end": "2025-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Sun"
   },
@@ -21,7 +30,7 @@
     "date": "2025-03-03 00:00:00",
     "start": "2025-03-03T04:00:00.000Z",
     "end": "2025-03-04T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,46 @@
     "date": "2025-03-04 00:00:00",
     "start": "2025-03-04T04:00:00.000Z",
     "end": "2025-03-05T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-19 00:00:00",
+    "start": "2025-03-19T04:00:00.000Z",
+    "end": "2025-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-23 00:00:00",
+    "start": "2025-03-23T04:00:00.000Z",
+    "end": "2025-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-12 00:00:00",
+    "start": "2025-04-12T04:00:00.000Z",
+    "end": "2025-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-17 00:00:00",
+    "start": "2025-04-17T04:00:00.000Z",
+    "end": "2025-04-18T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -45,55 +90,100 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T04:00:00.000Z",
-    "end": "2025-04-21T04:00:00.000Z",
-    "name": "Pascua",
-    "type": "observance",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T04:00:00.000Z",
+    "end": "2025-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
   },
   {
-    "date": "2025-05-29 00:00:00",
-    "start": "2025-05-29T04:00:00.000Z",
-    "end": "2025-05-30T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2025-05-27 00:00:00",
+    "start": "2025-05-27T04:00:00.000Z",
+    "end": "2025-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-06-06 00:00:00",
+    "start": "2025-06-06T04:00:00.000Z",
+    "end": "2025-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T04:00:00.000Z",
+    "end": "2025-06-20T04:00:00.000Z",
+    "name": "Corpus Christi",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "easter 60",
     "_weekday": "Thu"
   },
   {
     "date": "2025-06-21 00:00:00",
     "start": "2025-06-21T04:00:00.000Z",
     "end": "2025-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
-    "_weekday": "Sat"
-  },
-  {
-    "date": "2025-08-02 00:00:00",
-    "start": "2025-08-02T04:00:00.000Z",
-    "end": "2025-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
-    "type": "public",
-    "rule": "08-02",
     "_weekday": "Sat"
   },
   {
     "date": "2025-08-06 00:00:00",
     "start": "2025-08-06T04:00:00.000Z",
     "end": "2025-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Wed"
   },
   {
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T04:00:00.000Z",
+    "end": "2025-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-21 00:00:00",
+    "start": "2025-09-21T04:00:00.000Z",
+    "end": "2025-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-11 00:00:00",
+    "start": "2025-10-11T04:00:00.000Z",
+    "end": "2025-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-11-01T04:00:00.000Z",
+    "end": "2025-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2025-11-02 00:00:00",
     "start": "2025-11-02T04:00:00.000Z",
     "end": "2025-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Sun"

--- a/test/fixtures/BO-2026.json
+++ b/test/fixtures/BO-2026.json
@@ -9,11 +9,20 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2026-01-22 00:00:00",
+    "start": "2026-01-22T04:00:00.000Z",
+    "end": "2026-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2026-02-02 00:00:00",
     "start": "2026-02-02T04:00:00.000Z",
     "end": "2026-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Mon"
   },
@@ -21,7 +30,7 @@
     "date": "2026-02-16 00:00:00",
     "start": "2026-02-16T04:00:00.000Z",
     "end": "2026-02-17T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,37 @@
     "date": "2026-02-17 00:00:00",
     "start": "2026-02-17T04:00:00.000Z",
     "end": "2026-02-18T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2026-03-19 00:00:00",
+    "start": "2026-03-19T04:00:00.000Z",
+    "end": "2026-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T04:00:00.000Z",
+    "end": "2026-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-02 00:00:00",
+    "start": "2026-04-02T04:00:00.000Z",
+    "end": "2026-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -45,55 +81,118 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T04:00:00.000Z",
-    "end": "2026-04-06T04:00:00.000Z",
-    "name": "Pascua",
+    "date": "2026-04-12 00:00:00",
+    "start": "2026-04-12T04:00:00.000Z",
+    "end": "2026-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
     "type": "observance",
-    "rule": "easter",
+    "rule": "04-12",
     "_weekday": "Sun"
   },
   {
-    "date": "2026-05-14 00:00:00",
-    "start": "2026-05-14T04:00:00.000Z",
-    "end": "2026-05-15T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T04:00:00.000Z",
+    "end": "2026-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-27 00:00:00",
+    "start": "2026-05-27T04:00:00.000Z",
+    "end": "2026-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T04:00:00.000Z",
+    "end": "2026-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-06 00:00:00",
+    "start": "2026-06-06T04:00:00.000Z",
+    "end": "2026-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
   },
   {
     "date": "2026-06-21 00:00:00",
     "start": "2026-06-21T04:00:00.000Z",
     "end": "2026-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
     "_weekday": "Sun"
   },
   {
-    "date": "2026-08-02 00:00:00",
-    "start": "2026-08-02T04:00:00.000Z",
-    "end": "2026-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
+    "date": "2026-06-22 00:00:00",
+    "start": "2026-06-22T04:00:00.000Z",
+    "end": "2026-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
     "type": "public",
-    "rule": "08-02",
-    "_weekday": "Sun"
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2026-08-06 00:00:00",
     "start": "2026-08-06T04:00:00.000Z",
     "end": "2026-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Thu"
   },
   {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-17T04:00:00.000Z",
+    "end": "2026-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-21 00:00:00",
+    "start": "2026-09-21T04:00:00.000Z",
+    "end": "2026-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-11 00:00:00",
+    "start": "2026-10-11T04:00:00.000Z",
+    "end": "2026-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-11-01T04:00:00.000Z",
+    "end": "2026-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2026-11-02 00:00:00",
     "start": "2026-11-02T04:00:00.000Z",
     "end": "2026-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Mon"

--- a/test/fixtures/BO-2027.json
+++ b/test/fixtures/BO-2027.json
@@ -9,11 +9,20 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2027-01-22 00:00:00",
+    "start": "2027-01-22T04:00:00.000Z",
+    "end": "2027-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2027-02-02 00:00:00",
     "start": "2027-02-02T04:00:00.000Z",
     "end": "2027-02-03T04:00:00.000Z",
     "name": "Fiesta de la Virgen de Candelaria",
-    "type": "public",
+    "type": "observance",
     "rule": "02-02",
     "_weekday": "Tue"
   },
@@ -21,7 +30,7 @@
     "date": "2027-02-08 00:00:00",
     "start": "2027-02-08T04:00:00.000Z",
     "end": "2027-02-09T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Lunes de Carnaval",
     "type": "public",
     "rule": "easter -48",
     "_weekday": "Mon"
@@ -30,10 +39,37 @@
     "date": "2027-02-09 00:00:00",
     "start": "2027-02-09T04:00:00.000Z",
     "end": "2027-02-10T04:00:00.000Z",
-    "name": "Carnaval",
+    "name": "Martes de Carnaval",
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-19 00:00:00",
+    "start": "2027-03-19T04:00:00.000Z",
+    "end": "2027-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-23 00:00:00",
+    "start": "2027-03-23T04:00:00.000Z",
+    "end": "2027-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-25 00:00:00",
+    "start": "2027-03-25T04:00:00.000Z",
+    "end": "2027-03-26T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -45,55 +81,109 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T04:00:00.000Z",
-    "end": "2027-03-29T04:00:00.000Z",
-    "name": "Pascua",
+    "date": "2027-04-12 00:00:00",
+    "start": "2027-04-12T04:00:00.000Z",
+    "end": "2027-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
     "type": "observance",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "04-12",
+    "_weekday": "Mon"
   },
   {
-    "date": "2027-05-06 00:00:00",
-    "start": "2027-05-06T04:00:00.000Z",
-    "end": "2027-05-07T04:00:00.000Z",
-    "name": "La Asunción",
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T04:00:00.000Z",
+    "end": "2027-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
     "type": "public",
-    "rule": "easter 39",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-06 00:00:00",
+    "start": "2027-06-06T04:00:00.000Z",
+    "end": "2027-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
   },
   {
     "date": "2027-06-21 00:00:00",
     "start": "2027-06-21T04:00:00.000Z",
     "end": "2027-06-22T04:00:00.000Z",
-    "name": "Año Nuevo Andino",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
     "type": "public",
     "rule": "06-21",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2027-08-02 00:00:00",
-    "start": "2027-08-02T04:00:00.000Z",
-    "end": "2027-08-03T04:00:00.000Z",
-    "name": "Día de la Revolución Agraria, Productiva y Comunitaria",
-    "type": "public",
-    "rule": "08-02",
     "_weekday": "Mon"
   },
   {
     "date": "2027-08-06 00:00:00",
     "start": "2027-08-06T04:00:00.000Z",
     "end": "2027-08-07T04:00:00.000Z",
-    "name": "Día de la Patria",
+    "name": "Día de la Independencia",
     "type": "public",
     "rule": "08-06",
     "_weekday": "Fri"
   },
   {
+    "date": "2027-08-17 00:00:00",
+    "start": "2027-08-17T04:00:00.000Z",
+    "end": "2027-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-21 00:00:00",
+    "start": "2027-09-21T04:00:00.000Z",
+    "end": "2027-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-11-01T04:00:00.000Z",
+    "end": "2027-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-11-02 00:00:00",
     "start": "2027-11-02T04:00:00.000Z",
     "end": "2027-11-03T04:00:00.000Z",
-    "name": "Día de los Difuntos",
+    "name": "Todos Santos",
     "type": "public",
     "rule": "11-02",
     "_weekday": "Tue"

--- a/test/fixtures/BO-B-2015.json
+++ b/test/fixtures/BO-B-2015.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T04:00:00.000Z",
+    "end": "2015-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-22 00:00:00",
+    "start": "2015-01-22T04:00:00.000Z",
+    "end": "2015-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-02 00:00:00",
+    "start": "2015-02-02T04:00:00.000Z",
+    "end": "2015-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-03-19 00:00:00",
+    "start": "2015-03-19T04:00:00.000Z",
+    "end": "2015-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-03-23 00:00:00",
+    "start": "2015-03-23T04:00:00.000Z",
+    "end": "2015-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-02 00:00:00",
+    "start": "2015-04-02T04:00:00.000Z",
+    "end": "2015-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T04:00:00.000Z",
+    "end": "2015-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-12 00:00:00",
+    "start": "2015-04-12T04:00:00.000Z",
+    "end": "2015-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T04:00:00.000Z",
+    "end": "2015-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-27 00:00:00",
+    "start": "2015-05-27T04:00:00.000Z",
+    "end": "2015-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T04:00:00.000Z",
+    "end": "2015-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-06 00:00:00",
+    "start": "2015-06-06T04:00:00.000Z",
+    "end": "2015-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-21T04:00:00.000Z",
+    "end": "2015-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-22 00:00:00",
+    "start": "2015-06-22T04:00:00.000Z",
+    "end": "2015-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-06 00:00:00",
+    "start": "2015-08-06T04:00:00.000Z",
+    "end": "2015-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-17T04:00:00.000Z",
+    "end": "2015-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-21 00:00:00",
+    "start": "2015-09-21T04:00:00.000Z",
+    "end": "2015-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-11 00:00:00",
+    "start": "2015-10-11T04:00:00.000Z",
+    "end": "2015-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-11-01T04:00:00.000Z",
+    "end": "2015-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T04:00:00.000Z",
+    "end": "2015-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-11-18 00:00:00",
+    "start": "2015-11-18T04:00:00.000Z",
+    "end": "2015-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T04:00:00.000Z",
+    "end": "2015-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-B-2016.json
+++ b/test/fixtures/BO-B-2016.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T04:00:00.000Z",
+    "end": "2016-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-22 00:00:00",
+    "start": "2016-01-22T04:00:00.000Z",
+    "end": "2016-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-02 00:00:00",
+    "start": "2016-02-02T04:00:00.000Z",
+    "end": "2016-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-03-19 00:00:00",
+    "start": "2016-03-19T04:00:00.000Z",
+    "end": "2016-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-03-23 00:00:00",
+    "start": "2016-03-23T04:00:00.000Z",
+    "end": "2016-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-24 00:00:00",
+    "start": "2016-03-24T04:00:00.000Z",
+    "end": "2016-03-25T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T04:00:00.000Z",
+    "end": "2016-03-26T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-04-12 00:00:00",
+    "start": "2016-04-12T04:00:00.000Z",
+    "end": "2016-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T04:00:00.000Z",
+    "end": "2016-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-02 00:00:00",
+    "start": "2016-05-02T04:00:00.000Z",
+    "end": "2016-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T04:00:00.000Z",
+    "end": "2016-05-27T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-27 00:00:00",
+    "start": "2016-05-27T04:00:00.000Z",
+    "end": "2016-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-06-06 00:00:00",
+    "start": "2016-06-06T04:00:00.000Z",
+    "end": "2016-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-06-21 00:00:00",
+    "start": "2016-06-21T04:00:00.000Z",
+    "end": "2016-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-08-06 00:00:00",
+    "start": "2016-08-06T04:00:00.000Z",
+    "end": "2016-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-17T04:00:00.000Z",
+    "end": "2016-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-21 00:00:00",
+    "start": "2016-09-21T04:00:00.000Z",
+    "end": "2016-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-11 00:00:00",
+    "start": "2016-10-11T04:00:00.000Z",
+    "end": "2016-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-11-01T04:00:00.000Z",
+    "end": "2016-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T04:00:00.000Z",
+    "end": "2016-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-11-18 00:00:00",
+    "start": "2016-11-18T04:00:00.000Z",
+    "end": "2016-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T04:00:00.000Z",
+    "end": "2016-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-26T04:00:00.000Z",
+    "end": "2016-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-B-2017.json
+++ b/test/fixtures/BO-B-2017.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T04:00:00.000Z",
+    "end": "2017-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T04:00:00.000Z",
+    "end": "2017-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-01-22 00:00:00",
+    "start": "2017-01-22T04:00:00.000Z",
+    "end": "2017-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-23 00:00:00",
+    "start": "2017-01-23T04:00:00.000Z",
+    "end": "2017-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-02 00:00:00",
+    "start": "2017-02-02T04:00:00.000Z",
+    "end": "2017-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-19 00:00:00",
+    "start": "2017-03-19T04:00:00.000Z",
+    "end": "2017-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-23 00:00:00",
+    "start": "2017-03-23T04:00:00.000Z",
+    "end": "2017-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-12 00:00:00",
+    "start": "2017-04-12T04:00:00.000Z",
+    "end": "2017-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-13 00:00:00",
+    "start": "2017-04-13T04:00:00.000Z",
+    "end": "2017-04-14T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T04:00:00.000Z",
+    "end": "2017-04-15T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T04:00:00.000Z",
+    "end": "2017-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-27 00:00:00",
+    "start": "2017-05-27T04:00:00.000Z",
+    "end": "2017-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-06-06 00:00:00",
+    "start": "2017-06-06T04:00:00.000Z",
+    "end": "2017-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T04:00:00.000Z",
+    "end": "2017-06-16T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-06-21 00:00:00",
+    "start": "2017-06-21T04:00:00.000Z",
+    "end": "2017-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-08-06 00:00:00",
+    "start": "2017-08-06T04:00:00.000Z",
+    "end": "2017-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-17T04:00:00.000Z",
+    "end": "2017-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-21 00:00:00",
+    "start": "2017-09-21T04:00:00.000Z",
+    "end": "2017-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-11 00:00:00",
+    "start": "2017-10-11T04:00:00.000Z",
+    "end": "2017-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-11-01T04:00:00.000Z",
+    "end": "2017-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T04:00:00.000Z",
+    "end": "2017-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-11-18 00:00:00",
+    "start": "2017-11-18T04:00:00.000Z",
+    "end": "2017-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T04:00:00.000Z",
+    "end": "2017-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-B-2018.json
+++ b/test/fixtures/BO-B-2018.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T04:00:00.000Z",
+    "end": "2018-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-22 00:00:00",
+    "start": "2018-01-22T04:00:00.000Z",
+    "end": "2018-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-02 00:00:00",
+    "start": "2018-02-02T04:00:00.000Z",
+    "end": "2018-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T04:00:00.000Z",
+    "end": "2018-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-03-23 00:00:00",
+    "start": "2018-03-23T04:00:00.000Z",
+    "end": "2018-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-03-29 00:00:00",
+    "start": "2018-03-29T04:00:00.000Z",
+    "end": "2018-03-30T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T04:00:00.000Z",
+    "end": "2018-03-31T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-12 00:00:00",
+    "start": "2018-04-12T04:00:00.000Z",
+    "end": "2018-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T04:00:00.000Z",
+    "end": "2018-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-27T04:00:00.000Z",
+    "end": "2018-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T04:00:00.000Z",
+    "end": "2018-06-01T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-06 00:00:00",
+    "start": "2018-06-06T04:00:00.000Z",
+    "end": "2018-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-06-21 00:00:00",
+    "start": "2018-06-21T04:00:00.000Z",
+    "end": "2018-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T04:00:00.000Z",
+    "end": "2018-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-17T04:00:00.000Z",
+    "end": "2018-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-21 00:00:00",
+    "start": "2018-09-21T04:00:00.000Z",
+    "end": "2018-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-11 00:00:00",
+    "start": "2018-10-11T04:00:00.000Z",
+    "end": "2018-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-11-01T04:00:00.000Z",
+    "end": "2018-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T04:00:00.000Z",
+    "end": "2018-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-11-18 00:00:00",
+    "start": "2018-11-18T04:00:00.000Z",
+    "end": "2018-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-11-19 00:00:00",
+    "start": "2018-11-19T04:00:00.000Z",
+    "end": "2018-11-20T04:00:00.000Z",
+    "name": "Efemérides del Beni (substituto)",
+    "type": "public",
+    "rule": "substitutes 11-18 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T04:00:00.000Z",
+    "end": "2018-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BO-B-2019.json
+++ b/test/fixtures/BO-B-2019.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T04:00:00.000Z",
+    "end": "2019-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-22 00:00:00",
+    "start": "2019-01-22T04:00:00.000Z",
+    "end": "2019-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-02-02 00:00:00",
+    "start": "2019-02-02T04:00:00.000Z",
+    "end": "2019-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-19 00:00:00",
+    "start": "2019-03-19T04:00:00.000Z",
+    "end": "2019-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-23 00:00:00",
+    "start": "2019-03-23T04:00:00.000Z",
+    "end": "2019-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-04-12 00:00:00",
+    "start": "2019-04-12T04:00:00.000Z",
+    "end": "2019-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-18 00:00:00",
+    "start": "2019-04-18T04:00:00.000Z",
+    "end": "2019-04-19T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T04:00:00.000Z",
+    "end": "2019-04-20T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T04:00:00.000Z",
+    "end": "2019-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-27 00:00:00",
+    "start": "2019-05-27T04:00:00.000Z",
+    "end": "2019-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-06-06 00:00:00",
+    "start": "2019-06-06T04:00:00.000Z",
+    "end": "2019-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T04:00:00.000Z",
+    "end": "2019-06-21T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-21T04:00:00.000Z",
+    "end": "2019-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-08-06 00:00:00",
+    "start": "2019-08-06T04:00:00.000Z",
+    "end": "2019-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T04:00:00.000Z",
+    "end": "2019-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-21 00:00:00",
+    "start": "2019-09-21T04:00:00.000Z",
+    "end": "2019-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-11 00:00:00",
+    "start": "2019-10-11T04:00:00.000Z",
+    "end": "2019-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-11-01T04:00:00.000Z",
+    "end": "2019-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T04:00:00.000Z",
+    "end": "2019-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-11-18 00:00:00",
+    "start": "2019-11-18T04:00:00.000Z",
+    "end": "2019-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T04:00:00.000Z",
+    "end": "2019-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-B-2020.json
+++ b/test/fixtures/BO-B-2020.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T04:00:00.000Z",
+    "end": "2020-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-22 00:00:00",
+    "start": "2020-01-22T04:00:00.000Z",
+    "end": "2020-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-02 00:00:00",
+    "start": "2020-02-02T04:00:00.000Z",
+    "end": "2020-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-03-19 00:00:00",
+    "start": "2020-03-19T04:00:00.000Z",
+    "end": "2020-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-03-23 00:00:00",
+    "start": "2020-03-23T04:00:00.000Z",
+    "end": "2020-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-09 00:00:00",
+    "start": "2020-04-09T04:00:00.000Z",
+    "end": "2020-04-10T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T04:00:00.000Z",
+    "end": "2020-04-11T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T04:00:00.000Z",
+    "end": "2020-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T04:00:00.000Z",
+    "end": "2020-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-27 00:00:00",
+    "start": "2020-05-27T04:00:00.000Z",
+    "end": "2020-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-06-06 00:00:00",
+    "start": "2020-06-06T04:00:00.000Z",
+    "end": "2020-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T04:00:00.000Z",
+    "end": "2020-06-12T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-21T04:00:00.000Z",
+    "end": "2020-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-22 00:00:00",
+    "start": "2020-06-22T04:00:00.000Z",
+    "end": "2020-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-06 00:00:00",
+    "start": "2020-08-06T04:00:00.000Z",
+    "end": "2020-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-17T04:00:00.000Z",
+    "end": "2020-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-21 00:00:00",
+    "start": "2020-09-21T04:00:00.000Z",
+    "end": "2020-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-11 00:00:00",
+    "start": "2020-10-11T04:00:00.000Z",
+    "end": "2020-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-11-01T04:00:00.000Z",
+    "end": "2020-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T04:00:00.000Z",
+    "end": "2020-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-11-18 00:00:00",
+    "start": "2020-11-18T04:00:00.000Z",
+    "end": "2020-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T04:00:00.000Z",
+    "end": "2020-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-B-2021.json
+++ b/test/fixtures/BO-B-2021.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T04:00:00.000Z",
+    "end": "2021-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-22 00:00:00",
+    "start": "2021-01-22T04:00:00.000Z",
+    "end": "2021-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-02 00:00:00",
+    "start": "2021-02-02T04:00:00.000Z",
+    "end": "2021-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-03-19 00:00:00",
+    "start": "2021-03-19T04:00:00.000Z",
+    "end": "2021-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-03-23 00:00:00",
+    "start": "2021-03-23T04:00:00.000Z",
+    "end": "2021-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-04-01T04:00:00.000Z",
+    "end": "2021-04-02T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T04:00:00.000Z",
+    "end": "2021-04-03T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T04:00:00.000Z",
+    "end": "2021-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T04:00:00.000Z",
+    "end": "2021-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-27 00:00:00",
+    "start": "2021-05-27T04:00:00.000Z",
+    "end": "2021-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T04:00:00.000Z",
+    "end": "2021-06-04T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-06 00:00:00",
+    "start": "2021-06-06T04:00:00.000Z",
+    "end": "2021-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T04:00:00.000Z",
+    "end": "2021-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-06 00:00:00",
+    "start": "2021-08-06T04:00:00.000Z",
+    "end": "2021-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-17T04:00:00.000Z",
+    "end": "2021-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-21 00:00:00",
+    "start": "2021-09-21T04:00:00.000Z",
+    "end": "2021-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-11-01T04:00:00.000Z",
+    "end": "2021-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T04:00:00.000Z",
+    "end": "2021-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-11-18 00:00:00",
+    "start": "2021-11-18T04:00:00.000Z",
+    "end": "2021-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T04:00:00.000Z",
+    "end": "2021-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-B-2022.json
+++ b/test/fixtures/BO-B-2022.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T04:00:00.000Z",
+    "end": "2022-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-22 00:00:00",
+    "start": "2022-01-22T04:00:00.000Z",
+    "end": "2022-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-02 00:00:00",
+    "start": "2022-02-02T04:00:00.000Z",
+    "end": "2022-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-19 00:00:00",
+    "start": "2022-03-19T04:00:00.000Z",
+    "end": "2022-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-03-23 00:00:00",
+    "start": "2022-03-23T04:00:00.000Z",
+    "end": "2022-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-12 00:00:00",
+    "start": "2022-04-12T04:00:00.000Z",
+    "end": "2022-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-14 00:00:00",
+    "start": "2022-04-14T04:00:00.000Z",
+    "end": "2022-04-15T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T04:00:00.000Z",
+    "end": "2022-04-16T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T04:00:00.000Z",
+    "end": "2022-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-02T04:00:00.000Z",
+    "end": "2022-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-27 00:00:00",
+    "start": "2022-05-27T04:00:00.000Z",
+    "end": "2022-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-06-06 00:00:00",
+    "start": "2022-06-06T04:00:00.000Z",
+    "end": "2022-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T04:00:00.000Z",
+    "end": "2022-06-17T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-06-21 00:00:00",
+    "start": "2022-06-21T04:00:00.000Z",
+    "end": "2022-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T04:00:00.000Z",
+    "end": "2022-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-17T04:00:00.000Z",
+    "end": "2022-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-21 00:00:00",
+    "start": "2022-09-21T04:00:00.000Z",
+    "end": "2022-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-11 00:00:00",
+    "start": "2022-10-11T04:00:00.000Z",
+    "end": "2022-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-11-01T04:00:00.000Z",
+    "end": "2022-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T04:00:00.000Z",
+    "end": "2022-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-11-18 00:00:00",
+    "start": "2022-11-18T04:00:00.000Z",
+    "end": "2022-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T04:00:00.000Z",
+    "end": "2022-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-26T04:00:00.000Z",
+    "end": "2022-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-B-2023.json
+++ b/test/fixtures/BO-B-2023.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T04:00:00.000Z",
+    "end": "2023-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T04:00:00.000Z",
+    "end": "2023-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-01-22 00:00:00",
+    "start": "2023-01-22T04:00:00.000Z",
+    "end": "2023-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-23 00:00:00",
+    "start": "2023-01-23T04:00:00.000Z",
+    "end": "2023-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-02 00:00:00",
+    "start": "2023-02-02T04:00:00.000Z",
+    "end": "2023-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-03-19 00:00:00",
+    "start": "2023-03-19T04:00:00.000Z",
+    "end": "2023-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-03-23 00:00:00",
+    "start": "2023-03-23T04:00:00.000Z",
+    "end": "2023-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-06 00:00:00",
+    "start": "2023-04-06T04:00:00.000Z",
+    "end": "2023-04-07T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T04:00:00.000Z",
+    "end": "2023-04-08T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-12 00:00:00",
+    "start": "2023-04-12T04:00:00.000Z",
+    "end": "2023-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T04:00:00.000Z",
+    "end": "2023-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-27 00:00:00",
+    "start": "2023-05-27T04:00:00.000Z",
+    "end": "2023-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-06-06 00:00:00",
+    "start": "2023-06-06T04:00:00.000Z",
+    "end": "2023-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T04:00:00.000Z",
+    "end": "2023-06-09T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-21 00:00:00",
+    "start": "2023-06-21T04:00:00.000Z",
+    "end": "2023-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T04:00:00.000Z",
+    "end": "2023-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-17T04:00:00.000Z",
+    "end": "2023-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-21 00:00:00",
+    "start": "2023-09-21T04:00:00.000Z",
+    "end": "2023-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-11 00:00:00",
+    "start": "2023-10-11T04:00:00.000Z",
+    "end": "2023-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-11-01T04:00:00.000Z",
+    "end": "2023-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T04:00:00.000Z",
+    "end": "2023-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-11-18 00:00:00",
+    "start": "2023-11-18T04:00:00.000Z",
+    "end": "2023-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T04:00:00.000Z",
+    "end": "2023-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-B-2024.json
+++ b/test/fixtures/BO-B-2024.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T04:00:00.000Z",
+    "end": "2024-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-22 00:00:00",
+    "start": "2024-01-22T04:00:00.000Z",
+    "end": "2024-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-02 00:00:00",
+    "start": "2024-02-02T04:00:00.000Z",
+    "end": "2024-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-19 00:00:00",
+    "start": "2024-03-19T04:00:00.000Z",
+    "end": "2024-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-23 00:00:00",
+    "start": "2024-03-23T04:00:00.000Z",
+    "end": "2024-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-28 00:00:00",
+    "start": "2024-03-28T04:00:00.000Z",
+    "end": "2024-03-29T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T04:00:00.000Z",
+    "end": "2024-03-30T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-04-12 00:00:00",
+    "start": "2024-04-12T04:00:00.000Z",
+    "end": "2024-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T04:00:00.000Z",
+    "end": "2024-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-27 00:00:00",
+    "start": "2024-05-27T04:00:00.000Z",
+    "end": "2024-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T04:00:00.000Z",
+    "end": "2024-05-31T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-06 00:00:00",
+    "start": "2024-06-06T04:00:00.000Z",
+    "end": "2024-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-21T04:00:00.000Z",
+    "end": "2024-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T04:00:00.000Z",
+    "end": "2024-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T04:00:00.000Z",
+    "end": "2024-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-21 00:00:00",
+    "start": "2024-09-21T04:00:00.000Z",
+    "end": "2024-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T04:00:00.000Z",
+    "end": "2024-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-11-01T04:00:00.000Z",
+    "end": "2024-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T04:00:00.000Z",
+    "end": "2024-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-11-18 00:00:00",
+    "start": "2024-11-18T04:00:00.000Z",
+    "end": "2024-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T04:00:00.000Z",
+    "end": "2024-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-B-2025.json
+++ b/test/fixtures/BO-B-2025.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T04:00:00.000Z",
+    "end": "2025-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-22 00:00:00",
+    "start": "2025-01-22T04:00:00.000Z",
+    "end": "2025-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-02-02 00:00:00",
+    "start": "2025-02-02T04:00:00.000Z",
+    "end": "2025-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-19 00:00:00",
+    "start": "2025-03-19T04:00:00.000Z",
+    "end": "2025-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-23 00:00:00",
+    "start": "2025-03-23T04:00:00.000Z",
+    "end": "2025-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-12 00:00:00",
+    "start": "2025-04-12T04:00:00.000Z",
+    "end": "2025-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-17 00:00:00",
+    "start": "2025-04-17T04:00:00.000Z",
+    "end": "2025-04-18T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T04:00:00.000Z",
+    "end": "2025-04-19T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T04:00:00.000Z",
+    "end": "2025-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-27 00:00:00",
+    "start": "2025-05-27T04:00:00.000Z",
+    "end": "2025-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-06-06 00:00:00",
+    "start": "2025-06-06T04:00:00.000Z",
+    "end": "2025-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T04:00:00.000Z",
+    "end": "2025-06-20T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-21 00:00:00",
+    "start": "2025-06-21T04:00:00.000Z",
+    "end": "2025-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T04:00:00.000Z",
+    "end": "2025-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T04:00:00.000Z",
+    "end": "2025-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-21 00:00:00",
+    "start": "2025-09-21T04:00:00.000Z",
+    "end": "2025-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-11 00:00:00",
+    "start": "2025-10-11T04:00:00.000Z",
+    "end": "2025-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-11-01T04:00:00.000Z",
+    "end": "2025-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T04:00:00.000Z",
+    "end": "2025-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-11-18 00:00:00",
+    "start": "2025-11-18T04:00:00.000Z",
+    "end": "2025-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T04:00:00.000Z",
+    "end": "2025-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BO-B-2026.json
+++ b/test/fixtures/BO-B-2026.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T04:00:00.000Z",
+    "end": "2026-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-22 00:00:00",
+    "start": "2026-01-22T04:00:00.000Z",
+    "end": "2026-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-02 00:00:00",
+    "start": "2026-02-02T04:00:00.000Z",
+    "end": "2026-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-03-19 00:00:00",
+    "start": "2026-03-19T04:00:00.000Z",
+    "end": "2026-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T04:00:00.000Z",
+    "end": "2026-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-02 00:00:00",
+    "start": "2026-04-02T04:00:00.000Z",
+    "end": "2026-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T04:00:00.000Z",
+    "end": "2026-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-12 00:00:00",
+    "start": "2026-04-12T04:00:00.000Z",
+    "end": "2026-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T04:00:00.000Z",
+    "end": "2026-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-27 00:00:00",
+    "start": "2026-05-27T04:00:00.000Z",
+    "end": "2026-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T04:00:00.000Z",
+    "end": "2026-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-06 00:00:00",
+    "start": "2026-06-06T04:00:00.000Z",
+    "end": "2026-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-06-21 00:00:00",
+    "start": "2026-06-21T04:00:00.000Z",
+    "end": "2026-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-22 00:00:00",
+    "start": "2026-06-22T04:00:00.000Z",
+    "end": "2026-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T04:00:00.000Z",
+    "end": "2026-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-17T04:00:00.000Z",
+    "end": "2026-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-21 00:00:00",
+    "start": "2026-09-21T04:00:00.000Z",
+    "end": "2026-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-11 00:00:00",
+    "start": "2026-10-11T04:00:00.000Z",
+    "end": "2026-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-11-01T04:00:00.000Z",
+    "end": "2026-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T04:00:00.000Z",
+    "end": "2026-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-11-18 00:00:00",
+    "start": "2026-11-18T04:00:00.000Z",
+    "end": "2026-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T04:00:00.000Z",
+    "end": "2026-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-B-2027.json
+++ b/test/fixtures/BO-B-2027.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T04:00:00.000Z",
+    "end": "2027-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-22 00:00:00",
+    "start": "2027-01-22T04:00:00.000Z",
+    "end": "2027-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-02 00:00:00",
+    "start": "2027-02-02T04:00:00.000Z",
+    "end": "2027-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-19 00:00:00",
+    "start": "2027-03-19T04:00:00.000Z",
+    "end": "2027-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-23 00:00:00",
+    "start": "2027-03-23T04:00:00.000Z",
+    "end": "2027-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-25 00:00:00",
+    "start": "2027-03-25T04:00:00.000Z",
+    "end": "2027-03-26T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T04:00:00.000Z",
+    "end": "2027-03-27T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-04-12 00:00:00",
+    "start": "2027-04-12T04:00:00.000Z",
+    "end": "2027-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T04:00:00.000Z",
+    "end": "2027-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-06 00:00:00",
+    "start": "2027-06-06T04:00:00.000Z",
+    "end": "2027-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T04:00:00.000Z",
+    "end": "2027-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T04:00:00.000Z",
+    "end": "2027-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-08-17 00:00:00",
+    "start": "2027-08-17T04:00:00.000Z",
+    "end": "2027-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-21 00:00:00",
+    "start": "2027-09-21T04:00:00.000Z",
+    "end": "2027-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-11-01T04:00:00.000Z",
+    "end": "2027-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T04:00:00.000Z",
+    "end": "2027-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-11-18 00:00:00",
+    "start": "2027-11-18T04:00:00.000Z",
+    "end": "2027-11-19T04:00:00.000Z",
+    "name": "Efemérides del Beni",
+    "type": "public",
+    "rule": "11-18",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T04:00:00.000Z",
+    "end": "2027-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-C-2015.json
+++ b/test/fixtures/BO-C-2015.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T04:00:00.000Z",
+    "end": "2015-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-22 00:00:00",
+    "start": "2015-01-22T04:00:00.000Z",
+    "end": "2015-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-02 00:00:00",
+    "start": "2015-02-02T04:00:00.000Z",
+    "end": "2015-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-03-19 00:00:00",
+    "start": "2015-03-19T04:00:00.000Z",
+    "end": "2015-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-03-23 00:00:00",
+    "start": "2015-03-23T04:00:00.000Z",
+    "end": "2015-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-02 00:00:00",
+    "start": "2015-04-02T04:00:00.000Z",
+    "end": "2015-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T04:00:00.000Z",
+    "end": "2015-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-12 00:00:00",
+    "start": "2015-04-12T04:00:00.000Z",
+    "end": "2015-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T04:00:00.000Z",
+    "end": "2015-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-27 00:00:00",
+    "start": "2015-05-27T04:00:00.000Z",
+    "end": "2015-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T04:00:00.000Z",
+    "end": "2015-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-06 00:00:00",
+    "start": "2015-06-06T04:00:00.000Z",
+    "end": "2015-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-21T04:00:00.000Z",
+    "end": "2015-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-22 00:00:00",
+    "start": "2015-06-22T04:00:00.000Z",
+    "end": "2015-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-06 00:00:00",
+    "start": "2015-08-06T04:00:00.000Z",
+    "end": "2015-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-17T04:00:00.000Z",
+    "end": "2015-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-14 00:00:00",
+    "start": "2015-09-14T04:00:00.000Z",
+    "end": "2015-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-21 00:00:00",
+    "start": "2015-09-21T04:00:00.000Z",
+    "end": "2015-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-11 00:00:00",
+    "start": "2015-10-11T04:00:00.000Z",
+    "end": "2015-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-11-01T04:00:00.000Z",
+    "end": "2015-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T04:00:00.000Z",
+    "end": "2015-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T04:00:00.000Z",
+    "end": "2015-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-C-2016.json
+++ b/test/fixtures/BO-C-2016.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T04:00:00.000Z",
+    "end": "2016-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-22 00:00:00",
+    "start": "2016-01-22T04:00:00.000Z",
+    "end": "2016-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-02 00:00:00",
+    "start": "2016-02-02T04:00:00.000Z",
+    "end": "2016-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-03-19 00:00:00",
+    "start": "2016-03-19T04:00:00.000Z",
+    "end": "2016-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-03-23 00:00:00",
+    "start": "2016-03-23T04:00:00.000Z",
+    "end": "2016-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-24 00:00:00",
+    "start": "2016-03-24T04:00:00.000Z",
+    "end": "2016-03-25T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T04:00:00.000Z",
+    "end": "2016-03-26T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-04-12 00:00:00",
+    "start": "2016-04-12T04:00:00.000Z",
+    "end": "2016-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T04:00:00.000Z",
+    "end": "2016-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-02 00:00:00",
+    "start": "2016-05-02T04:00:00.000Z",
+    "end": "2016-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T04:00:00.000Z",
+    "end": "2016-05-27T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-27 00:00:00",
+    "start": "2016-05-27T04:00:00.000Z",
+    "end": "2016-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-06-06 00:00:00",
+    "start": "2016-06-06T04:00:00.000Z",
+    "end": "2016-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-06-21 00:00:00",
+    "start": "2016-06-21T04:00:00.000Z",
+    "end": "2016-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-08-06 00:00:00",
+    "start": "2016-08-06T04:00:00.000Z",
+    "end": "2016-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-17T04:00:00.000Z",
+    "end": "2016-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-14 00:00:00",
+    "start": "2016-09-14T04:00:00.000Z",
+    "end": "2016-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-21 00:00:00",
+    "start": "2016-09-21T04:00:00.000Z",
+    "end": "2016-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-11 00:00:00",
+    "start": "2016-10-11T04:00:00.000Z",
+    "end": "2016-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-11-01T04:00:00.000Z",
+    "end": "2016-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T04:00:00.000Z",
+    "end": "2016-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T04:00:00.000Z",
+    "end": "2016-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-26T04:00:00.000Z",
+    "end": "2016-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-C-2017.json
+++ b/test/fixtures/BO-C-2017.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T04:00:00.000Z",
+    "end": "2017-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T04:00:00.000Z",
+    "end": "2017-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-01-22 00:00:00",
+    "start": "2017-01-22T04:00:00.000Z",
+    "end": "2017-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-23 00:00:00",
+    "start": "2017-01-23T04:00:00.000Z",
+    "end": "2017-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-02 00:00:00",
+    "start": "2017-02-02T04:00:00.000Z",
+    "end": "2017-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-19 00:00:00",
+    "start": "2017-03-19T04:00:00.000Z",
+    "end": "2017-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-23 00:00:00",
+    "start": "2017-03-23T04:00:00.000Z",
+    "end": "2017-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-12 00:00:00",
+    "start": "2017-04-12T04:00:00.000Z",
+    "end": "2017-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-13 00:00:00",
+    "start": "2017-04-13T04:00:00.000Z",
+    "end": "2017-04-14T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T04:00:00.000Z",
+    "end": "2017-04-15T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T04:00:00.000Z",
+    "end": "2017-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-27 00:00:00",
+    "start": "2017-05-27T04:00:00.000Z",
+    "end": "2017-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-06-06 00:00:00",
+    "start": "2017-06-06T04:00:00.000Z",
+    "end": "2017-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T04:00:00.000Z",
+    "end": "2017-06-16T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-06-21 00:00:00",
+    "start": "2017-06-21T04:00:00.000Z",
+    "end": "2017-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-08-06 00:00:00",
+    "start": "2017-08-06T04:00:00.000Z",
+    "end": "2017-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-17T04:00:00.000Z",
+    "end": "2017-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-14 00:00:00",
+    "start": "2017-09-14T04:00:00.000Z",
+    "end": "2017-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-21 00:00:00",
+    "start": "2017-09-21T04:00:00.000Z",
+    "end": "2017-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-11 00:00:00",
+    "start": "2017-10-11T04:00:00.000Z",
+    "end": "2017-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-11-01T04:00:00.000Z",
+    "end": "2017-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T04:00:00.000Z",
+    "end": "2017-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T04:00:00.000Z",
+    "end": "2017-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-C-2018.json
+++ b/test/fixtures/BO-C-2018.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T04:00:00.000Z",
+    "end": "2018-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-22 00:00:00",
+    "start": "2018-01-22T04:00:00.000Z",
+    "end": "2018-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-02 00:00:00",
+    "start": "2018-02-02T04:00:00.000Z",
+    "end": "2018-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T04:00:00.000Z",
+    "end": "2018-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-03-23 00:00:00",
+    "start": "2018-03-23T04:00:00.000Z",
+    "end": "2018-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-03-29 00:00:00",
+    "start": "2018-03-29T04:00:00.000Z",
+    "end": "2018-03-30T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T04:00:00.000Z",
+    "end": "2018-03-31T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-12 00:00:00",
+    "start": "2018-04-12T04:00:00.000Z",
+    "end": "2018-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T04:00:00.000Z",
+    "end": "2018-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-27T04:00:00.000Z",
+    "end": "2018-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T04:00:00.000Z",
+    "end": "2018-06-01T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-06 00:00:00",
+    "start": "2018-06-06T04:00:00.000Z",
+    "end": "2018-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-06-21 00:00:00",
+    "start": "2018-06-21T04:00:00.000Z",
+    "end": "2018-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T04:00:00.000Z",
+    "end": "2018-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-17T04:00:00.000Z",
+    "end": "2018-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-14 00:00:00",
+    "start": "2018-09-14T04:00:00.000Z",
+    "end": "2018-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-21 00:00:00",
+    "start": "2018-09-21T04:00:00.000Z",
+    "end": "2018-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-11 00:00:00",
+    "start": "2018-10-11T04:00:00.000Z",
+    "end": "2018-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-11-01T04:00:00.000Z",
+    "end": "2018-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T04:00:00.000Z",
+    "end": "2018-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T04:00:00.000Z",
+    "end": "2018-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BO-C-2019.json
+++ b/test/fixtures/BO-C-2019.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T04:00:00.000Z",
+    "end": "2019-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-22 00:00:00",
+    "start": "2019-01-22T04:00:00.000Z",
+    "end": "2019-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-02-02 00:00:00",
+    "start": "2019-02-02T04:00:00.000Z",
+    "end": "2019-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-19 00:00:00",
+    "start": "2019-03-19T04:00:00.000Z",
+    "end": "2019-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-23 00:00:00",
+    "start": "2019-03-23T04:00:00.000Z",
+    "end": "2019-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-04-12 00:00:00",
+    "start": "2019-04-12T04:00:00.000Z",
+    "end": "2019-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-18 00:00:00",
+    "start": "2019-04-18T04:00:00.000Z",
+    "end": "2019-04-19T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T04:00:00.000Z",
+    "end": "2019-04-20T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T04:00:00.000Z",
+    "end": "2019-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-27 00:00:00",
+    "start": "2019-05-27T04:00:00.000Z",
+    "end": "2019-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-06-06 00:00:00",
+    "start": "2019-06-06T04:00:00.000Z",
+    "end": "2019-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T04:00:00.000Z",
+    "end": "2019-06-21T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-21T04:00:00.000Z",
+    "end": "2019-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-08-06 00:00:00",
+    "start": "2019-08-06T04:00:00.000Z",
+    "end": "2019-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T04:00:00.000Z",
+    "end": "2019-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-14 00:00:00",
+    "start": "2019-09-14T04:00:00.000Z",
+    "end": "2019-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-21 00:00:00",
+    "start": "2019-09-21T04:00:00.000Z",
+    "end": "2019-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-11 00:00:00",
+    "start": "2019-10-11T04:00:00.000Z",
+    "end": "2019-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-11-01T04:00:00.000Z",
+    "end": "2019-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T04:00:00.000Z",
+    "end": "2019-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T04:00:00.000Z",
+    "end": "2019-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-C-2020.json
+++ b/test/fixtures/BO-C-2020.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T04:00:00.000Z",
+    "end": "2020-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-22 00:00:00",
+    "start": "2020-01-22T04:00:00.000Z",
+    "end": "2020-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-02 00:00:00",
+    "start": "2020-02-02T04:00:00.000Z",
+    "end": "2020-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-03-19 00:00:00",
+    "start": "2020-03-19T04:00:00.000Z",
+    "end": "2020-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-03-23 00:00:00",
+    "start": "2020-03-23T04:00:00.000Z",
+    "end": "2020-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-09 00:00:00",
+    "start": "2020-04-09T04:00:00.000Z",
+    "end": "2020-04-10T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T04:00:00.000Z",
+    "end": "2020-04-11T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T04:00:00.000Z",
+    "end": "2020-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T04:00:00.000Z",
+    "end": "2020-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-27 00:00:00",
+    "start": "2020-05-27T04:00:00.000Z",
+    "end": "2020-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-06-06 00:00:00",
+    "start": "2020-06-06T04:00:00.000Z",
+    "end": "2020-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T04:00:00.000Z",
+    "end": "2020-06-12T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-21T04:00:00.000Z",
+    "end": "2020-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-22 00:00:00",
+    "start": "2020-06-22T04:00:00.000Z",
+    "end": "2020-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-06 00:00:00",
+    "start": "2020-08-06T04:00:00.000Z",
+    "end": "2020-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-17T04:00:00.000Z",
+    "end": "2020-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-14 00:00:00",
+    "start": "2020-09-14T04:00:00.000Z",
+    "end": "2020-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-21 00:00:00",
+    "start": "2020-09-21T04:00:00.000Z",
+    "end": "2020-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-11 00:00:00",
+    "start": "2020-10-11T04:00:00.000Z",
+    "end": "2020-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-11-01T04:00:00.000Z",
+    "end": "2020-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T04:00:00.000Z",
+    "end": "2020-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T04:00:00.000Z",
+    "end": "2020-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-C-2021.json
+++ b/test/fixtures/BO-C-2021.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T04:00:00.000Z",
+    "end": "2021-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-22 00:00:00",
+    "start": "2021-01-22T04:00:00.000Z",
+    "end": "2021-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-02 00:00:00",
+    "start": "2021-02-02T04:00:00.000Z",
+    "end": "2021-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-03-19 00:00:00",
+    "start": "2021-03-19T04:00:00.000Z",
+    "end": "2021-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-03-23 00:00:00",
+    "start": "2021-03-23T04:00:00.000Z",
+    "end": "2021-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-04-01T04:00:00.000Z",
+    "end": "2021-04-02T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T04:00:00.000Z",
+    "end": "2021-04-03T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T04:00:00.000Z",
+    "end": "2021-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T04:00:00.000Z",
+    "end": "2021-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-27 00:00:00",
+    "start": "2021-05-27T04:00:00.000Z",
+    "end": "2021-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T04:00:00.000Z",
+    "end": "2021-06-04T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-06 00:00:00",
+    "start": "2021-06-06T04:00:00.000Z",
+    "end": "2021-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T04:00:00.000Z",
+    "end": "2021-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-06 00:00:00",
+    "start": "2021-08-06T04:00:00.000Z",
+    "end": "2021-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-17T04:00:00.000Z",
+    "end": "2021-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-14 00:00:00",
+    "start": "2021-09-14T04:00:00.000Z",
+    "end": "2021-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-21 00:00:00",
+    "start": "2021-09-21T04:00:00.000Z",
+    "end": "2021-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-11-01T04:00:00.000Z",
+    "end": "2021-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T04:00:00.000Z",
+    "end": "2021-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T04:00:00.000Z",
+    "end": "2021-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-C-2022.json
+++ b/test/fixtures/BO-C-2022.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T04:00:00.000Z",
+    "end": "2022-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-22 00:00:00",
+    "start": "2022-01-22T04:00:00.000Z",
+    "end": "2022-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-02 00:00:00",
+    "start": "2022-02-02T04:00:00.000Z",
+    "end": "2022-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-19 00:00:00",
+    "start": "2022-03-19T04:00:00.000Z",
+    "end": "2022-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-03-23 00:00:00",
+    "start": "2022-03-23T04:00:00.000Z",
+    "end": "2022-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-12 00:00:00",
+    "start": "2022-04-12T04:00:00.000Z",
+    "end": "2022-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-14 00:00:00",
+    "start": "2022-04-14T04:00:00.000Z",
+    "end": "2022-04-15T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T04:00:00.000Z",
+    "end": "2022-04-16T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T04:00:00.000Z",
+    "end": "2022-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-02T04:00:00.000Z",
+    "end": "2022-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-27 00:00:00",
+    "start": "2022-05-27T04:00:00.000Z",
+    "end": "2022-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-06-06 00:00:00",
+    "start": "2022-06-06T04:00:00.000Z",
+    "end": "2022-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T04:00:00.000Z",
+    "end": "2022-06-17T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-06-21 00:00:00",
+    "start": "2022-06-21T04:00:00.000Z",
+    "end": "2022-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T04:00:00.000Z",
+    "end": "2022-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-17T04:00:00.000Z",
+    "end": "2022-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-14 00:00:00",
+    "start": "2022-09-14T04:00:00.000Z",
+    "end": "2022-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-21 00:00:00",
+    "start": "2022-09-21T04:00:00.000Z",
+    "end": "2022-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-11 00:00:00",
+    "start": "2022-10-11T04:00:00.000Z",
+    "end": "2022-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-11-01T04:00:00.000Z",
+    "end": "2022-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T04:00:00.000Z",
+    "end": "2022-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T04:00:00.000Z",
+    "end": "2022-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-26T04:00:00.000Z",
+    "end": "2022-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-C-2023.json
+++ b/test/fixtures/BO-C-2023.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T04:00:00.000Z",
+    "end": "2023-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T04:00:00.000Z",
+    "end": "2023-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-01-22 00:00:00",
+    "start": "2023-01-22T04:00:00.000Z",
+    "end": "2023-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-23 00:00:00",
+    "start": "2023-01-23T04:00:00.000Z",
+    "end": "2023-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-02 00:00:00",
+    "start": "2023-02-02T04:00:00.000Z",
+    "end": "2023-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-03-19 00:00:00",
+    "start": "2023-03-19T04:00:00.000Z",
+    "end": "2023-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-03-23 00:00:00",
+    "start": "2023-03-23T04:00:00.000Z",
+    "end": "2023-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-06 00:00:00",
+    "start": "2023-04-06T04:00:00.000Z",
+    "end": "2023-04-07T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T04:00:00.000Z",
+    "end": "2023-04-08T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-12 00:00:00",
+    "start": "2023-04-12T04:00:00.000Z",
+    "end": "2023-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T04:00:00.000Z",
+    "end": "2023-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-27 00:00:00",
+    "start": "2023-05-27T04:00:00.000Z",
+    "end": "2023-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-06-06 00:00:00",
+    "start": "2023-06-06T04:00:00.000Z",
+    "end": "2023-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T04:00:00.000Z",
+    "end": "2023-06-09T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-21 00:00:00",
+    "start": "2023-06-21T04:00:00.000Z",
+    "end": "2023-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T04:00:00.000Z",
+    "end": "2023-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-17T04:00:00.000Z",
+    "end": "2023-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-14 00:00:00",
+    "start": "2023-09-14T04:00:00.000Z",
+    "end": "2023-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-21 00:00:00",
+    "start": "2023-09-21T04:00:00.000Z",
+    "end": "2023-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-11 00:00:00",
+    "start": "2023-10-11T04:00:00.000Z",
+    "end": "2023-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-11-01T04:00:00.000Z",
+    "end": "2023-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T04:00:00.000Z",
+    "end": "2023-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T04:00:00.000Z",
+    "end": "2023-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-C-2024.json
+++ b/test/fixtures/BO-C-2024.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T04:00:00.000Z",
+    "end": "2024-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-22 00:00:00",
+    "start": "2024-01-22T04:00:00.000Z",
+    "end": "2024-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-02 00:00:00",
+    "start": "2024-02-02T04:00:00.000Z",
+    "end": "2024-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-19 00:00:00",
+    "start": "2024-03-19T04:00:00.000Z",
+    "end": "2024-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-23 00:00:00",
+    "start": "2024-03-23T04:00:00.000Z",
+    "end": "2024-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-28 00:00:00",
+    "start": "2024-03-28T04:00:00.000Z",
+    "end": "2024-03-29T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T04:00:00.000Z",
+    "end": "2024-03-30T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-04-12 00:00:00",
+    "start": "2024-04-12T04:00:00.000Z",
+    "end": "2024-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T04:00:00.000Z",
+    "end": "2024-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-27 00:00:00",
+    "start": "2024-05-27T04:00:00.000Z",
+    "end": "2024-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T04:00:00.000Z",
+    "end": "2024-05-31T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-06 00:00:00",
+    "start": "2024-06-06T04:00:00.000Z",
+    "end": "2024-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-21T04:00:00.000Z",
+    "end": "2024-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T04:00:00.000Z",
+    "end": "2024-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T04:00:00.000Z",
+    "end": "2024-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-14 00:00:00",
+    "start": "2024-09-14T04:00:00.000Z",
+    "end": "2024-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-21 00:00:00",
+    "start": "2024-09-21T04:00:00.000Z",
+    "end": "2024-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T04:00:00.000Z",
+    "end": "2024-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-11-01T04:00:00.000Z",
+    "end": "2024-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T04:00:00.000Z",
+    "end": "2024-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T04:00:00.000Z",
+    "end": "2024-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-C-2025.json
+++ b/test/fixtures/BO-C-2025.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T04:00:00.000Z",
+    "end": "2025-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-22 00:00:00",
+    "start": "2025-01-22T04:00:00.000Z",
+    "end": "2025-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-02-02 00:00:00",
+    "start": "2025-02-02T04:00:00.000Z",
+    "end": "2025-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-19 00:00:00",
+    "start": "2025-03-19T04:00:00.000Z",
+    "end": "2025-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-23 00:00:00",
+    "start": "2025-03-23T04:00:00.000Z",
+    "end": "2025-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-12 00:00:00",
+    "start": "2025-04-12T04:00:00.000Z",
+    "end": "2025-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-17 00:00:00",
+    "start": "2025-04-17T04:00:00.000Z",
+    "end": "2025-04-18T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T04:00:00.000Z",
+    "end": "2025-04-19T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T04:00:00.000Z",
+    "end": "2025-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-27 00:00:00",
+    "start": "2025-05-27T04:00:00.000Z",
+    "end": "2025-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-06-06 00:00:00",
+    "start": "2025-06-06T04:00:00.000Z",
+    "end": "2025-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T04:00:00.000Z",
+    "end": "2025-06-20T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-21 00:00:00",
+    "start": "2025-06-21T04:00:00.000Z",
+    "end": "2025-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T04:00:00.000Z",
+    "end": "2025-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T04:00:00.000Z",
+    "end": "2025-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-14 00:00:00",
+    "start": "2025-09-14T04:00:00.000Z",
+    "end": "2025-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-15 00:00:00",
+    "start": "2025-09-15T04:00:00.000Z",
+    "end": "2025-09-16T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba (substituto)",
+    "type": "public",
+    "rule": "substitutes 09-14 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-09-21 00:00:00",
+    "start": "2025-09-21T04:00:00.000Z",
+    "end": "2025-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-11 00:00:00",
+    "start": "2025-10-11T04:00:00.000Z",
+    "end": "2025-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-11-01T04:00:00.000Z",
+    "end": "2025-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T04:00:00.000Z",
+    "end": "2025-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T04:00:00.000Z",
+    "end": "2025-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BO-C-2026.json
+++ b/test/fixtures/BO-C-2026.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T04:00:00.000Z",
+    "end": "2026-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-22 00:00:00",
+    "start": "2026-01-22T04:00:00.000Z",
+    "end": "2026-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-02 00:00:00",
+    "start": "2026-02-02T04:00:00.000Z",
+    "end": "2026-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-03-19 00:00:00",
+    "start": "2026-03-19T04:00:00.000Z",
+    "end": "2026-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T04:00:00.000Z",
+    "end": "2026-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-02 00:00:00",
+    "start": "2026-04-02T04:00:00.000Z",
+    "end": "2026-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T04:00:00.000Z",
+    "end": "2026-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-12 00:00:00",
+    "start": "2026-04-12T04:00:00.000Z",
+    "end": "2026-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T04:00:00.000Z",
+    "end": "2026-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-27 00:00:00",
+    "start": "2026-05-27T04:00:00.000Z",
+    "end": "2026-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T04:00:00.000Z",
+    "end": "2026-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-06 00:00:00",
+    "start": "2026-06-06T04:00:00.000Z",
+    "end": "2026-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-06-21 00:00:00",
+    "start": "2026-06-21T04:00:00.000Z",
+    "end": "2026-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-22 00:00:00",
+    "start": "2026-06-22T04:00:00.000Z",
+    "end": "2026-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T04:00:00.000Z",
+    "end": "2026-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-17T04:00:00.000Z",
+    "end": "2026-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-14 00:00:00",
+    "start": "2026-09-14T04:00:00.000Z",
+    "end": "2026-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-21 00:00:00",
+    "start": "2026-09-21T04:00:00.000Z",
+    "end": "2026-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-11 00:00:00",
+    "start": "2026-10-11T04:00:00.000Z",
+    "end": "2026-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-11-01T04:00:00.000Z",
+    "end": "2026-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T04:00:00.000Z",
+    "end": "2026-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T04:00:00.000Z",
+    "end": "2026-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-C-2027.json
+++ b/test/fixtures/BO-C-2027.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T04:00:00.000Z",
+    "end": "2027-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-22 00:00:00",
+    "start": "2027-01-22T04:00:00.000Z",
+    "end": "2027-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-02 00:00:00",
+    "start": "2027-02-02T04:00:00.000Z",
+    "end": "2027-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-19 00:00:00",
+    "start": "2027-03-19T04:00:00.000Z",
+    "end": "2027-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-23 00:00:00",
+    "start": "2027-03-23T04:00:00.000Z",
+    "end": "2027-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-25 00:00:00",
+    "start": "2027-03-25T04:00:00.000Z",
+    "end": "2027-03-26T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T04:00:00.000Z",
+    "end": "2027-03-27T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-04-12 00:00:00",
+    "start": "2027-04-12T04:00:00.000Z",
+    "end": "2027-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T04:00:00.000Z",
+    "end": "2027-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-06 00:00:00",
+    "start": "2027-06-06T04:00:00.000Z",
+    "end": "2027-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T04:00:00.000Z",
+    "end": "2027-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T04:00:00.000Z",
+    "end": "2027-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-08-17 00:00:00",
+    "start": "2027-08-17T04:00:00.000Z",
+    "end": "2027-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-14 00:00:00",
+    "start": "2027-09-14T04:00:00.000Z",
+    "end": "2027-09-15T04:00:00.000Z",
+    "name": "Efemérides de Cochabamba",
+    "type": "public",
+    "rule": "09-14",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-21 00:00:00",
+    "start": "2027-09-21T04:00:00.000Z",
+    "end": "2027-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-11-01T04:00:00.000Z",
+    "end": "2027-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T04:00:00.000Z",
+    "end": "2027-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T04:00:00.000Z",
+    "end": "2027-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-H-2015.json
+++ b/test/fixtures/BO-H-2015.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T04:00:00.000Z",
+    "end": "2015-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-22 00:00:00",
+    "start": "2015-01-22T04:00:00.000Z",
+    "end": "2015-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-02 00:00:00",
+    "start": "2015-02-02T04:00:00.000Z",
+    "end": "2015-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-03-19 00:00:00",
+    "start": "2015-03-19T04:00:00.000Z",
+    "end": "2015-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-03-23 00:00:00",
+    "start": "2015-03-23T04:00:00.000Z",
+    "end": "2015-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-02 00:00:00",
+    "start": "2015-04-02T04:00:00.000Z",
+    "end": "2015-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T04:00:00.000Z",
+    "end": "2015-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-12 00:00:00",
+    "start": "2015-04-12T04:00:00.000Z",
+    "end": "2015-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T04:00:00.000Z",
+    "end": "2015-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-25 00:00:00",
+    "start": "2015-05-25T04:00:00.000Z",
+    "end": "2015-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-05-27 00:00:00",
+    "start": "2015-05-27T04:00:00.000Z",
+    "end": "2015-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T04:00:00.000Z",
+    "end": "2015-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-06 00:00:00",
+    "start": "2015-06-06T04:00:00.000Z",
+    "end": "2015-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-21T04:00:00.000Z",
+    "end": "2015-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-22 00:00:00",
+    "start": "2015-06-22T04:00:00.000Z",
+    "end": "2015-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-06 00:00:00",
+    "start": "2015-08-06T04:00:00.000Z",
+    "end": "2015-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-17T04:00:00.000Z",
+    "end": "2015-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-21 00:00:00",
+    "start": "2015-09-21T04:00:00.000Z",
+    "end": "2015-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-11 00:00:00",
+    "start": "2015-10-11T04:00:00.000Z",
+    "end": "2015-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-11-01T04:00:00.000Z",
+    "end": "2015-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T04:00:00.000Z",
+    "end": "2015-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T04:00:00.000Z",
+    "end": "2015-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-H-2016.json
+++ b/test/fixtures/BO-H-2016.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T04:00:00.000Z",
+    "end": "2016-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-22 00:00:00",
+    "start": "2016-01-22T04:00:00.000Z",
+    "end": "2016-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-02 00:00:00",
+    "start": "2016-02-02T04:00:00.000Z",
+    "end": "2016-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-03-19 00:00:00",
+    "start": "2016-03-19T04:00:00.000Z",
+    "end": "2016-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-03-23 00:00:00",
+    "start": "2016-03-23T04:00:00.000Z",
+    "end": "2016-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-24 00:00:00",
+    "start": "2016-03-24T04:00:00.000Z",
+    "end": "2016-03-25T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T04:00:00.000Z",
+    "end": "2016-03-26T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-04-12 00:00:00",
+    "start": "2016-04-12T04:00:00.000Z",
+    "end": "2016-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T04:00:00.000Z",
+    "end": "2016-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-02 00:00:00",
+    "start": "2016-05-02T04:00:00.000Z",
+    "end": "2016-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-25 00:00:00",
+    "start": "2016-05-25T04:00:00.000Z",
+    "end": "2016-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T04:00:00.000Z",
+    "end": "2016-05-27T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-27 00:00:00",
+    "start": "2016-05-27T04:00:00.000Z",
+    "end": "2016-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-06-06 00:00:00",
+    "start": "2016-06-06T04:00:00.000Z",
+    "end": "2016-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-06-21 00:00:00",
+    "start": "2016-06-21T04:00:00.000Z",
+    "end": "2016-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-08-06 00:00:00",
+    "start": "2016-08-06T04:00:00.000Z",
+    "end": "2016-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-17T04:00:00.000Z",
+    "end": "2016-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-21 00:00:00",
+    "start": "2016-09-21T04:00:00.000Z",
+    "end": "2016-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-11 00:00:00",
+    "start": "2016-10-11T04:00:00.000Z",
+    "end": "2016-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-11-01T04:00:00.000Z",
+    "end": "2016-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T04:00:00.000Z",
+    "end": "2016-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T04:00:00.000Z",
+    "end": "2016-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-26T04:00:00.000Z",
+    "end": "2016-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-H-2017.json
+++ b/test/fixtures/BO-H-2017.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T04:00:00.000Z",
+    "end": "2017-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T04:00:00.000Z",
+    "end": "2017-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-01-22 00:00:00",
+    "start": "2017-01-22T04:00:00.000Z",
+    "end": "2017-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-23 00:00:00",
+    "start": "2017-01-23T04:00:00.000Z",
+    "end": "2017-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-02 00:00:00",
+    "start": "2017-02-02T04:00:00.000Z",
+    "end": "2017-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-19 00:00:00",
+    "start": "2017-03-19T04:00:00.000Z",
+    "end": "2017-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-23 00:00:00",
+    "start": "2017-03-23T04:00:00.000Z",
+    "end": "2017-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-12 00:00:00",
+    "start": "2017-04-12T04:00:00.000Z",
+    "end": "2017-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-13 00:00:00",
+    "start": "2017-04-13T04:00:00.000Z",
+    "end": "2017-04-14T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T04:00:00.000Z",
+    "end": "2017-04-15T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T04:00:00.000Z",
+    "end": "2017-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-25 00:00:00",
+    "start": "2017-05-25T04:00:00.000Z",
+    "end": "2017-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-05-27 00:00:00",
+    "start": "2017-05-27T04:00:00.000Z",
+    "end": "2017-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-06-06 00:00:00",
+    "start": "2017-06-06T04:00:00.000Z",
+    "end": "2017-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T04:00:00.000Z",
+    "end": "2017-06-16T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-06-21 00:00:00",
+    "start": "2017-06-21T04:00:00.000Z",
+    "end": "2017-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-08-06 00:00:00",
+    "start": "2017-08-06T04:00:00.000Z",
+    "end": "2017-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-17T04:00:00.000Z",
+    "end": "2017-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-21 00:00:00",
+    "start": "2017-09-21T04:00:00.000Z",
+    "end": "2017-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-11 00:00:00",
+    "start": "2017-10-11T04:00:00.000Z",
+    "end": "2017-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-11-01T04:00:00.000Z",
+    "end": "2017-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T04:00:00.000Z",
+    "end": "2017-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T04:00:00.000Z",
+    "end": "2017-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-H-2018.json
+++ b/test/fixtures/BO-H-2018.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T04:00:00.000Z",
+    "end": "2018-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-22 00:00:00",
+    "start": "2018-01-22T04:00:00.000Z",
+    "end": "2018-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-02 00:00:00",
+    "start": "2018-02-02T04:00:00.000Z",
+    "end": "2018-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T04:00:00.000Z",
+    "end": "2018-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-03-23 00:00:00",
+    "start": "2018-03-23T04:00:00.000Z",
+    "end": "2018-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-03-29 00:00:00",
+    "start": "2018-03-29T04:00:00.000Z",
+    "end": "2018-03-30T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T04:00:00.000Z",
+    "end": "2018-03-31T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-12 00:00:00",
+    "start": "2018-04-12T04:00:00.000Z",
+    "end": "2018-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T04:00:00.000Z",
+    "end": "2018-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-25 00:00:00",
+    "start": "2018-05-25T04:00:00.000Z",
+    "end": "2018-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-27T04:00:00.000Z",
+    "end": "2018-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T04:00:00.000Z",
+    "end": "2018-06-01T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-06 00:00:00",
+    "start": "2018-06-06T04:00:00.000Z",
+    "end": "2018-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-06-21 00:00:00",
+    "start": "2018-06-21T04:00:00.000Z",
+    "end": "2018-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T04:00:00.000Z",
+    "end": "2018-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-17T04:00:00.000Z",
+    "end": "2018-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-21 00:00:00",
+    "start": "2018-09-21T04:00:00.000Z",
+    "end": "2018-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-11 00:00:00",
+    "start": "2018-10-11T04:00:00.000Z",
+    "end": "2018-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-11-01T04:00:00.000Z",
+    "end": "2018-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T04:00:00.000Z",
+    "end": "2018-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T04:00:00.000Z",
+    "end": "2018-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BO-H-2019.json
+++ b/test/fixtures/BO-H-2019.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T04:00:00.000Z",
+    "end": "2019-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-22 00:00:00",
+    "start": "2019-01-22T04:00:00.000Z",
+    "end": "2019-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-02-02 00:00:00",
+    "start": "2019-02-02T04:00:00.000Z",
+    "end": "2019-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-19 00:00:00",
+    "start": "2019-03-19T04:00:00.000Z",
+    "end": "2019-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-23 00:00:00",
+    "start": "2019-03-23T04:00:00.000Z",
+    "end": "2019-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-04-12 00:00:00",
+    "start": "2019-04-12T04:00:00.000Z",
+    "end": "2019-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-18 00:00:00",
+    "start": "2019-04-18T04:00:00.000Z",
+    "end": "2019-04-19T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T04:00:00.000Z",
+    "end": "2019-04-20T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T04:00:00.000Z",
+    "end": "2019-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-25 00:00:00",
+    "start": "2019-05-25T04:00:00.000Z",
+    "end": "2019-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-05-27 00:00:00",
+    "start": "2019-05-27T04:00:00.000Z",
+    "end": "2019-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-06-06 00:00:00",
+    "start": "2019-06-06T04:00:00.000Z",
+    "end": "2019-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T04:00:00.000Z",
+    "end": "2019-06-21T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-21T04:00:00.000Z",
+    "end": "2019-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-08-06 00:00:00",
+    "start": "2019-08-06T04:00:00.000Z",
+    "end": "2019-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T04:00:00.000Z",
+    "end": "2019-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-21 00:00:00",
+    "start": "2019-09-21T04:00:00.000Z",
+    "end": "2019-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-11 00:00:00",
+    "start": "2019-10-11T04:00:00.000Z",
+    "end": "2019-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-11-01T04:00:00.000Z",
+    "end": "2019-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T04:00:00.000Z",
+    "end": "2019-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T04:00:00.000Z",
+    "end": "2019-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-H-2020.json
+++ b/test/fixtures/BO-H-2020.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T04:00:00.000Z",
+    "end": "2020-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-22 00:00:00",
+    "start": "2020-01-22T04:00:00.000Z",
+    "end": "2020-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-02 00:00:00",
+    "start": "2020-02-02T04:00:00.000Z",
+    "end": "2020-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-03-19 00:00:00",
+    "start": "2020-03-19T04:00:00.000Z",
+    "end": "2020-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-03-23 00:00:00",
+    "start": "2020-03-23T04:00:00.000Z",
+    "end": "2020-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-09 00:00:00",
+    "start": "2020-04-09T04:00:00.000Z",
+    "end": "2020-04-10T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T04:00:00.000Z",
+    "end": "2020-04-11T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T04:00:00.000Z",
+    "end": "2020-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T04:00:00.000Z",
+    "end": "2020-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-25 00:00:00",
+    "start": "2020-05-25T04:00:00.000Z",
+    "end": "2020-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-05-27 00:00:00",
+    "start": "2020-05-27T04:00:00.000Z",
+    "end": "2020-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-06-06 00:00:00",
+    "start": "2020-06-06T04:00:00.000Z",
+    "end": "2020-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T04:00:00.000Z",
+    "end": "2020-06-12T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-21T04:00:00.000Z",
+    "end": "2020-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-22 00:00:00",
+    "start": "2020-06-22T04:00:00.000Z",
+    "end": "2020-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-06 00:00:00",
+    "start": "2020-08-06T04:00:00.000Z",
+    "end": "2020-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-17T04:00:00.000Z",
+    "end": "2020-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-21 00:00:00",
+    "start": "2020-09-21T04:00:00.000Z",
+    "end": "2020-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-11 00:00:00",
+    "start": "2020-10-11T04:00:00.000Z",
+    "end": "2020-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-11-01T04:00:00.000Z",
+    "end": "2020-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T04:00:00.000Z",
+    "end": "2020-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T04:00:00.000Z",
+    "end": "2020-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-H-2021.json
+++ b/test/fixtures/BO-H-2021.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T04:00:00.000Z",
+    "end": "2021-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-22 00:00:00",
+    "start": "2021-01-22T04:00:00.000Z",
+    "end": "2021-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-02 00:00:00",
+    "start": "2021-02-02T04:00:00.000Z",
+    "end": "2021-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-03-19 00:00:00",
+    "start": "2021-03-19T04:00:00.000Z",
+    "end": "2021-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-03-23 00:00:00",
+    "start": "2021-03-23T04:00:00.000Z",
+    "end": "2021-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-04-01T04:00:00.000Z",
+    "end": "2021-04-02T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T04:00:00.000Z",
+    "end": "2021-04-03T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T04:00:00.000Z",
+    "end": "2021-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T04:00:00.000Z",
+    "end": "2021-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-25 00:00:00",
+    "start": "2021-05-25T04:00:00.000Z",
+    "end": "2021-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-05-27 00:00:00",
+    "start": "2021-05-27T04:00:00.000Z",
+    "end": "2021-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T04:00:00.000Z",
+    "end": "2021-06-04T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-06 00:00:00",
+    "start": "2021-06-06T04:00:00.000Z",
+    "end": "2021-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T04:00:00.000Z",
+    "end": "2021-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-06 00:00:00",
+    "start": "2021-08-06T04:00:00.000Z",
+    "end": "2021-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-17T04:00:00.000Z",
+    "end": "2021-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-21 00:00:00",
+    "start": "2021-09-21T04:00:00.000Z",
+    "end": "2021-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-11-01T04:00:00.000Z",
+    "end": "2021-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T04:00:00.000Z",
+    "end": "2021-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T04:00:00.000Z",
+    "end": "2021-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-H-2022.json
+++ b/test/fixtures/BO-H-2022.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T04:00:00.000Z",
+    "end": "2022-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-22 00:00:00",
+    "start": "2022-01-22T04:00:00.000Z",
+    "end": "2022-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-02 00:00:00",
+    "start": "2022-02-02T04:00:00.000Z",
+    "end": "2022-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-19 00:00:00",
+    "start": "2022-03-19T04:00:00.000Z",
+    "end": "2022-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-03-23 00:00:00",
+    "start": "2022-03-23T04:00:00.000Z",
+    "end": "2022-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-12 00:00:00",
+    "start": "2022-04-12T04:00:00.000Z",
+    "end": "2022-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-14 00:00:00",
+    "start": "2022-04-14T04:00:00.000Z",
+    "end": "2022-04-15T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T04:00:00.000Z",
+    "end": "2022-04-16T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T04:00:00.000Z",
+    "end": "2022-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-02T04:00:00.000Z",
+    "end": "2022-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-25 00:00:00",
+    "start": "2022-05-25T04:00:00.000Z",
+    "end": "2022-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-05-27 00:00:00",
+    "start": "2022-05-27T04:00:00.000Z",
+    "end": "2022-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-06-06 00:00:00",
+    "start": "2022-06-06T04:00:00.000Z",
+    "end": "2022-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T04:00:00.000Z",
+    "end": "2022-06-17T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-06-21 00:00:00",
+    "start": "2022-06-21T04:00:00.000Z",
+    "end": "2022-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T04:00:00.000Z",
+    "end": "2022-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-17T04:00:00.000Z",
+    "end": "2022-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-21 00:00:00",
+    "start": "2022-09-21T04:00:00.000Z",
+    "end": "2022-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-11 00:00:00",
+    "start": "2022-10-11T04:00:00.000Z",
+    "end": "2022-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-11-01T04:00:00.000Z",
+    "end": "2022-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T04:00:00.000Z",
+    "end": "2022-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T04:00:00.000Z",
+    "end": "2022-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-26T04:00:00.000Z",
+    "end": "2022-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-H-2023.json
+++ b/test/fixtures/BO-H-2023.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T04:00:00.000Z",
+    "end": "2023-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T04:00:00.000Z",
+    "end": "2023-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-01-22 00:00:00",
+    "start": "2023-01-22T04:00:00.000Z",
+    "end": "2023-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-23 00:00:00",
+    "start": "2023-01-23T04:00:00.000Z",
+    "end": "2023-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-02 00:00:00",
+    "start": "2023-02-02T04:00:00.000Z",
+    "end": "2023-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-03-19 00:00:00",
+    "start": "2023-03-19T04:00:00.000Z",
+    "end": "2023-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-03-23 00:00:00",
+    "start": "2023-03-23T04:00:00.000Z",
+    "end": "2023-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-06 00:00:00",
+    "start": "2023-04-06T04:00:00.000Z",
+    "end": "2023-04-07T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T04:00:00.000Z",
+    "end": "2023-04-08T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-12 00:00:00",
+    "start": "2023-04-12T04:00:00.000Z",
+    "end": "2023-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T04:00:00.000Z",
+    "end": "2023-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-25 00:00:00",
+    "start": "2023-05-25T04:00:00.000Z",
+    "end": "2023-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-05-27 00:00:00",
+    "start": "2023-05-27T04:00:00.000Z",
+    "end": "2023-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-06-06 00:00:00",
+    "start": "2023-06-06T04:00:00.000Z",
+    "end": "2023-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T04:00:00.000Z",
+    "end": "2023-06-09T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-21 00:00:00",
+    "start": "2023-06-21T04:00:00.000Z",
+    "end": "2023-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T04:00:00.000Z",
+    "end": "2023-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-17T04:00:00.000Z",
+    "end": "2023-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-21 00:00:00",
+    "start": "2023-09-21T04:00:00.000Z",
+    "end": "2023-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-11 00:00:00",
+    "start": "2023-10-11T04:00:00.000Z",
+    "end": "2023-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-11-01T04:00:00.000Z",
+    "end": "2023-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T04:00:00.000Z",
+    "end": "2023-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T04:00:00.000Z",
+    "end": "2023-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-H-2024.json
+++ b/test/fixtures/BO-H-2024.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T04:00:00.000Z",
+    "end": "2024-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-22 00:00:00",
+    "start": "2024-01-22T04:00:00.000Z",
+    "end": "2024-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-02 00:00:00",
+    "start": "2024-02-02T04:00:00.000Z",
+    "end": "2024-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-19 00:00:00",
+    "start": "2024-03-19T04:00:00.000Z",
+    "end": "2024-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-23 00:00:00",
+    "start": "2024-03-23T04:00:00.000Z",
+    "end": "2024-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-28 00:00:00",
+    "start": "2024-03-28T04:00:00.000Z",
+    "end": "2024-03-29T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T04:00:00.000Z",
+    "end": "2024-03-30T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-04-12 00:00:00",
+    "start": "2024-04-12T04:00:00.000Z",
+    "end": "2024-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T04:00:00.000Z",
+    "end": "2024-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-25 00:00:00",
+    "start": "2024-05-25T04:00:00.000Z",
+    "end": "2024-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-05-27 00:00:00",
+    "start": "2024-05-27T04:00:00.000Z",
+    "end": "2024-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T04:00:00.000Z",
+    "end": "2024-05-31T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-06 00:00:00",
+    "start": "2024-06-06T04:00:00.000Z",
+    "end": "2024-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-21T04:00:00.000Z",
+    "end": "2024-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T04:00:00.000Z",
+    "end": "2024-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T04:00:00.000Z",
+    "end": "2024-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-21 00:00:00",
+    "start": "2024-09-21T04:00:00.000Z",
+    "end": "2024-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T04:00:00.000Z",
+    "end": "2024-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-11-01T04:00:00.000Z",
+    "end": "2024-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T04:00:00.000Z",
+    "end": "2024-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T04:00:00.000Z",
+    "end": "2024-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-H-2025.json
+++ b/test/fixtures/BO-H-2025.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T04:00:00.000Z",
+    "end": "2025-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-22 00:00:00",
+    "start": "2025-01-22T04:00:00.000Z",
+    "end": "2025-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-02-02 00:00:00",
+    "start": "2025-02-02T04:00:00.000Z",
+    "end": "2025-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-19 00:00:00",
+    "start": "2025-03-19T04:00:00.000Z",
+    "end": "2025-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-23 00:00:00",
+    "start": "2025-03-23T04:00:00.000Z",
+    "end": "2025-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-12 00:00:00",
+    "start": "2025-04-12T04:00:00.000Z",
+    "end": "2025-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-17 00:00:00",
+    "start": "2025-04-17T04:00:00.000Z",
+    "end": "2025-04-18T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T04:00:00.000Z",
+    "end": "2025-04-19T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T04:00:00.000Z",
+    "end": "2025-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-25 00:00:00",
+    "start": "2025-05-25T04:00:00.000Z",
+    "end": "2025-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-05-26 00:00:00",
+    "start": "2025-05-26T04:00:00.000Z",
+    "end": "2025-05-27T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-25 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-05-27 00:00:00",
+    "start": "2025-05-27T04:00:00.000Z",
+    "end": "2025-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-06-06 00:00:00",
+    "start": "2025-06-06T04:00:00.000Z",
+    "end": "2025-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T04:00:00.000Z",
+    "end": "2025-06-20T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-21 00:00:00",
+    "start": "2025-06-21T04:00:00.000Z",
+    "end": "2025-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T04:00:00.000Z",
+    "end": "2025-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T04:00:00.000Z",
+    "end": "2025-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-21 00:00:00",
+    "start": "2025-09-21T04:00:00.000Z",
+    "end": "2025-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-11 00:00:00",
+    "start": "2025-10-11T04:00:00.000Z",
+    "end": "2025-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-11-01T04:00:00.000Z",
+    "end": "2025-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T04:00:00.000Z",
+    "end": "2025-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T04:00:00.000Z",
+    "end": "2025-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BO-H-2026.json
+++ b/test/fixtures/BO-H-2026.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T04:00:00.000Z",
+    "end": "2026-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-22 00:00:00",
+    "start": "2026-01-22T04:00:00.000Z",
+    "end": "2026-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-02 00:00:00",
+    "start": "2026-02-02T04:00:00.000Z",
+    "end": "2026-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-03-19 00:00:00",
+    "start": "2026-03-19T04:00:00.000Z",
+    "end": "2026-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T04:00:00.000Z",
+    "end": "2026-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-02 00:00:00",
+    "start": "2026-04-02T04:00:00.000Z",
+    "end": "2026-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T04:00:00.000Z",
+    "end": "2026-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-12 00:00:00",
+    "start": "2026-04-12T04:00:00.000Z",
+    "end": "2026-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T04:00:00.000Z",
+    "end": "2026-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-25 00:00:00",
+    "start": "2026-05-25T04:00:00.000Z",
+    "end": "2026-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-05-27 00:00:00",
+    "start": "2026-05-27T04:00:00.000Z",
+    "end": "2026-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T04:00:00.000Z",
+    "end": "2026-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-06 00:00:00",
+    "start": "2026-06-06T04:00:00.000Z",
+    "end": "2026-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-06-21 00:00:00",
+    "start": "2026-06-21T04:00:00.000Z",
+    "end": "2026-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-22 00:00:00",
+    "start": "2026-06-22T04:00:00.000Z",
+    "end": "2026-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T04:00:00.000Z",
+    "end": "2026-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-17T04:00:00.000Z",
+    "end": "2026-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-21 00:00:00",
+    "start": "2026-09-21T04:00:00.000Z",
+    "end": "2026-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-11 00:00:00",
+    "start": "2026-10-11T04:00:00.000Z",
+    "end": "2026-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-11-01T04:00:00.000Z",
+    "end": "2026-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T04:00:00.000Z",
+    "end": "2026-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T04:00:00.000Z",
+    "end": "2026-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-H-2027.json
+++ b/test/fixtures/BO-H-2027.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T04:00:00.000Z",
+    "end": "2027-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-22 00:00:00",
+    "start": "2027-01-22T04:00:00.000Z",
+    "end": "2027-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-02 00:00:00",
+    "start": "2027-02-02T04:00:00.000Z",
+    "end": "2027-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-19 00:00:00",
+    "start": "2027-03-19T04:00:00.000Z",
+    "end": "2027-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-23 00:00:00",
+    "start": "2027-03-23T04:00:00.000Z",
+    "end": "2027-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-25 00:00:00",
+    "start": "2027-03-25T04:00:00.000Z",
+    "end": "2027-03-26T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T04:00:00.000Z",
+    "end": "2027-03-27T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-04-12 00:00:00",
+    "start": "2027-04-12T04:00:00.000Z",
+    "end": "2027-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T04:00:00.000Z",
+    "end": "2027-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-25 00:00:00",
+    "start": "2027-05-25T04:00:00.000Z",
+    "end": "2027-05-26T04:00:00.000Z",
+    "name": "Efemérides de Chuquisaca",
+    "type": "public",
+    "rule": "05-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-06 00:00:00",
+    "start": "2027-06-06T04:00:00.000Z",
+    "end": "2027-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T04:00:00.000Z",
+    "end": "2027-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T04:00:00.000Z",
+    "end": "2027-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-08-17 00:00:00",
+    "start": "2027-08-17T04:00:00.000Z",
+    "end": "2027-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-21 00:00:00",
+    "start": "2027-09-21T04:00:00.000Z",
+    "end": "2027-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-11-01T04:00:00.000Z",
+    "end": "2027-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T04:00:00.000Z",
+    "end": "2027-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T04:00:00.000Z",
+    "end": "2027-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-L-2015.json
+++ b/test/fixtures/BO-L-2015.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T04:00:00.000Z",
+    "end": "2015-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-22 00:00:00",
+    "start": "2015-01-22T04:00:00.000Z",
+    "end": "2015-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-02 00:00:00",
+    "start": "2015-02-02T04:00:00.000Z",
+    "end": "2015-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-03-19 00:00:00",
+    "start": "2015-03-19T04:00:00.000Z",
+    "end": "2015-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-03-23 00:00:00",
+    "start": "2015-03-23T04:00:00.000Z",
+    "end": "2015-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-02 00:00:00",
+    "start": "2015-04-02T04:00:00.000Z",
+    "end": "2015-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T04:00:00.000Z",
+    "end": "2015-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-12 00:00:00",
+    "start": "2015-04-12T04:00:00.000Z",
+    "end": "2015-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T04:00:00.000Z",
+    "end": "2015-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-27 00:00:00",
+    "start": "2015-05-27T04:00:00.000Z",
+    "end": "2015-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T04:00:00.000Z",
+    "end": "2015-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-06 00:00:00",
+    "start": "2015-06-06T04:00:00.000Z",
+    "end": "2015-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-21T04:00:00.000Z",
+    "end": "2015-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-22 00:00:00",
+    "start": "2015-06-22T04:00:00.000Z",
+    "end": "2015-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-07-16 00:00:00",
+    "start": "2015-07-16T04:00:00.000Z",
+    "end": "2015-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-08-06 00:00:00",
+    "start": "2015-08-06T04:00:00.000Z",
+    "end": "2015-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-17T04:00:00.000Z",
+    "end": "2015-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-21 00:00:00",
+    "start": "2015-09-21T04:00:00.000Z",
+    "end": "2015-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-11 00:00:00",
+    "start": "2015-10-11T04:00:00.000Z",
+    "end": "2015-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-11-01T04:00:00.000Z",
+    "end": "2015-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T04:00:00.000Z",
+    "end": "2015-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T04:00:00.000Z",
+    "end": "2015-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-L-2016.json
+++ b/test/fixtures/BO-L-2016.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T04:00:00.000Z",
+    "end": "2016-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-22 00:00:00",
+    "start": "2016-01-22T04:00:00.000Z",
+    "end": "2016-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-02 00:00:00",
+    "start": "2016-02-02T04:00:00.000Z",
+    "end": "2016-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-03-19 00:00:00",
+    "start": "2016-03-19T04:00:00.000Z",
+    "end": "2016-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-03-23 00:00:00",
+    "start": "2016-03-23T04:00:00.000Z",
+    "end": "2016-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-24 00:00:00",
+    "start": "2016-03-24T04:00:00.000Z",
+    "end": "2016-03-25T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T04:00:00.000Z",
+    "end": "2016-03-26T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-04-12 00:00:00",
+    "start": "2016-04-12T04:00:00.000Z",
+    "end": "2016-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T04:00:00.000Z",
+    "end": "2016-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-02 00:00:00",
+    "start": "2016-05-02T04:00:00.000Z",
+    "end": "2016-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T04:00:00.000Z",
+    "end": "2016-05-27T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-27 00:00:00",
+    "start": "2016-05-27T04:00:00.000Z",
+    "end": "2016-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-06-06 00:00:00",
+    "start": "2016-06-06T04:00:00.000Z",
+    "end": "2016-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-06-21 00:00:00",
+    "start": "2016-06-21T04:00:00.000Z",
+    "end": "2016-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-07-16 00:00:00",
+    "start": "2016-07-16T04:00:00.000Z",
+    "end": "2016-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-08-06 00:00:00",
+    "start": "2016-08-06T04:00:00.000Z",
+    "end": "2016-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-17T04:00:00.000Z",
+    "end": "2016-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-21 00:00:00",
+    "start": "2016-09-21T04:00:00.000Z",
+    "end": "2016-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-11 00:00:00",
+    "start": "2016-10-11T04:00:00.000Z",
+    "end": "2016-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-11-01T04:00:00.000Z",
+    "end": "2016-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T04:00:00.000Z",
+    "end": "2016-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T04:00:00.000Z",
+    "end": "2016-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-26T04:00:00.000Z",
+    "end": "2016-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-L-2017.json
+++ b/test/fixtures/BO-L-2017.json
@@ -1,0 +1,245 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T04:00:00.000Z",
+    "end": "2017-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T04:00:00.000Z",
+    "end": "2017-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-01-22 00:00:00",
+    "start": "2017-01-22T04:00:00.000Z",
+    "end": "2017-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-23 00:00:00",
+    "start": "2017-01-23T04:00:00.000Z",
+    "end": "2017-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-02 00:00:00",
+    "start": "2017-02-02T04:00:00.000Z",
+    "end": "2017-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-19 00:00:00",
+    "start": "2017-03-19T04:00:00.000Z",
+    "end": "2017-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-23 00:00:00",
+    "start": "2017-03-23T04:00:00.000Z",
+    "end": "2017-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-12 00:00:00",
+    "start": "2017-04-12T04:00:00.000Z",
+    "end": "2017-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-13 00:00:00",
+    "start": "2017-04-13T04:00:00.000Z",
+    "end": "2017-04-14T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T04:00:00.000Z",
+    "end": "2017-04-15T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T04:00:00.000Z",
+    "end": "2017-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-27 00:00:00",
+    "start": "2017-05-27T04:00:00.000Z",
+    "end": "2017-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-06-06 00:00:00",
+    "start": "2017-06-06T04:00:00.000Z",
+    "end": "2017-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T04:00:00.000Z",
+    "end": "2017-06-16T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-06-21 00:00:00",
+    "start": "2017-06-21T04:00:00.000Z",
+    "end": "2017-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-07-16 00:00:00",
+    "start": "2017-07-16T04:00:00.000Z",
+    "end": "2017-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-07-17 00:00:00",
+    "start": "2017-07-17T04:00:00.000Z",
+    "end": "2017-07-18T04:00:00.000Z",
+    "name": "Efemérides de La Paz (substituto)",
+    "type": "public",
+    "rule": "substitutes 07-16 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-06 00:00:00",
+    "start": "2017-08-06T04:00:00.000Z",
+    "end": "2017-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-17T04:00:00.000Z",
+    "end": "2017-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-21 00:00:00",
+    "start": "2017-09-21T04:00:00.000Z",
+    "end": "2017-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-11 00:00:00",
+    "start": "2017-10-11T04:00:00.000Z",
+    "end": "2017-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-11-01T04:00:00.000Z",
+    "end": "2017-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T04:00:00.000Z",
+    "end": "2017-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T04:00:00.000Z",
+    "end": "2017-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-L-2018.json
+++ b/test/fixtures/BO-L-2018.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T04:00:00.000Z",
+    "end": "2018-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-22 00:00:00",
+    "start": "2018-01-22T04:00:00.000Z",
+    "end": "2018-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-02 00:00:00",
+    "start": "2018-02-02T04:00:00.000Z",
+    "end": "2018-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T04:00:00.000Z",
+    "end": "2018-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-03-23 00:00:00",
+    "start": "2018-03-23T04:00:00.000Z",
+    "end": "2018-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-03-29 00:00:00",
+    "start": "2018-03-29T04:00:00.000Z",
+    "end": "2018-03-30T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T04:00:00.000Z",
+    "end": "2018-03-31T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-12 00:00:00",
+    "start": "2018-04-12T04:00:00.000Z",
+    "end": "2018-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T04:00:00.000Z",
+    "end": "2018-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-27T04:00:00.000Z",
+    "end": "2018-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T04:00:00.000Z",
+    "end": "2018-06-01T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-06 00:00:00",
+    "start": "2018-06-06T04:00:00.000Z",
+    "end": "2018-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-06-21 00:00:00",
+    "start": "2018-06-21T04:00:00.000Z",
+    "end": "2018-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-07-16 00:00:00",
+    "start": "2018-07-16T04:00:00.000Z",
+    "end": "2018-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T04:00:00.000Z",
+    "end": "2018-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-17T04:00:00.000Z",
+    "end": "2018-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-21 00:00:00",
+    "start": "2018-09-21T04:00:00.000Z",
+    "end": "2018-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-11 00:00:00",
+    "start": "2018-10-11T04:00:00.000Z",
+    "end": "2018-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-11-01T04:00:00.000Z",
+    "end": "2018-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T04:00:00.000Z",
+    "end": "2018-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T04:00:00.000Z",
+    "end": "2018-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BO-L-2019.json
+++ b/test/fixtures/BO-L-2019.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T04:00:00.000Z",
+    "end": "2019-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-22 00:00:00",
+    "start": "2019-01-22T04:00:00.000Z",
+    "end": "2019-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-02-02 00:00:00",
+    "start": "2019-02-02T04:00:00.000Z",
+    "end": "2019-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-19 00:00:00",
+    "start": "2019-03-19T04:00:00.000Z",
+    "end": "2019-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-23 00:00:00",
+    "start": "2019-03-23T04:00:00.000Z",
+    "end": "2019-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-04-12 00:00:00",
+    "start": "2019-04-12T04:00:00.000Z",
+    "end": "2019-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-18 00:00:00",
+    "start": "2019-04-18T04:00:00.000Z",
+    "end": "2019-04-19T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T04:00:00.000Z",
+    "end": "2019-04-20T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T04:00:00.000Z",
+    "end": "2019-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-27 00:00:00",
+    "start": "2019-05-27T04:00:00.000Z",
+    "end": "2019-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-06-06 00:00:00",
+    "start": "2019-06-06T04:00:00.000Z",
+    "end": "2019-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T04:00:00.000Z",
+    "end": "2019-06-21T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-21T04:00:00.000Z",
+    "end": "2019-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-07-16 00:00:00",
+    "start": "2019-07-16T04:00:00.000Z",
+    "end": "2019-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-08-06 00:00:00",
+    "start": "2019-08-06T04:00:00.000Z",
+    "end": "2019-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T04:00:00.000Z",
+    "end": "2019-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-21 00:00:00",
+    "start": "2019-09-21T04:00:00.000Z",
+    "end": "2019-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-11 00:00:00",
+    "start": "2019-10-11T04:00:00.000Z",
+    "end": "2019-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-11-01T04:00:00.000Z",
+    "end": "2019-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T04:00:00.000Z",
+    "end": "2019-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T04:00:00.000Z",
+    "end": "2019-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-L-2020.json
+++ b/test/fixtures/BO-L-2020.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T04:00:00.000Z",
+    "end": "2020-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-22 00:00:00",
+    "start": "2020-01-22T04:00:00.000Z",
+    "end": "2020-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-02 00:00:00",
+    "start": "2020-02-02T04:00:00.000Z",
+    "end": "2020-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-03-19 00:00:00",
+    "start": "2020-03-19T04:00:00.000Z",
+    "end": "2020-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-03-23 00:00:00",
+    "start": "2020-03-23T04:00:00.000Z",
+    "end": "2020-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-09 00:00:00",
+    "start": "2020-04-09T04:00:00.000Z",
+    "end": "2020-04-10T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T04:00:00.000Z",
+    "end": "2020-04-11T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T04:00:00.000Z",
+    "end": "2020-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T04:00:00.000Z",
+    "end": "2020-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-27 00:00:00",
+    "start": "2020-05-27T04:00:00.000Z",
+    "end": "2020-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-06-06 00:00:00",
+    "start": "2020-06-06T04:00:00.000Z",
+    "end": "2020-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T04:00:00.000Z",
+    "end": "2020-06-12T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-21T04:00:00.000Z",
+    "end": "2020-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-22 00:00:00",
+    "start": "2020-06-22T04:00:00.000Z",
+    "end": "2020-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-07-16 00:00:00",
+    "start": "2020-07-16T04:00:00.000Z",
+    "end": "2020-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-08-06 00:00:00",
+    "start": "2020-08-06T04:00:00.000Z",
+    "end": "2020-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-17T04:00:00.000Z",
+    "end": "2020-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-21 00:00:00",
+    "start": "2020-09-21T04:00:00.000Z",
+    "end": "2020-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-11 00:00:00",
+    "start": "2020-10-11T04:00:00.000Z",
+    "end": "2020-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-11-01T04:00:00.000Z",
+    "end": "2020-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T04:00:00.000Z",
+    "end": "2020-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T04:00:00.000Z",
+    "end": "2020-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-L-2021.json
+++ b/test/fixtures/BO-L-2021.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T04:00:00.000Z",
+    "end": "2021-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-22 00:00:00",
+    "start": "2021-01-22T04:00:00.000Z",
+    "end": "2021-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-02 00:00:00",
+    "start": "2021-02-02T04:00:00.000Z",
+    "end": "2021-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-03-19 00:00:00",
+    "start": "2021-03-19T04:00:00.000Z",
+    "end": "2021-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-03-23 00:00:00",
+    "start": "2021-03-23T04:00:00.000Z",
+    "end": "2021-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-04-01T04:00:00.000Z",
+    "end": "2021-04-02T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T04:00:00.000Z",
+    "end": "2021-04-03T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T04:00:00.000Z",
+    "end": "2021-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T04:00:00.000Z",
+    "end": "2021-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-27 00:00:00",
+    "start": "2021-05-27T04:00:00.000Z",
+    "end": "2021-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T04:00:00.000Z",
+    "end": "2021-06-04T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-06 00:00:00",
+    "start": "2021-06-06T04:00:00.000Z",
+    "end": "2021-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T04:00:00.000Z",
+    "end": "2021-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-07-16 00:00:00",
+    "start": "2021-07-16T04:00:00.000Z",
+    "end": "2021-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-06 00:00:00",
+    "start": "2021-08-06T04:00:00.000Z",
+    "end": "2021-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-17T04:00:00.000Z",
+    "end": "2021-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-21 00:00:00",
+    "start": "2021-09-21T04:00:00.000Z",
+    "end": "2021-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-11-01T04:00:00.000Z",
+    "end": "2021-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T04:00:00.000Z",
+    "end": "2021-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T04:00:00.000Z",
+    "end": "2021-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-L-2022.json
+++ b/test/fixtures/BO-L-2022.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T04:00:00.000Z",
+    "end": "2022-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-22 00:00:00",
+    "start": "2022-01-22T04:00:00.000Z",
+    "end": "2022-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-02 00:00:00",
+    "start": "2022-02-02T04:00:00.000Z",
+    "end": "2022-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-19 00:00:00",
+    "start": "2022-03-19T04:00:00.000Z",
+    "end": "2022-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-03-23 00:00:00",
+    "start": "2022-03-23T04:00:00.000Z",
+    "end": "2022-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-12 00:00:00",
+    "start": "2022-04-12T04:00:00.000Z",
+    "end": "2022-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-14 00:00:00",
+    "start": "2022-04-14T04:00:00.000Z",
+    "end": "2022-04-15T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T04:00:00.000Z",
+    "end": "2022-04-16T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T04:00:00.000Z",
+    "end": "2022-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-02T04:00:00.000Z",
+    "end": "2022-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-27 00:00:00",
+    "start": "2022-05-27T04:00:00.000Z",
+    "end": "2022-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-06-06 00:00:00",
+    "start": "2022-06-06T04:00:00.000Z",
+    "end": "2022-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T04:00:00.000Z",
+    "end": "2022-06-17T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-06-21 00:00:00",
+    "start": "2022-06-21T04:00:00.000Z",
+    "end": "2022-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-07-16 00:00:00",
+    "start": "2022-07-16T04:00:00.000Z",
+    "end": "2022-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T04:00:00.000Z",
+    "end": "2022-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-17T04:00:00.000Z",
+    "end": "2022-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-21 00:00:00",
+    "start": "2022-09-21T04:00:00.000Z",
+    "end": "2022-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-11 00:00:00",
+    "start": "2022-10-11T04:00:00.000Z",
+    "end": "2022-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-11-01T04:00:00.000Z",
+    "end": "2022-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T04:00:00.000Z",
+    "end": "2022-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T04:00:00.000Z",
+    "end": "2022-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-26T04:00:00.000Z",
+    "end": "2022-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-L-2023.json
+++ b/test/fixtures/BO-L-2023.json
@@ -1,0 +1,245 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T04:00:00.000Z",
+    "end": "2023-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T04:00:00.000Z",
+    "end": "2023-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-01-22 00:00:00",
+    "start": "2023-01-22T04:00:00.000Z",
+    "end": "2023-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-23 00:00:00",
+    "start": "2023-01-23T04:00:00.000Z",
+    "end": "2023-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-02 00:00:00",
+    "start": "2023-02-02T04:00:00.000Z",
+    "end": "2023-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-03-19 00:00:00",
+    "start": "2023-03-19T04:00:00.000Z",
+    "end": "2023-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-03-23 00:00:00",
+    "start": "2023-03-23T04:00:00.000Z",
+    "end": "2023-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-06 00:00:00",
+    "start": "2023-04-06T04:00:00.000Z",
+    "end": "2023-04-07T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T04:00:00.000Z",
+    "end": "2023-04-08T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-12 00:00:00",
+    "start": "2023-04-12T04:00:00.000Z",
+    "end": "2023-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T04:00:00.000Z",
+    "end": "2023-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-27 00:00:00",
+    "start": "2023-05-27T04:00:00.000Z",
+    "end": "2023-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-06-06 00:00:00",
+    "start": "2023-06-06T04:00:00.000Z",
+    "end": "2023-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T04:00:00.000Z",
+    "end": "2023-06-09T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-21 00:00:00",
+    "start": "2023-06-21T04:00:00.000Z",
+    "end": "2023-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-07-16 00:00:00",
+    "start": "2023-07-16T04:00:00.000Z",
+    "end": "2023-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-07-17 00:00:00",
+    "start": "2023-07-17T04:00:00.000Z",
+    "end": "2023-07-18T04:00:00.000Z",
+    "name": "Efemérides de La Paz (substituto)",
+    "type": "public",
+    "rule": "substitutes 07-16 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T04:00:00.000Z",
+    "end": "2023-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-17T04:00:00.000Z",
+    "end": "2023-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-21 00:00:00",
+    "start": "2023-09-21T04:00:00.000Z",
+    "end": "2023-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-11 00:00:00",
+    "start": "2023-10-11T04:00:00.000Z",
+    "end": "2023-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-11-01T04:00:00.000Z",
+    "end": "2023-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T04:00:00.000Z",
+    "end": "2023-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T04:00:00.000Z",
+    "end": "2023-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-L-2024.json
+++ b/test/fixtures/BO-L-2024.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T04:00:00.000Z",
+    "end": "2024-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-22 00:00:00",
+    "start": "2024-01-22T04:00:00.000Z",
+    "end": "2024-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-02 00:00:00",
+    "start": "2024-02-02T04:00:00.000Z",
+    "end": "2024-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-19 00:00:00",
+    "start": "2024-03-19T04:00:00.000Z",
+    "end": "2024-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-23 00:00:00",
+    "start": "2024-03-23T04:00:00.000Z",
+    "end": "2024-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-28 00:00:00",
+    "start": "2024-03-28T04:00:00.000Z",
+    "end": "2024-03-29T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T04:00:00.000Z",
+    "end": "2024-03-30T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-04-12 00:00:00",
+    "start": "2024-04-12T04:00:00.000Z",
+    "end": "2024-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T04:00:00.000Z",
+    "end": "2024-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-27 00:00:00",
+    "start": "2024-05-27T04:00:00.000Z",
+    "end": "2024-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T04:00:00.000Z",
+    "end": "2024-05-31T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-06 00:00:00",
+    "start": "2024-06-06T04:00:00.000Z",
+    "end": "2024-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-21T04:00:00.000Z",
+    "end": "2024-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-07-16 00:00:00",
+    "start": "2024-07-16T04:00:00.000Z",
+    "end": "2024-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T04:00:00.000Z",
+    "end": "2024-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T04:00:00.000Z",
+    "end": "2024-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-21 00:00:00",
+    "start": "2024-09-21T04:00:00.000Z",
+    "end": "2024-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T04:00:00.000Z",
+    "end": "2024-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-11-01T04:00:00.000Z",
+    "end": "2024-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T04:00:00.000Z",
+    "end": "2024-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T04:00:00.000Z",
+    "end": "2024-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-L-2025.json
+++ b/test/fixtures/BO-L-2025.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T04:00:00.000Z",
+    "end": "2025-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-22 00:00:00",
+    "start": "2025-01-22T04:00:00.000Z",
+    "end": "2025-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-02-02 00:00:00",
+    "start": "2025-02-02T04:00:00.000Z",
+    "end": "2025-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-19 00:00:00",
+    "start": "2025-03-19T04:00:00.000Z",
+    "end": "2025-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-23 00:00:00",
+    "start": "2025-03-23T04:00:00.000Z",
+    "end": "2025-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-12 00:00:00",
+    "start": "2025-04-12T04:00:00.000Z",
+    "end": "2025-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-17 00:00:00",
+    "start": "2025-04-17T04:00:00.000Z",
+    "end": "2025-04-18T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T04:00:00.000Z",
+    "end": "2025-04-19T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T04:00:00.000Z",
+    "end": "2025-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-27 00:00:00",
+    "start": "2025-05-27T04:00:00.000Z",
+    "end": "2025-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-06-06 00:00:00",
+    "start": "2025-06-06T04:00:00.000Z",
+    "end": "2025-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T04:00:00.000Z",
+    "end": "2025-06-20T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-21 00:00:00",
+    "start": "2025-06-21T04:00:00.000Z",
+    "end": "2025-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-07-16 00:00:00",
+    "start": "2025-07-16T04:00:00.000Z",
+    "end": "2025-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T04:00:00.000Z",
+    "end": "2025-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T04:00:00.000Z",
+    "end": "2025-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-21 00:00:00",
+    "start": "2025-09-21T04:00:00.000Z",
+    "end": "2025-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-11 00:00:00",
+    "start": "2025-10-11T04:00:00.000Z",
+    "end": "2025-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-11-01T04:00:00.000Z",
+    "end": "2025-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T04:00:00.000Z",
+    "end": "2025-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T04:00:00.000Z",
+    "end": "2025-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BO-L-2026.json
+++ b/test/fixtures/BO-L-2026.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T04:00:00.000Z",
+    "end": "2026-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-22 00:00:00",
+    "start": "2026-01-22T04:00:00.000Z",
+    "end": "2026-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-02 00:00:00",
+    "start": "2026-02-02T04:00:00.000Z",
+    "end": "2026-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-03-19 00:00:00",
+    "start": "2026-03-19T04:00:00.000Z",
+    "end": "2026-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T04:00:00.000Z",
+    "end": "2026-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-02 00:00:00",
+    "start": "2026-04-02T04:00:00.000Z",
+    "end": "2026-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T04:00:00.000Z",
+    "end": "2026-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-12 00:00:00",
+    "start": "2026-04-12T04:00:00.000Z",
+    "end": "2026-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T04:00:00.000Z",
+    "end": "2026-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-27 00:00:00",
+    "start": "2026-05-27T04:00:00.000Z",
+    "end": "2026-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T04:00:00.000Z",
+    "end": "2026-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-06 00:00:00",
+    "start": "2026-06-06T04:00:00.000Z",
+    "end": "2026-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-06-21 00:00:00",
+    "start": "2026-06-21T04:00:00.000Z",
+    "end": "2026-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-22 00:00:00",
+    "start": "2026-06-22T04:00:00.000Z",
+    "end": "2026-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-07-16 00:00:00",
+    "start": "2026-07-16T04:00:00.000Z",
+    "end": "2026-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T04:00:00.000Z",
+    "end": "2026-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-17T04:00:00.000Z",
+    "end": "2026-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-21 00:00:00",
+    "start": "2026-09-21T04:00:00.000Z",
+    "end": "2026-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-11 00:00:00",
+    "start": "2026-10-11T04:00:00.000Z",
+    "end": "2026-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-11-01T04:00:00.000Z",
+    "end": "2026-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T04:00:00.000Z",
+    "end": "2026-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T04:00:00.000Z",
+    "end": "2026-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-L-2027.json
+++ b/test/fixtures/BO-L-2027.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T04:00:00.000Z",
+    "end": "2027-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-22 00:00:00",
+    "start": "2027-01-22T04:00:00.000Z",
+    "end": "2027-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-02 00:00:00",
+    "start": "2027-02-02T04:00:00.000Z",
+    "end": "2027-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-19 00:00:00",
+    "start": "2027-03-19T04:00:00.000Z",
+    "end": "2027-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-23 00:00:00",
+    "start": "2027-03-23T04:00:00.000Z",
+    "end": "2027-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-25 00:00:00",
+    "start": "2027-03-25T04:00:00.000Z",
+    "end": "2027-03-26T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T04:00:00.000Z",
+    "end": "2027-03-27T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-04-12 00:00:00",
+    "start": "2027-04-12T04:00:00.000Z",
+    "end": "2027-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T04:00:00.000Z",
+    "end": "2027-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-06 00:00:00",
+    "start": "2027-06-06T04:00:00.000Z",
+    "end": "2027-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T04:00:00.000Z",
+    "end": "2027-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-07-16 00:00:00",
+    "start": "2027-07-16T04:00:00.000Z",
+    "end": "2027-07-17T04:00:00.000Z",
+    "name": "Efemérides de La Paz",
+    "type": "public",
+    "rule": "07-16",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T04:00:00.000Z",
+    "end": "2027-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-08-17 00:00:00",
+    "start": "2027-08-17T04:00:00.000Z",
+    "end": "2027-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-21 00:00:00",
+    "start": "2027-09-21T04:00:00.000Z",
+    "end": "2027-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-11-01T04:00:00.000Z",
+    "end": "2027-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T04:00:00.000Z",
+    "end": "2027-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T04:00:00.000Z",
+    "end": "2027-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-N-2015.json
+++ b/test/fixtures/BO-N-2015.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T04:00:00.000Z",
+    "end": "2015-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-22 00:00:00",
+    "start": "2015-01-22T04:00:00.000Z",
+    "end": "2015-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-02 00:00:00",
+    "start": "2015-02-02T04:00:00.000Z",
+    "end": "2015-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-03-19 00:00:00",
+    "start": "2015-03-19T04:00:00.000Z",
+    "end": "2015-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-03-23 00:00:00",
+    "start": "2015-03-23T04:00:00.000Z",
+    "end": "2015-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-02 00:00:00",
+    "start": "2015-04-02T04:00:00.000Z",
+    "end": "2015-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T04:00:00.000Z",
+    "end": "2015-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-12 00:00:00",
+    "start": "2015-04-12T04:00:00.000Z",
+    "end": "2015-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T04:00:00.000Z",
+    "end": "2015-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-27 00:00:00",
+    "start": "2015-05-27T04:00:00.000Z",
+    "end": "2015-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T04:00:00.000Z",
+    "end": "2015-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-06 00:00:00",
+    "start": "2015-06-06T04:00:00.000Z",
+    "end": "2015-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-21T04:00:00.000Z",
+    "end": "2015-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-22 00:00:00",
+    "start": "2015-06-22T04:00:00.000Z",
+    "end": "2015-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-06 00:00:00",
+    "start": "2015-08-06T04:00:00.000Z",
+    "end": "2015-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-17T04:00:00.000Z",
+    "end": "2015-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-21 00:00:00",
+    "start": "2015-09-21T04:00:00.000Z",
+    "end": "2015-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-24 00:00:00",
+    "start": "2015-09-24T04:00:00.000Z",
+    "end": "2015-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-10-11 00:00:00",
+    "start": "2015-10-11T04:00:00.000Z",
+    "end": "2015-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-11-01T04:00:00.000Z",
+    "end": "2015-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T04:00:00.000Z",
+    "end": "2015-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T04:00:00.000Z",
+    "end": "2015-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-N-2016.json
+++ b/test/fixtures/BO-N-2016.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T04:00:00.000Z",
+    "end": "2016-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-22 00:00:00",
+    "start": "2016-01-22T04:00:00.000Z",
+    "end": "2016-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-02 00:00:00",
+    "start": "2016-02-02T04:00:00.000Z",
+    "end": "2016-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-03-19 00:00:00",
+    "start": "2016-03-19T04:00:00.000Z",
+    "end": "2016-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-03-23 00:00:00",
+    "start": "2016-03-23T04:00:00.000Z",
+    "end": "2016-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-24 00:00:00",
+    "start": "2016-03-24T04:00:00.000Z",
+    "end": "2016-03-25T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T04:00:00.000Z",
+    "end": "2016-03-26T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-04-12 00:00:00",
+    "start": "2016-04-12T04:00:00.000Z",
+    "end": "2016-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T04:00:00.000Z",
+    "end": "2016-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-02 00:00:00",
+    "start": "2016-05-02T04:00:00.000Z",
+    "end": "2016-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T04:00:00.000Z",
+    "end": "2016-05-27T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-27 00:00:00",
+    "start": "2016-05-27T04:00:00.000Z",
+    "end": "2016-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-06-06 00:00:00",
+    "start": "2016-06-06T04:00:00.000Z",
+    "end": "2016-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-06-21 00:00:00",
+    "start": "2016-06-21T04:00:00.000Z",
+    "end": "2016-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-08-06 00:00:00",
+    "start": "2016-08-06T04:00:00.000Z",
+    "end": "2016-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-17T04:00:00.000Z",
+    "end": "2016-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-21 00:00:00",
+    "start": "2016-09-21T04:00:00.000Z",
+    "end": "2016-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-24 00:00:00",
+    "start": "2016-09-24T04:00:00.000Z",
+    "end": "2016-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-10-11 00:00:00",
+    "start": "2016-10-11T04:00:00.000Z",
+    "end": "2016-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-11-01T04:00:00.000Z",
+    "end": "2016-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T04:00:00.000Z",
+    "end": "2016-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T04:00:00.000Z",
+    "end": "2016-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-26T04:00:00.000Z",
+    "end": "2016-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-N-2017.json
+++ b/test/fixtures/BO-N-2017.json
@@ -1,0 +1,245 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T04:00:00.000Z",
+    "end": "2017-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T04:00:00.000Z",
+    "end": "2017-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-01-22 00:00:00",
+    "start": "2017-01-22T04:00:00.000Z",
+    "end": "2017-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-23 00:00:00",
+    "start": "2017-01-23T04:00:00.000Z",
+    "end": "2017-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-02 00:00:00",
+    "start": "2017-02-02T04:00:00.000Z",
+    "end": "2017-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-19 00:00:00",
+    "start": "2017-03-19T04:00:00.000Z",
+    "end": "2017-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-23 00:00:00",
+    "start": "2017-03-23T04:00:00.000Z",
+    "end": "2017-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-12 00:00:00",
+    "start": "2017-04-12T04:00:00.000Z",
+    "end": "2017-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-13 00:00:00",
+    "start": "2017-04-13T04:00:00.000Z",
+    "end": "2017-04-14T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T04:00:00.000Z",
+    "end": "2017-04-15T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T04:00:00.000Z",
+    "end": "2017-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-27 00:00:00",
+    "start": "2017-05-27T04:00:00.000Z",
+    "end": "2017-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-06-06 00:00:00",
+    "start": "2017-06-06T04:00:00.000Z",
+    "end": "2017-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T04:00:00.000Z",
+    "end": "2017-06-16T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-06-21 00:00:00",
+    "start": "2017-06-21T04:00:00.000Z",
+    "end": "2017-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-08-06 00:00:00",
+    "start": "2017-08-06T04:00:00.000Z",
+    "end": "2017-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-17T04:00:00.000Z",
+    "end": "2017-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-21 00:00:00",
+    "start": "2017-09-21T04:00:00.000Z",
+    "end": "2017-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-24 00:00:00",
+    "start": "2017-09-24T04:00:00.000Z",
+    "end": "2017-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-09-25 00:00:00",
+    "start": "2017-09-25T04:00:00.000Z",
+    "end": "2017-09-26T04:00:00.000Z",
+    "name": "Efemérides de Pando (substituto)",
+    "type": "public",
+    "rule": "substitutes 09-24 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-10-11 00:00:00",
+    "start": "2017-10-11T04:00:00.000Z",
+    "end": "2017-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-11-01T04:00:00.000Z",
+    "end": "2017-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T04:00:00.000Z",
+    "end": "2017-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T04:00:00.000Z",
+    "end": "2017-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-N-2018.json
+++ b/test/fixtures/BO-N-2018.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T04:00:00.000Z",
+    "end": "2018-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-22 00:00:00",
+    "start": "2018-01-22T04:00:00.000Z",
+    "end": "2018-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-02 00:00:00",
+    "start": "2018-02-02T04:00:00.000Z",
+    "end": "2018-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T04:00:00.000Z",
+    "end": "2018-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-03-23 00:00:00",
+    "start": "2018-03-23T04:00:00.000Z",
+    "end": "2018-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-03-29 00:00:00",
+    "start": "2018-03-29T04:00:00.000Z",
+    "end": "2018-03-30T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T04:00:00.000Z",
+    "end": "2018-03-31T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-12 00:00:00",
+    "start": "2018-04-12T04:00:00.000Z",
+    "end": "2018-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T04:00:00.000Z",
+    "end": "2018-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-27T04:00:00.000Z",
+    "end": "2018-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T04:00:00.000Z",
+    "end": "2018-06-01T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-06 00:00:00",
+    "start": "2018-06-06T04:00:00.000Z",
+    "end": "2018-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-06-21 00:00:00",
+    "start": "2018-06-21T04:00:00.000Z",
+    "end": "2018-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T04:00:00.000Z",
+    "end": "2018-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-17T04:00:00.000Z",
+    "end": "2018-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-21 00:00:00",
+    "start": "2018-09-21T04:00:00.000Z",
+    "end": "2018-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-24 00:00:00",
+    "start": "2018-09-24T04:00:00.000Z",
+    "end": "2018-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-10-11 00:00:00",
+    "start": "2018-10-11T04:00:00.000Z",
+    "end": "2018-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-11-01T04:00:00.000Z",
+    "end": "2018-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T04:00:00.000Z",
+    "end": "2018-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T04:00:00.000Z",
+    "end": "2018-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BO-N-2019.json
+++ b/test/fixtures/BO-N-2019.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T04:00:00.000Z",
+    "end": "2019-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-22 00:00:00",
+    "start": "2019-01-22T04:00:00.000Z",
+    "end": "2019-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-02-02 00:00:00",
+    "start": "2019-02-02T04:00:00.000Z",
+    "end": "2019-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-19 00:00:00",
+    "start": "2019-03-19T04:00:00.000Z",
+    "end": "2019-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-23 00:00:00",
+    "start": "2019-03-23T04:00:00.000Z",
+    "end": "2019-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-04-12 00:00:00",
+    "start": "2019-04-12T04:00:00.000Z",
+    "end": "2019-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-18 00:00:00",
+    "start": "2019-04-18T04:00:00.000Z",
+    "end": "2019-04-19T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T04:00:00.000Z",
+    "end": "2019-04-20T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T04:00:00.000Z",
+    "end": "2019-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-27 00:00:00",
+    "start": "2019-05-27T04:00:00.000Z",
+    "end": "2019-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-06-06 00:00:00",
+    "start": "2019-06-06T04:00:00.000Z",
+    "end": "2019-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T04:00:00.000Z",
+    "end": "2019-06-21T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-21T04:00:00.000Z",
+    "end": "2019-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-08-06 00:00:00",
+    "start": "2019-08-06T04:00:00.000Z",
+    "end": "2019-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T04:00:00.000Z",
+    "end": "2019-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-21 00:00:00",
+    "start": "2019-09-21T04:00:00.000Z",
+    "end": "2019-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-24 00:00:00",
+    "start": "2019-09-24T04:00:00.000Z",
+    "end": "2019-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-10-11 00:00:00",
+    "start": "2019-10-11T04:00:00.000Z",
+    "end": "2019-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-11-01T04:00:00.000Z",
+    "end": "2019-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T04:00:00.000Z",
+    "end": "2019-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T04:00:00.000Z",
+    "end": "2019-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-N-2020.json
+++ b/test/fixtures/BO-N-2020.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T04:00:00.000Z",
+    "end": "2020-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-22 00:00:00",
+    "start": "2020-01-22T04:00:00.000Z",
+    "end": "2020-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-02 00:00:00",
+    "start": "2020-02-02T04:00:00.000Z",
+    "end": "2020-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-03-19 00:00:00",
+    "start": "2020-03-19T04:00:00.000Z",
+    "end": "2020-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-03-23 00:00:00",
+    "start": "2020-03-23T04:00:00.000Z",
+    "end": "2020-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-09 00:00:00",
+    "start": "2020-04-09T04:00:00.000Z",
+    "end": "2020-04-10T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T04:00:00.000Z",
+    "end": "2020-04-11T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T04:00:00.000Z",
+    "end": "2020-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T04:00:00.000Z",
+    "end": "2020-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-27 00:00:00",
+    "start": "2020-05-27T04:00:00.000Z",
+    "end": "2020-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-06-06 00:00:00",
+    "start": "2020-06-06T04:00:00.000Z",
+    "end": "2020-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T04:00:00.000Z",
+    "end": "2020-06-12T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-21T04:00:00.000Z",
+    "end": "2020-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-22 00:00:00",
+    "start": "2020-06-22T04:00:00.000Z",
+    "end": "2020-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-06 00:00:00",
+    "start": "2020-08-06T04:00:00.000Z",
+    "end": "2020-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-17T04:00:00.000Z",
+    "end": "2020-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-21 00:00:00",
+    "start": "2020-09-21T04:00:00.000Z",
+    "end": "2020-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-24 00:00:00",
+    "start": "2020-09-24T04:00:00.000Z",
+    "end": "2020-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-10-11 00:00:00",
+    "start": "2020-10-11T04:00:00.000Z",
+    "end": "2020-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-11-01T04:00:00.000Z",
+    "end": "2020-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T04:00:00.000Z",
+    "end": "2020-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T04:00:00.000Z",
+    "end": "2020-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-N-2021.json
+++ b/test/fixtures/BO-N-2021.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T04:00:00.000Z",
+    "end": "2021-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-22 00:00:00",
+    "start": "2021-01-22T04:00:00.000Z",
+    "end": "2021-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-02 00:00:00",
+    "start": "2021-02-02T04:00:00.000Z",
+    "end": "2021-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-03-19 00:00:00",
+    "start": "2021-03-19T04:00:00.000Z",
+    "end": "2021-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-03-23 00:00:00",
+    "start": "2021-03-23T04:00:00.000Z",
+    "end": "2021-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-04-01T04:00:00.000Z",
+    "end": "2021-04-02T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T04:00:00.000Z",
+    "end": "2021-04-03T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T04:00:00.000Z",
+    "end": "2021-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T04:00:00.000Z",
+    "end": "2021-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-27 00:00:00",
+    "start": "2021-05-27T04:00:00.000Z",
+    "end": "2021-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T04:00:00.000Z",
+    "end": "2021-06-04T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-06 00:00:00",
+    "start": "2021-06-06T04:00:00.000Z",
+    "end": "2021-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T04:00:00.000Z",
+    "end": "2021-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-06 00:00:00",
+    "start": "2021-08-06T04:00:00.000Z",
+    "end": "2021-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-17T04:00:00.000Z",
+    "end": "2021-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-21 00:00:00",
+    "start": "2021-09-21T04:00:00.000Z",
+    "end": "2021-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-24 00:00:00",
+    "start": "2021-09-24T04:00:00.000Z",
+    "end": "2021-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-11-01T04:00:00.000Z",
+    "end": "2021-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T04:00:00.000Z",
+    "end": "2021-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T04:00:00.000Z",
+    "end": "2021-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-N-2022.json
+++ b/test/fixtures/BO-N-2022.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T04:00:00.000Z",
+    "end": "2022-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-22 00:00:00",
+    "start": "2022-01-22T04:00:00.000Z",
+    "end": "2022-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-02 00:00:00",
+    "start": "2022-02-02T04:00:00.000Z",
+    "end": "2022-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-19 00:00:00",
+    "start": "2022-03-19T04:00:00.000Z",
+    "end": "2022-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-03-23 00:00:00",
+    "start": "2022-03-23T04:00:00.000Z",
+    "end": "2022-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-12 00:00:00",
+    "start": "2022-04-12T04:00:00.000Z",
+    "end": "2022-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-14 00:00:00",
+    "start": "2022-04-14T04:00:00.000Z",
+    "end": "2022-04-15T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T04:00:00.000Z",
+    "end": "2022-04-16T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T04:00:00.000Z",
+    "end": "2022-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-02T04:00:00.000Z",
+    "end": "2022-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-27 00:00:00",
+    "start": "2022-05-27T04:00:00.000Z",
+    "end": "2022-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-06-06 00:00:00",
+    "start": "2022-06-06T04:00:00.000Z",
+    "end": "2022-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T04:00:00.000Z",
+    "end": "2022-06-17T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-06-21 00:00:00",
+    "start": "2022-06-21T04:00:00.000Z",
+    "end": "2022-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T04:00:00.000Z",
+    "end": "2022-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-17T04:00:00.000Z",
+    "end": "2022-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-21 00:00:00",
+    "start": "2022-09-21T04:00:00.000Z",
+    "end": "2022-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-24 00:00:00",
+    "start": "2022-09-24T04:00:00.000Z",
+    "end": "2022-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-10-11 00:00:00",
+    "start": "2022-10-11T04:00:00.000Z",
+    "end": "2022-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-11-01T04:00:00.000Z",
+    "end": "2022-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T04:00:00.000Z",
+    "end": "2022-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T04:00:00.000Z",
+    "end": "2022-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-26T04:00:00.000Z",
+    "end": "2022-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-N-2023.json
+++ b/test/fixtures/BO-N-2023.json
@@ -1,0 +1,245 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T04:00:00.000Z",
+    "end": "2023-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T04:00:00.000Z",
+    "end": "2023-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-01-22 00:00:00",
+    "start": "2023-01-22T04:00:00.000Z",
+    "end": "2023-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-23 00:00:00",
+    "start": "2023-01-23T04:00:00.000Z",
+    "end": "2023-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-02 00:00:00",
+    "start": "2023-02-02T04:00:00.000Z",
+    "end": "2023-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-03-19 00:00:00",
+    "start": "2023-03-19T04:00:00.000Z",
+    "end": "2023-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-03-23 00:00:00",
+    "start": "2023-03-23T04:00:00.000Z",
+    "end": "2023-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-06 00:00:00",
+    "start": "2023-04-06T04:00:00.000Z",
+    "end": "2023-04-07T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T04:00:00.000Z",
+    "end": "2023-04-08T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-12 00:00:00",
+    "start": "2023-04-12T04:00:00.000Z",
+    "end": "2023-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T04:00:00.000Z",
+    "end": "2023-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-27 00:00:00",
+    "start": "2023-05-27T04:00:00.000Z",
+    "end": "2023-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-06-06 00:00:00",
+    "start": "2023-06-06T04:00:00.000Z",
+    "end": "2023-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T04:00:00.000Z",
+    "end": "2023-06-09T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-21 00:00:00",
+    "start": "2023-06-21T04:00:00.000Z",
+    "end": "2023-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T04:00:00.000Z",
+    "end": "2023-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-17T04:00:00.000Z",
+    "end": "2023-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-21 00:00:00",
+    "start": "2023-09-21T04:00:00.000Z",
+    "end": "2023-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-24 00:00:00",
+    "start": "2023-09-24T04:00:00.000Z",
+    "end": "2023-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-09-25 00:00:00",
+    "start": "2023-09-25T04:00:00.000Z",
+    "end": "2023-09-26T04:00:00.000Z",
+    "name": "Efemérides de Pando (substituto)",
+    "type": "public",
+    "rule": "substitutes 09-24 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-10-11 00:00:00",
+    "start": "2023-10-11T04:00:00.000Z",
+    "end": "2023-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-11-01T04:00:00.000Z",
+    "end": "2023-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T04:00:00.000Z",
+    "end": "2023-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T04:00:00.000Z",
+    "end": "2023-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-N-2024.json
+++ b/test/fixtures/BO-N-2024.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T04:00:00.000Z",
+    "end": "2024-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-22 00:00:00",
+    "start": "2024-01-22T04:00:00.000Z",
+    "end": "2024-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-02 00:00:00",
+    "start": "2024-02-02T04:00:00.000Z",
+    "end": "2024-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-19 00:00:00",
+    "start": "2024-03-19T04:00:00.000Z",
+    "end": "2024-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-23 00:00:00",
+    "start": "2024-03-23T04:00:00.000Z",
+    "end": "2024-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-28 00:00:00",
+    "start": "2024-03-28T04:00:00.000Z",
+    "end": "2024-03-29T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T04:00:00.000Z",
+    "end": "2024-03-30T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-04-12 00:00:00",
+    "start": "2024-04-12T04:00:00.000Z",
+    "end": "2024-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T04:00:00.000Z",
+    "end": "2024-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-27 00:00:00",
+    "start": "2024-05-27T04:00:00.000Z",
+    "end": "2024-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T04:00:00.000Z",
+    "end": "2024-05-31T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-06 00:00:00",
+    "start": "2024-06-06T04:00:00.000Z",
+    "end": "2024-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-21T04:00:00.000Z",
+    "end": "2024-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T04:00:00.000Z",
+    "end": "2024-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T04:00:00.000Z",
+    "end": "2024-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-21 00:00:00",
+    "start": "2024-09-21T04:00:00.000Z",
+    "end": "2024-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-24 00:00:00",
+    "start": "2024-09-24T04:00:00.000Z",
+    "end": "2024-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T04:00:00.000Z",
+    "end": "2024-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-11-01T04:00:00.000Z",
+    "end": "2024-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T04:00:00.000Z",
+    "end": "2024-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T04:00:00.000Z",
+    "end": "2024-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-N-2025.json
+++ b/test/fixtures/BO-N-2025.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T04:00:00.000Z",
+    "end": "2025-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-22 00:00:00",
+    "start": "2025-01-22T04:00:00.000Z",
+    "end": "2025-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-02-02 00:00:00",
+    "start": "2025-02-02T04:00:00.000Z",
+    "end": "2025-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-19 00:00:00",
+    "start": "2025-03-19T04:00:00.000Z",
+    "end": "2025-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-23 00:00:00",
+    "start": "2025-03-23T04:00:00.000Z",
+    "end": "2025-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-12 00:00:00",
+    "start": "2025-04-12T04:00:00.000Z",
+    "end": "2025-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-17 00:00:00",
+    "start": "2025-04-17T04:00:00.000Z",
+    "end": "2025-04-18T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T04:00:00.000Z",
+    "end": "2025-04-19T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T04:00:00.000Z",
+    "end": "2025-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-27 00:00:00",
+    "start": "2025-05-27T04:00:00.000Z",
+    "end": "2025-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-06-06 00:00:00",
+    "start": "2025-06-06T04:00:00.000Z",
+    "end": "2025-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T04:00:00.000Z",
+    "end": "2025-06-20T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-21 00:00:00",
+    "start": "2025-06-21T04:00:00.000Z",
+    "end": "2025-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T04:00:00.000Z",
+    "end": "2025-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T04:00:00.000Z",
+    "end": "2025-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-21 00:00:00",
+    "start": "2025-09-21T04:00:00.000Z",
+    "end": "2025-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-24 00:00:00",
+    "start": "2025-09-24T04:00:00.000Z",
+    "end": "2025-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-10-11 00:00:00",
+    "start": "2025-10-11T04:00:00.000Z",
+    "end": "2025-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-11-01T04:00:00.000Z",
+    "end": "2025-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T04:00:00.000Z",
+    "end": "2025-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T04:00:00.000Z",
+    "end": "2025-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BO-N-2026.json
+++ b/test/fixtures/BO-N-2026.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T04:00:00.000Z",
+    "end": "2026-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-22 00:00:00",
+    "start": "2026-01-22T04:00:00.000Z",
+    "end": "2026-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-02 00:00:00",
+    "start": "2026-02-02T04:00:00.000Z",
+    "end": "2026-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-03-19 00:00:00",
+    "start": "2026-03-19T04:00:00.000Z",
+    "end": "2026-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T04:00:00.000Z",
+    "end": "2026-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-02 00:00:00",
+    "start": "2026-04-02T04:00:00.000Z",
+    "end": "2026-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T04:00:00.000Z",
+    "end": "2026-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-12 00:00:00",
+    "start": "2026-04-12T04:00:00.000Z",
+    "end": "2026-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T04:00:00.000Z",
+    "end": "2026-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-27 00:00:00",
+    "start": "2026-05-27T04:00:00.000Z",
+    "end": "2026-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T04:00:00.000Z",
+    "end": "2026-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-06 00:00:00",
+    "start": "2026-06-06T04:00:00.000Z",
+    "end": "2026-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-06-21 00:00:00",
+    "start": "2026-06-21T04:00:00.000Z",
+    "end": "2026-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-22 00:00:00",
+    "start": "2026-06-22T04:00:00.000Z",
+    "end": "2026-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T04:00:00.000Z",
+    "end": "2026-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-17T04:00:00.000Z",
+    "end": "2026-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-21 00:00:00",
+    "start": "2026-09-21T04:00:00.000Z",
+    "end": "2026-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-24 00:00:00",
+    "start": "2026-09-24T04:00:00.000Z",
+    "end": "2026-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-10-11 00:00:00",
+    "start": "2026-10-11T04:00:00.000Z",
+    "end": "2026-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-11-01T04:00:00.000Z",
+    "end": "2026-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T04:00:00.000Z",
+    "end": "2026-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T04:00:00.000Z",
+    "end": "2026-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-N-2027.json
+++ b/test/fixtures/BO-N-2027.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T04:00:00.000Z",
+    "end": "2027-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-22 00:00:00",
+    "start": "2027-01-22T04:00:00.000Z",
+    "end": "2027-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-02 00:00:00",
+    "start": "2027-02-02T04:00:00.000Z",
+    "end": "2027-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-19 00:00:00",
+    "start": "2027-03-19T04:00:00.000Z",
+    "end": "2027-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-23 00:00:00",
+    "start": "2027-03-23T04:00:00.000Z",
+    "end": "2027-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-25 00:00:00",
+    "start": "2027-03-25T04:00:00.000Z",
+    "end": "2027-03-26T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T04:00:00.000Z",
+    "end": "2027-03-27T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-04-12 00:00:00",
+    "start": "2027-04-12T04:00:00.000Z",
+    "end": "2027-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T04:00:00.000Z",
+    "end": "2027-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-06 00:00:00",
+    "start": "2027-06-06T04:00:00.000Z",
+    "end": "2027-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T04:00:00.000Z",
+    "end": "2027-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T04:00:00.000Z",
+    "end": "2027-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-08-17 00:00:00",
+    "start": "2027-08-17T04:00:00.000Z",
+    "end": "2027-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-21 00:00:00",
+    "start": "2027-09-21T04:00:00.000Z",
+    "end": "2027-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-24 00:00:00",
+    "start": "2027-09-24T04:00:00.000Z",
+    "end": "2027-09-25T04:00:00.000Z",
+    "name": "Efemérides de Pando",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-11-01T04:00:00.000Z",
+    "end": "2027-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T04:00:00.000Z",
+    "end": "2027-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T04:00:00.000Z",
+    "end": "2027-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-O-2015.json
+++ b/test/fixtures/BO-O-2015.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T04:00:00.000Z",
+    "end": "2015-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-22 00:00:00",
+    "start": "2015-01-22T04:00:00.000Z",
+    "end": "2015-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-02 00:00:00",
+    "start": "2015-02-02T04:00:00.000Z",
+    "end": "2015-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-10 00:00:00",
+    "start": "2015-02-10T04:00:00.000Z",
+    "end": "2015-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-03-19 00:00:00",
+    "start": "2015-03-19T04:00:00.000Z",
+    "end": "2015-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-03-23 00:00:00",
+    "start": "2015-03-23T04:00:00.000Z",
+    "end": "2015-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-02 00:00:00",
+    "start": "2015-04-02T04:00:00.000Z",
+    "end": "2015-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T04:00:00.000Z",
+    "end": "2015-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-12 00:00:00",
+    "start": "2015-04-12T04:00:00.000Z",
+    "end": "2015-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T04:00:00.000Z",
+    "end": "2015-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-27 00:00:00",
+    "start": "2015-05-27T04:00:00.000Z",
+    "end": "2015-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T04:00:00.000Z",
+    "end": "2015-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-06 00:00:00",
+    "start": "2015-06-06T04:00:00.000Z",
+    "end": "2015-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-21T04:00:00.000Z",
+    "end": "2015-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-22 00:00:00",
+    "start": "2015-06-22T04:00:00.000Z",
+    "end": "2015-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-06 00:00:00",
+    "start": "2015-08-06T04:00:00.000Z",
+    "end": "2015-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-17T04:00:00.000Z",
+    "end": "2015-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-21 00:00:00",
+    "start": "2015-09-21T04:00:00.000Z",
+    "end": "2015-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-11 00:00:00",
+    "start": "2015-10-11T04:00:00.000Z",
+    "end": "2015-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-11-01T04:00:00.000Z",
+    "end": "2015-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T04:00:00.000Z",
+    "end": "2015-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T04:00:00.000Z",
+    "end": "2015-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-O-2016.json
+++ b/test/fixtures/BO-O-2016.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T04:00:00.000Z",
+    "end": "2016-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-22 00:00:00",
+    "start": "2016-01-22T04:00:00.000Z",
+    "end": "2016-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-02 00:00:00",
+    "start": "2016-02-02T04:00:00.000Z",
+    "end": "2016-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T04:00:00.000Z",
+    "end": "2016-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-19 00:00:00",
+    "start": "2016-03-19T04:00:00.000Z",
+    "end": "2016-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-03-23 00:00:00",
+    "start": "2016-03-23T04:00:00.000Z",
+    "end": "2016-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-24 00:00:00",
+    "start": "2016-03-24T04:00:00.000Z",
+    "end": "2016-03-25T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T04:00:00.000Z",
+    "end": "2016-03-26T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-04-12 00:00:00",
+    "start": "2016-04-12T04:00:00.000Z",
+    "end": "2016-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T04:00:00.000Z",
+    "end": "2016-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-02 00:00:00",
+    "start": "2016-05-02T04:00:00.000Z",
+    "end": "2016-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T04:00:00.000Z",
+    "end": "2016-05-27T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-27 00:00:00",
+    "start": "2016-05-27T04:00:00.000Z",
+    "end": "2016-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-06-06 00:00:00",
+    "start": "2016-06-06T04:00:00.000Z",
+    "end": "2016-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-06-21 00:00:00",
+    "start": "2016-06-21T04:00:00.000Z",
+    "end": "2016-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-08-06 00:00:00",
+    "start": "2016-08-06T04:00:00.000Z",
+    "end": "2016-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-17T04:00:00.000Z",
+    "end": "2016-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-21 00:00:00",
+    "start": "2016-09-21T04:00:00.000Z",
+    "end": "2016-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-11 00:00:00",
+    "start": "2016-10-11T04:00:00.000Z",
+    "end": "2016-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-11-01T04:00:00.000Z",
+    "end": "2016-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T04:00:00.000Z",
+    "end": "2016-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T04:00:00.000Z",
+    "end": "2016-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-26T04:00:00.000Z",
+    "end": "2016-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-O-2017.json
+++ b/test/fixtures/BO-O-2017.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T04:00:00.000Z",
+    "end": "2017-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T04:00:00.000Z",
+    "end": "2017-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-01-22 00:00:00",
+    "start": "2017-01-22T04:00:00.000Z",
+    "end": "2017-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-23 00:00:00",
+    "start": "2017-01-23T04:00:00.000Z",
+    "end": "2017-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-02 00:00:00",
+    "start": "2017-02-02T04:00:00.000Z",
+    "end": "2017-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-02-10 00:00:00",
+    "start": "2017-02-10T04:00:00.000Z",
+    "end": "2017-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-19 00:00:00",
+    "start": "2017-03-19T04:00:00.000Z",
+    "end": "2017-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-23 00:00:00",
+    "start": "2017-03-23T04:00:00.000Z",
+    "end": "2017-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-12 00:00:00",
+    "start": "2017-04-12T04:00:00.000Z",
+    "end": "2017-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-13 00:00:00",
+    "start": "2017-04-13T04:00:00.000Z",
+    "end": "2017-04-14T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T04:00:00.000Z",
+    "end": "2017-04-15T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T04:00:00.000Z",
+    "end": "2017-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-27 00:00:00",
+    "start": "2017-05-27T04:00:00.000Z",
+    "end": "2017-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-06-06 00:00:00",
+    "start": "2017-06-06T04:00:00.000Z",
+    "end": "2017-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T04:00:00.000Z",
+    "end": "2017-06-16T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-06-21 00:00:00",
+    "start": "2017-06-21T04:00:00.000Z",
+    "end": "2017-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-08-06 00:00:00",
+    "start": "2017-08-06T04:00:00.000Z",
+    "end": "2017-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-17T04:00:00.000Z",
+    "end": "2017-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-21 00:00:00",
+    "start": "2017-09-21T04:00:00.000Z",
+    "end": "2017-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-11 00:00:00",
+    "start": "2017-10-11T04:00:00.000Z",
+    "end": "2017-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-11-01T04:00:00.000Z",
+    "end": "2017-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T04:00:00.000Z",
+    "end": "2017-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T04:00:00.000Z",
+    "end": "2017-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-O-2018.json
+++ b/test/fixtures/BO-O-2018.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T04:00:00.000Z",
+    "end": "2018-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-22 00:00:00",
+    "start": "2018-01-22T04:00:00.000Z",
+    "end": "2018-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-02 00:00:00",
+    "start": "2018-02-02T04:00:00.000Z",
+    "end": "2018-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-02-10 00:00:00",
+    "start": "2018-02-10T04:00:00.000Z",
+    "end": "2018-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T04:00:00.000Z",
+    "end": "2018-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-03-23 00:00:00",
+    "start": "2018-03-23T04:00:00.000Z",
+    "end": "2018-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-03-29 00:00:00",
+    "start": "2018-03-29T04:00:00.000Z",
+    "end": "2018-03-30T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T04:00:00.000Z",
+    "end": "2018-03-31T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-12 00:00:00",
+    "start": "2018-04-12T04:00:00.000Z",
+    "end": "2018-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T04:00:00.000Z",
+    "end": "2018-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-27T04:00:00.000Z",
+    "end": "2018-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T04:00:00.000Z",
+    "end": "2018-06-01T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-06 00:00:00",
+    "start": "2018-06-06T04:00:00.000Z",
+    "end": "2018-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-06-21 00:00:00",
+    "start": "2018-06-21T04:00:00.000Z",
+    "end": "2018-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T04:00:00.000Z",
+    "end": "2018-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-17T04:00:00.000Z",
+    "end": "2018-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-21 00:00:00",
+    "start": "2018-09-21T04:00:00.000Z",
+    "end": "2018-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-11 00:00:00",
+    "start": "2018-10-11T04:00:00.000Z",
+    "end": "2018-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-11-01T04:00:00.000Z",
+    "end": "2018-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T04:00:00.000Z",
+    "end": "2018-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T04:00:00.000Z",
+    "end": "2018-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BO-O-2019.json
+++ b/test/fixtures/BO-O-2019.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T04:00:00.000Z",
+    "end": "2019-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-22 00:00:00",
+    "start": "2019-01-22T04:00:00.000Z",
+    "end": "2019-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-02-02 00:00:00",
+    "start": "2019-02-02T04:00:00.000Z",
+    "end": "2019-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-02-10 00:00:00",
+    "start": "2019-02-10T04:00:00.000Z",
+    "end": "2019-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-02-11 00:00:00",
+    "start": "2019-02-11T04:00:00.000Z",
+    "end": "2019-02-12T04:00:00.000Z",
+    "name": "Efemérides de Oruro (substituto)",
+    "type": "public",
+    "rule": "substitutes 02-10 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-19 00:00:00",
+    "start": "2019-03-19T04:00:00.000Z",
+    "end": "2019-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-23 00:00:00",
+    "start": "2019-03-23T04:00:00.000Z",
+    "end": "2019-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-04-12 00:00:00",
+    "start": "2019-04-12T04:00:00.000Z",
+    "end": "2019-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-18 00:00:00",
+    "start": "2019-04-18T04:00:00.000Z",
+    "end": "2019-04-19T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T04:00:00.000Z",
+    "end": "2019-04-20T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T04:00:00.000Z",
+    "end": "2019-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-27 00:00:00",
+    "start": "2019-05-27T04:00:00.000Z",
+    "end": "2019-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-06-06 00:00:00",
+    "start": "2019-06-06T04:00:00.000Z",
+    "end": "2019-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T04:00:00.000Z",
+    "end": "2019-06-21T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-21T04:00:00.000Z",
+    "end": "2019-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-08-06 00:00:00",
+    "start": "2019-08-06T04:00:00.000Z",
+    "end": "2019-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T04:00:00.000Z",
+    "end": "2019-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-21 00:00:00",
+    "start": "2019-09-21T04:00:00.000Z",
+    "end": "2019-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-11 00:00:00",
+    "start": "2019-10-11T04:00:00.000Z",
+    "end": "2019-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-11-01T04:00:00.000Z",
+    "end": "2019-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T04:00:00.000Z",
+    "end": "2019-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T04:00:00.000Z",
+    "end": "2019-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-O-2020.json
+++ b/test/fixtures/BO-O-2020.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T04:00:00.000Z",
+    "end": "2020-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-22 00:00:00",
+    "start": "2020-01-22T04:00:00.000Z",
+    "end": "2020-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-02 00:00:00",
+    "start": "2020-02-02T04:00:00.000Z",
+    "end": "2020-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-10 00:00:00",
+    "start": "2020-02-10T04:00:00.000Z",
+    "end": "2020-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-03-19 00:00:00",
+    "start": "2020-03-19T04:00:00.000Z",
+    "end": "2020-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-03-23 00:00:00",
+    "start": "2020-03-23T04:00:00.000Z",
+    "end": "2020-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-09 00:00:00",
+    "start": "2020-04-09T04:00:00.000Z",
+    "end": "2020-04-10T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T04:00:00.000Z",
+    "end": "2020-04-11T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T04:00:00.000Z",
+    "end": "2020-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T04:00:00.000Z",
+    "end": "2020-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-27 00:00:00",
+    "start": "2020-05-27T04:00:00.000Z",
+    "end": "2020-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-06-06 00:00:00",
+    "start": "2020-06-06T04:00:00.000Z",
+    "end": "2020-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T04:00:00.000Z",
+    "end": "2020-06-12T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-21T04:00:00.000Z",
+    "end": "2020-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-22 00:00:00",
+    "start": "2020-06-22T04:00:00.000Z",
+    "end": "2020-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-06 00:00:00",
+    "start": "2020-08-06T04:00:00.000Z",
+    "end": "2020-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-17T04:00:00.000Z",
+    "end": "2020-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-21 00:00:00",
+    "start": "2020-09-21T04:00:00.000Z",
+    "end": "2020-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-11 00:00:00",
+    "start": "2020-10-11T04:00:00.000Z",
+    "end": "2020-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-11-01T04:00:00.000Z",
+    "end": "2020-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T04:00:00.000Z",
+    "end": "2020-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T04:00:00.000Z",
+    "end": "2020-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-O-2021.json
+++ b/test/fixtures/BO-O-2021.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T04:00:00.000Z",
+    "end": "2021-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-22 00:00:00",
+    "start": "2021-01-22T04:00:00.000Z",
+    "end": "2021-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-02 00:00:00",
+    "start": "2021-02-02T04:00:00.000Z",
+    "end": "2021-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-10 00:00:00",
+    "start": "2021-02-10T04:00:00.000Z",
+    "end": "2021-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-03-19 00:00:00",
+    "start": "2021-03-19T04:00:00.000Z",
+    "end": "2021-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-03-23 00:00:00",
+    "start": "2021-03-23T04:00:00.000Z",
+    "end": "2021-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-04-01T04:00:00.000Z",
+    "end": "2021-04-02T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T04:00:00.000Z",
+    "end": "2021-04-03T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T04:00:00.000Z",
+    "end": "2021-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T04:00:00.000Z",
+    "end": "2021-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-27 00:00:00",
+    "start": "2021-05-27T04:00:00.000Z",
+    "end": "2021-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T04:00:00.000Z",
+    "end": "2021-06-04T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-06 00:00:00",
+    "start": "2021-06-06T04:00:00.000Z",
+    "end": "2021-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T04:00:00.000Z",
+    "end": "2021-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-06 00:00:00",
+    "start": "2021-08-06T04:00:00.000Z",
+    "end": "2021-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-17T04:00:00.000Z",
+    "end": "2021-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-21 00:00:00",
+    "start": "2021-09-21T04:00:00.000Z",
+    "end": "2021-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-11-01T04:00:00.000Z",
+    "end": "2021-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T04:00:00.000Z",
+    "end": "2021-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T04:00:00.000Z",
+    "end": "2021-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-O-2022.json
+++ b/test/fixtures/BO-O-2022.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T04:00:00.000Z",
+    "end": "2022-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-22 00:00:00",
+    "start": "2022-01-22T04:00:00.000Z",
+    "end": "2022-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-02 00:00:00",
+    "start": "2022-02-02T04:00:00.000Z",
+    "end": "2022-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-02-10 00:00:00",
+    "start": "2022-02-10T04:00:00.000Z",
+    "end": "2022-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-19 00:00:00",
+    "start": "2022-03-19T04:00:00.000Z",
+    "end": "2022-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-03-23 00:00:00",
+    "start": "2022-03-23T04:00:00.000Z",
+    "end": "2022-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-12 00:00:00",
+    "start": "2022-04-12T04:00:00.000Z",
+    "end": "2022-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-14 00:00:00",
+    "start": "2022-04-14T04:00:00.000Z",
+    "end": "2022-04-15T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T04:00:00.000Z",
+    "end": "2022-04-16T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T04:00:00.000Z",
+    "end": "2022-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-02T04:00:00.000Z",
+    "end": "2022-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-27 00:00:00",
+    "start": "2022-05-27T04:00:00.000Z",
+    "end": "2022-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-06-06 00:00:00",
+    "start": "2022-06-06T04:00:00.000Z",
+    "end": "2022-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T04:00:00.000Z",
+    "end": "2022-06-17T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-06-21 00:00:00",
+    "start": "2022-06-21T04:00:00.000Z",
+    "end": "2022-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T04:00:00.000Z",
+    "end": "2022-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-17T04:00:00.000Z",
+    "end": "2022-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-21 00:00:00",
+    "start": "2022-09-21T04:00:00.000Z",
+    "end": "2022-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-11 00:00:00",
+    "start": "2022-10-11T04:00:00.000Z",
+    "end": "2022-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-11-01T04:00:00.000Z",
+    "end": "2022-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T04:00:00.000Z",
+    "end": "2022-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T04:00:00.000Z",
+    "end": "2022-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-26T04:00:00.000Z",
+    "end": "2022-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-O-2023.json
+++ b/test/fixtures/BO-O-2023.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T04:00:00.000Z",
+    "end": "2023-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T04:00:00.000Z",
+    "end": "2023-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-01-22 00:00:00",
+    "start": "2023-01-22T04:00:00.000Z",
+    "end": "2023-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-23 00:00:00",
+    "start": "2023-01-23T04:00:00.000Z",
+    "end": "2023-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-02 00:00:00",
+    "start": "2023-02-02T04:00:00.000Z",
+    "end": "2023-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-02-10 00:00:00",
+    "start": "2023-02-10T04:00:00.000Z",
+    "end": "2023-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-03-19 00:00:00",
+    "start": "2023-03-19T04:00:00.000Z",
+    "end": "2023-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-03-23 00:00:00",
+    "start": "2023-03-23T04:00:00.000Z",
+    "end": "2023-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-06 00:00:00",
+    "start": "2023-04-06T04:00:00.000Z",
+    "end": "2023-04-07T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T04:00:00.000Z",
+    "end": "2023-04-08T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-12 00:00:00",
+    "start": "2023-04-12T04:00:00.000Z",
+    "end": "2023-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T04:00:00.000Z",
+    "end": "2023-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-27 00:00:00",
+    "start": "2023-05-27T04:00:00.000Z",
+    "end": "2023-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-06-06 00:00:00",
+    "start": "2023-06-06T04:00:00.000Z",
+    "end": "2023-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T04:00:00.000Z",
+    "end": "2023-06-09T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-21 00:00:00",
+    "start": "2023-06-21T04:00:00.000Z",
+    "end": "2023-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T04:00:00.000Z",
+    "end": "2023-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-17T04:00:00.000Z",
+    "end": "2023-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-21 00:00:00",
+    "start": "2023-09-21T04:00:00.000Z",
+    "end": "2023-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-11 00:00:00",
+    "start": "2023-10-11T04:00:00.000Z",
+    "end": "2023-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-11-01T04:00:00.000Z",
+    "end": "2023-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T04:00:00.000Z",
+    "end": "2023-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T04:00:00.000Z",
+    "end": "2023-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-O-2024.json
+++ b/test/fixtures/BO-O-2024.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T04:00:00.000Z",
+    "end": "2024-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-22 00:00:00",
+    "start": "2024-01-22T04:00:00.000Z",
+    "end": "2024-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-02 00:00:00",
+    "start": "2024-02-02T04:00:00.000Z",
+    "end": "2024-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-02-10 00:00:00",
+    "start": "2024-02-10T04:00:00.000Z",
+    "end": "2024-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-19 00:00:00",
+    "start": "2024-03-19T04:00:00.000Z",
+    "end": "2024-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-23 00:00:00",
+    "start": "2024-03-23T04:00:00.000Z",
+    "end": "2024-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-28 00:00:00",
+    "start": "2024-03-28T04:00:00.000Z",
+    "end": "2024-03-29T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T04:00:00.000Z",
+    "end": "2024-03-30T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-04-12 00:00:00",
+    "start": "2024-04-12T04:00:00.000Z",
+    "end": "2024-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T04:00:00.000Z",
+    "end": "2024-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-27 00:00:00",
+    "start": "2024-05-27T04:00:00.000Z",
+    "end": "2024-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T04:00:00.000Z",
+    "end": "2024-05-31T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-06 00:00:00",
+    "start": "2024-06-06T04:00:00.000Z",
+    "end": "2024-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-21T04:00:00.000Z",
+    "end": "2024-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T04:00:00.000Z",
+    "end": "2024-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T04:00:00.000Z",
+    "end": "2024-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-21 00:00:00",
+    "start": "2024-09-21T04:00:00.000Z",
+    "end": "2024-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T04:00:00.000Z",
+    "end": "2024-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-11-01T04:00:00.000Z",
+    "end": "2024-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T04:00:00.000Z",
+    "end": "2024-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T04:00:00.000Z",
+    "end": "2024-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-O-2025.json
+++ b/test/fixtures/BO-O-2025.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T04:00:00.000Z",
+    "end": "2025-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-22 00:00:00",
+    "start": "2025-01-22T04:00:00.000Z",
+    "end": "2025-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-02-02 00:00:00",
+    "start": "2025-02-02T04:00:00.000Z",
+    "end": "2025-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-02-10 00:00:00",
+    "start": "2025-02-10T04:00:00.000Z",
+    "end": "2025-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-19 00:00:00",
+    "start": "2025-03-19T04:00:00.000Z",
+    "end": "2025-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-23 00:00:00",
+    "start": "2025-03-23T04:00:00.000Z",
+    "end": "2025-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-12 00:00:00",
+    "start": "2025-04-12T04:00:00.000Z",
+    "end": "2025-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-17 00:00:00",
+    "start": "2025-04-17T04:00:00.000Z",
+    "end": "2025-04-18T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T04:00:00.000Z",
+    "end": "2025-04-19T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T04:00:00.000Z",
+    "end": "2025-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-27 00:00:00",
+    "start": "2025-05-27T04:00:00.000Z",
+    "end": "2025-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-06-06 00:00:00",
+    "start": "2025-06-06T04:00:00.000Z",
+    "end": "2025-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T04:00:00.000Z",
+    "end": "2025-06-20T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-21 00:00:00",
+    "start": "2025-06-21T04:00:00.000Z",
+    "end": "2025-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T04:00:00.000Z",
+    "end": "2025-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T04:00:00.000Z",
+    "end": "2025-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-21 00:00:00",
+    "start": "2025-09-21T04:00:00.000Z",
+    "end": "2025-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-11 00:00:00",
+    "start": "2025-10-11T04:00:00.000Z",
+    "end": "2025-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-11-01T04:00:00.000Z",
+    "end": "2025-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T04:00:00.000Z",
+    "end": "2025-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T04:00:00.000Z",
+    "end": "2025-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BO-O-2026.json
+++ b/test/fixtures/BO-O-2026.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T04:00:00.000Z",
+    "end": "2026-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-22 00:00:00",
+    "start": "2026-01-22T04:00:00.000Z",
+    "end": "2026-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-02 00:00:00",
+    "start": "2026-02-02T04:00:00.000Z",
+    "end": "2026-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-10 00:00:00",
+    "start": "2026-02-10T04:00:00.000Z",
+    "end": "2026-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-03-19 00:00:00",
+    "start": "2026-03-19T04:00:00.000Z",
+    "end": "2026-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T04:00:00.000Z",
+    "end": "2026-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-02 00:00:00",
+    "start": "2026-04-02T04:00:00.000Z",
+    "end": "2026-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T04:00:00.000Z",
+    "end": "2026-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-12 00:00:00",
+    "start": "2026-04-12T04:00:00.000Z",
+    "end": "2026-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T04:00:00.000Z",
+    "end": "2026-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-27 00:00:00",
+    "start": "2026-05-27T04:00:00.000Z",
+    "end": "2026-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T04:00:00.000Z",
+    "end": "2026-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-06 00:00:00",
+    "start": "2026-06-06T04:00:00.000Z",
+    "end": "2026-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-06-21 00:00:00",
+    "start": "2026-06-21T04:00:00.000Z",
+    "end": "2026-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-22 00:00:00",
+    "start": "2026-06-22T04:00:00.000Z",
+    "end": "2026-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T04:00:00.000Z",
+    "end": "2026-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-17T04:00:00.000Z",
+    "end": "2026-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-21 00:00:00",
+    "start": "2026-09-21T04:00:00.000Z",
+    "end": "2026-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-11 00:00:00",
+    "start": "2026-10-11T04:00:00.000Z",
+    "end": "2026-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-11-01T04:00:00.000Z",
+    "end": "2026-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T04:00:00.000Z",
+    "end": "2026-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T04:00:00.000Z",
+    "end": "2026-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-O-2027.json
+++ b/test/fixtures/BO-O-2027.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T04:00:00.000Z",
+    "end": "2027-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-22 00:00:00",
+    "start": "2027-01-22T04:00:00.000Z",
+    "end": "2027-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-02 00:00:00",
+    "start": "2027-02-02T04:00:00.000Z",
+    "end": "2027-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T04:00:00.000Z",
+    "end": "2027-02-11T04:00:00.000Z",
+    "name": "Efemérides de Oruro",
+    "type": "public",
+    "rule": "02-10",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-03-19 00:00:00",
+    "start": "2027-03-19T04:00:00.000Z",
+    "end": "2027-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-23 00:00:00",
+    "start": "2027-03-23T04:00:00.000Z",
+    "end": "2027-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-25 00:00:00",
+    "start": "2027-03-25T04:00:00.000Z",
+    "end": "2027-03-26T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T04:00:00.000Z",
+    "end": "2027-03-27T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-04-12 00:00:00",
+    "start": "2027-04-12T04:00:00.000Z",
+    "end": "2027-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T04:00:00.000Z",
+    "end": "2027-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-06 00:00:00",
+    "start": "2027-06-06T04:00:00.000Z",
+    "end": "2027-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T04:00:00.000Z",
+    "end": "2027-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T04:00:00.000Z",
+    "end": "2027-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-08-17 00:00:00",
+    "start": "2027-08-17T04:00:00.000Z",
+    "end": "2027-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-21 00:00:00",
+    "start": "2027-09-21T04:00:00.000Z",
+    "end": "2027-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-11-01T04:00:00.000Z",
+    "end": "2027-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T04:00:00.000Z",
+    "end": "2027-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T04:00:00.000Z",
+    "end": "2027-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-P-2015.json
+++ b/test/fixtures/BO-P-2015.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T04:00:00.000Z",
+    "end": "2015-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-22 00:00:00",
+    "start": "2015-01-22T04:00:00.000Z",
+    "end": "2015-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-02 00:00:00",
+    "start": "2015-02-02T04:00:00.000Z",
+    "end": "2015-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-03-19 00:00:00",
+    "start": "2015-03-19T04:00:00.000Z",
+    "end": "2015-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-03-23 00:00:00",
+    "start": "2015-03-23T04:00:00.000Z",
+    "end": "2015-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-02 00:00:00",
+    "start": "2015-04-02T04:00:00.000Z",
+    "end": "2015-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T04:00:00.000Z",
+    "end": "2015-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-12 00:00:00",
+    "start": "2015-04-12T04:00:00.000Z",
+    "end": "2015-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T04:00:00.000Z",
+    "end": "2015-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-27 00:00:00",
+    "start": "2015-05-27T04:00:00.000Z",
+    "end": "2015-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T04:00:00.000Z",
+    "end": "2015-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-06 00:00:00",
+    "start": "2015-06-06T04:00:00.000Z",
+    "end": "2015-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-21T04:00:00.000Z",
+    "end": "2015-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-22 00:00:00",
+    "start": "2015-06-22T04:00:00.000Z",
+    "end": "2015-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-06 00:00:00",
+    "start": "2015-08-06T04:00:00.000Z",
+    "end": "2015-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-17T04:00:00.000Z",
+    "end": "2015-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-21 00:00:00",
+    "start": "2015-09-21T04:00:00.000Z",
+    "end": "2015-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-11 00:00:00",
+    "start": "2015-10-11T04:00:00.000Z",
+    "end": "2015-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-11-01T04:00:00.000Z",
+    "end": "2015-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T04:00:00.000Z",
+    "end": "2015-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-11-10 00:00:00",
+    "start": "2015-11-10T04:00:00.000Z",
+    "end": "2015-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T04:00:00.000Z",
+    "end": "2015-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-P-2016.json
+++ b/test/fixtures/BO-P-2016.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T04:00:00.000Z",
+    "end": "2016-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-22 00:00:00",
+    "start": "2016-01-22T04:00:00.000Z",
+    "end": "2016-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-02 00:00:00",
+    "start": "2016-02-02T04:00:00.000Z",
+    "end": "2016-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-03-19 00:00:00",
+    "start": "2016-03-19T04:00:00.000Z",
+    "end": "2016-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-03-23 00:00:00",
+    "start": "2016-03-23T04:00:00.000Z",
+    "end": "2016-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-24 00:00:00",
+    "start": "2016-03-24T04:00:00.000Z",
+    "end": "2016-03-25T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T04:00:00.000Z",
+    "end": "2016-03-26T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-04-12 00:00:00",
+    "start": "2016-04-12T04:00:00.000Z",
+    "end": "2016-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T04:00:00.000Z",
+    "end": "2016-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-02 00:00:00",
+    "start": "2016-05-02T04:00:00.000Z",
+    "end": "2016-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T04:00:00.000Z",
+    "end": "2016-05-27T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-27 00:00:00",
+    "start": "2016-05-27T04:00:00.000Z",
+    "end": "2016-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-06-06 00:00:00",
+    "start": "2016-06-06T04:00:00.000Z",
+    "end": "2016-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-06-21 00:00:00",
+    "start": "2016-06-21T04:00:00.000Z",
+    "end": "2016-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-08-06 00:00:00",
+    "start": "2016-08-06T04:00:00.000Z",
+    "end": "2016-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-17T04:00:00.000Z",
+    "end": "2016-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-21 00:00:00",
+    "start": "2016-09-21T04:00:00.000Z",
+    "end": "2016-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-11 00:00:00",
+    "start": "2016-10-11T04:00:00.000Z",
+    "end": "2016-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-11-01T04:00:00.000Z",
+    "end": "2016-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T04:00:00.000Z",
+    "end": "2016-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-11-10 00:00:00",
+    "start": "2016-11-10T04:00:00.000Z",
+    "end": "2016-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T04:00:00.000Z",
+    "end": "2016-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-26T04:00:00.000Z",
+    "end": "2016-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-P-2017.json
+++ b/test/fixtures/BO-P-2017.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T04:00:00.000Z",
+    "end": "2017-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T04:00:00.000Z",
+    "end": "2017-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-01-22 00:00:00",
+    "start": "2017-01-22T04:00:00.000Z",
+    "end": "2017-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-23 00:00:00",
+    "start": "2017-01-23T04:00:00.000Z",
+    "end": "2017-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-02 00:00:00",
+    "start": "2017-02-02T04:00:00.000Z",
+    "end": "2017-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-19 00:00:00",
+    "start": "2017-03-19T04:00:00.000Z",
+    "end": "2017-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-23 00:00:00",
+    "start": "2017-03-23T04:00:00.000Z",
+    "end": "2017-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-12 00:00:00",
+    "start": "2017-04-12T04:00:00.000Z",
+    "end": "2017-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-13 00:00:00",
+    "start": "2017-04-13T04:00:00.000Z",
+    "end": "2017-04-14T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T04:00:00.000Z",
+    "end": "2017-04-15T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T04:00:00.000Z",
+    "end": "2017-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-27 00:00:00",
+    "start": "2017-05-27T04:00:00.000Z",
+    "end": "2017-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-06-06 00:00:00",
+    "start": "2017-06-06T04:00:00.000Z",
+    "end": "2017-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T04:00:00.000Z",
+    "end": "2017-06-16T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-06-21 00:00:00",
+    "start": "2017-06-21T04:00:00.000Z",
+    "end": "2017-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-08-06 00:00:00",
+    "start": "2017-08-06T04:00:00.000Z",
+    "end": "2017-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-17T04:00:00.000Z",
+    "end": "2017-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-21 00:00:00",
+    "start": "2017-09-21T04:00:00.000Z",
+    "end": "2017-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-11 00:00:00",
+    "start": "2017-10-11T04:00:00.000Z",
+    "end": "2017-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-11-01T04:00:00.000Z",
+    "end": "2017-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T04:00:00.000Z",
+    "end": "2017-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-11-10 00:00:00",
+    "start": "2017-11-10T04:00:00.000Z",
+    "end": "2017-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T04:00:00.000Z",
+    "end": "2017-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-P-2018.json
+++ b/test/fixtures/BO-P-2018.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T04:00:00.000Z",
+    "end": "2018-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-22 00:00:00",
+    "start": "2018-01-22T04:00:00.000Z",
+    "end": "2018-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-02 00:00:00",
+    "start": "2018-02-02T04:00:00.000Z",
+    "end": "2018-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T04:00:00.000Z",
+    "end": "2018-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-03-23 00:00:00",
+    "start": "2018-03-23T04:00:00.000Z",
+    "end": "2018-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-03-29 00:00:00",
+    "start": "2018-03-29T04:00:00.000Z",
+    "end": "2018-03-30T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T04:00:00.000Z",
+    "end": "2018-03-31T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-12 00:00:00",
+    "start": "2018-04-12T04:00:00.000Z",
+    "end": "2018-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T04:00:00.000Z",
+    "end": "2018-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-27T04:00:00.000Z",
+    "end": "2018-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T04:00:00.000Z",
+    "end": "2018-06-01T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-06 00:00:00",
+    "start": "2018-06-06T04:00:00.000Z",
+    "end": "2018-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-06-21 00:00:00",
+    "start": "2018-06-21T04:00:00.000Z",
+    "end": "2018-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T04:00:00.000Z",
+    "end": "2018-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-17T04:00:00.000Z",
+    "end": "2018-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-21 00:00:00",
+    "start": "2018-09-21T04:00:00.000Z",
+    "end": "2018-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-11 00:00:00",
+    "start": "2018-10-11T04:00:00.000Z",
+    "end": "2018-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-11-01T04:00:00.000Z",
+    "end": "2018-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T04:00:00.000Z",
+    "end": "2018-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-11-10 00:00:00",
+    "start": "2018-11-10T04:00:00.000Z",
+    "end": "2018-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T04:00:00.000Z",
+    "end": "2018-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BO-P-2019.json
+++ b/test/fixtures/BO-P-2019.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T04:00:00.000Z",
+    "end": "2019-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-22 00:00:00",
+    "start": "2019-01-22T04:00:00.000Z",
+    "end": "2019-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-02-02 00:00:00",
+    "start": "2019-02-02T04:00:00.000Z",
+    "end": "2019-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-19 00:00:00",
+    "start": "2019-03-19T04:00:00.000Z",
+    "end": "2019-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-23 00:00:00",
+    "start": "2019-03-23T04:00:00.000Z",
+    "end": "2019-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-04-12 00:00:00",
+    "start": "2019-04-12T04:00:00.000Z",
+    "end": "2019-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-18 00:00:00",
+    "start": "2019-04-18T04:00:00.000Z",
+    "end": "2019-04-19T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T04:00:00.000Z",
+    "end": "2019-04-20T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T04:00:00.000Z",
+    "end": "2019-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-27 00:00:00",
+    "start": "2019-05-27T04:00:00.000Z",
+    "end": "2019-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-06-06 00:00:00",
+    "start": "2019-06-06T04:00:00.000Z",
+    "end": "2019-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T04:00:00.000Z",
+    "end": "2019-06-21T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-21T04:00:00.000Z",
+    "end": "2019-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-08-06 00:00:00",
+    "start": "2019-08-06T04:00:00.000Z",
+    "end": "2019-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T04:00:00.000Z",
+    "end": "2019-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-21 00:00:00",
+    "start": "2019-09-21T04:00:00.000Z",
+    "end": "2019-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-11 00:00:00",
+    "start": "2019-10-11T04:00:00.000Z",
+    "end": "2019-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-11-01T04:00:00.000Z",
+    "end": "2019-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T04:00:00.000Z",
+    "end": "2019-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-11-10 00:00:00",
+    "start": "2019-11-10T04:00:00.000Z",
+    "end": "2019-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-11-11 00:00:00",
+    "start": "2019-11-11T04:00:00.000Z",
+    "end": "2019-11-12T04:00:00.000Z",
+    "name": "Efemérides de Potosí (substituto)",
+    "type": "public",
+    "rule": "substitutes 11-10 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T04:00:00.000Z",
+    "end": "2019-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-P-2020.json
+++ b/test/fixtures/BO-P-2020.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T04:00:00.000Z",
+    "end": "2020-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-22 00:00:00",
+    "start": "2020-01-22T04:00:00.000Z",
+    "end": "2020-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-02 00:00:00",
+    "start": "2020-02-02T04:00:00.000Z",
+    "end": "2020-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-03-19 00:00:00",
+    "start": "2020-03-19T04:00:00.000Z",
+    "end": "2020-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-03-23 00:00:00",
+    "start": "2020-03-23T04:00:00.000Z",
+    "end": "2020-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-09 00:00:00",
+    "start": "2020-04-09T04:00:00.000Z",
+    "end": "2020-04-10T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T04:00:00.000Z",
+    "end": "2020-04-11T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T04:00:00.000Z",
+    "end": "2020-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T04:00:00.000Z",
+    "end": "2020-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-27 00:00:00",
+    "start": "2020-05-27T04:00:00.000Z",
+    "end": "2020-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-06-06 00:00:00",
+    "start": "2020-06-06T04:00:00.000Z",
+    "end": "2020-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T04:00:00.000Z",
+    "end": "2020-06-12T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-21T04:00:00.000Z",
+    "end": "2020-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-22 00:00:00",
+    "start": "2020-06-22T04:00:00.000Z",
+    "end": "2020-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-06 00:00:00",
+    "start": "2020-08-06T04:00:00.000Z",
+    "end": "2020-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-17T04:00:00.000Z",
+    "end": "2020-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-21 00:00:00",
+    "start": "2020-09-21T04:00:00.000Z",
+    "end": "2020-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-11 00:00:00",
+    "start": "2020-10-11T04:00:00.000Z",
+    "end": "2020-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-11-01T04:00:00.000Z",
+    "end": "2020-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T04:00:00.000Z",
+    "end": "2020-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-11-10 00:00:00",
+    "start": "2020-11-10T04:00:00.000Z",
+    "end": "2020-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T04:00:00.000Z",
+    "end": "2020-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-P-2021.json
+++ b/test/fixtures/BO-P-2021.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T04:00:00.000Z",
+    "end": "2021-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-22 00:00:00",
+    "start": "2021-01-22T04:00:00.000Z",
+    "end": "2021-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-02 00:00:00",
+    "start": "2021-02-02T04:00:00.000Z",
+    "end": "2021-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-03-19 00:00:00",
+    "start": "2021-03-19T04:00:00.000Z",
+    "end": "2021-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-03-23 00:00:00",
+    "start": "2021-03-23T04:00:00.000Z",
+    "end": "2021-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-04-01T04:00:00.000Z",
+    "end": "2021-04-02T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T04:00:00.000Z",
+    "end": "2021-04-03T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T04:00:00.000Z",
+    "end": "2021-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T04:00:00.000Z",
+    "end": "2021-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-27 00:00:00",
+    "start": "2021-05-27T04:00:00.000Z",
+    "end": "2021-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T04:00:00.000Z",
+    "end": "2021-06-04T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-06 00:00:00",
+    "start": "2021-06-06T04:00:00.000Z",
+    "end": "2021-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T04:00:00.000Z",
+    "end": "2021-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-06 00:00:00",
+    "start": "2021-08-06T04:00:00.000Z",
+    "end": "2021-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-17T04:00:00.000Z",
+    "end": "2021-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-21 00:00:00",
+    "start": "2021-09-21T04:00:00.000Z",
+    "end": "2021-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-11-01T04:00:00.000Z",
+    "end": "2021-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T04:00:00.000Z",
+    "end": "2021-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-11-10 00:00:00",
+    "start": "2021-11-10T04:00:00.000Z",
+    "end": "2021-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T04:00:00.000Z",
+    "end": "2021-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-P-2022.json
+++ b/test/fixtures/BO-P-2022.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T04:00:00.000Z",
+    "end": "2022-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-22 00:00:00",
+    "start": "2022-01-22T04:00:00.000Z",
+    "end": "2022-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-02 00:00:00",
+    "start": "2022-02-02T04:00:00.000Z",
+    "end": "2022-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-19 00:00:00",
+    "start": "2022-03-19T04:00:00.000Z",
+    "end": "2022-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-03-23 00:00:00",
+    "start": "2022-03-23T04:00:00.000Z",
+    "end": "2022-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-12 00:00:00",
+    "start": "2022-04-12T04:00:00.000Z",
+    "end": "2022-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-14 00:00:00",
+    "start": "2022-04-14T04:00:00.000Z",
+    "end": "2022-04-15T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T04:00:00.000Z",
+    "end": "2022-04-16T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T04:00:00.000Z",
+    "end": "2022-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-02T04:00:00.000Z",
+    "end": "2022-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-27 00:00:00",
+    "start": "2022-05-27T04:00:00.000Z",
+    "end": "2022-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-06-06 00:00:00",
+    "start": "2022-06-06T04:00:00.000Z",
+    "end": "2022-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T04:00:00.000Z",
+    "end": "2022-06-17T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-06-21 00:00:00",
+    "start": "2022-06-21T04:00:00.000Z",
+    "end": "2022-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T04:00:00.000Z",
+    "end": "2022-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-17T04:00:00.000Z",
+    "end": "2022-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-21 00:00:00",
+    "start": "2022-09-21T04:00:00.000Z",
+    "end": "2022-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-11 00:00:00",
+    "start": "2022-10-11T04:00:00.000Z",
+    "end": "2022-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-11-01T04:00:00.000Z",
+    "end": "2022-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T04:00:00.000Z",
+    "end": "2022-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-11-10 00:00:00",
+    "start": "2022-11-10T04:00:00.000Z",
+    "end": "2022-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T04:00:00.000Z",
+    "end": "2022-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-26T04:00:00.000Z",
+    "end": "2022-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-P-2023.json
+++ b/test/fixtures/BO-P-2023.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T04:00:00.000Z",
+    "end": "2023-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T04:00:00.000Z",
+    "end": "2023-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-01-22 00:00:00",
+    "start": "2023-01-22T04:00:00.000Z",
+    "end": "2023-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-23 00:00:00",
+    "start": "2023-01-23T04:00:00.000Z",
+    "end": "2023-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-02 00:00:00",
+    "start": "2023-02-02T04:00:00.000Z",
+    "end": "2023-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-03-19 00:00:00",
+    "start": "2023-03-19T04:00:00.000Z",
+    "end": "2023-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-03-23 00:00:00",
+    "start": "2023-03-23T04:00:00.000Z",
+    "end": "2023-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-06 00:00:00",
+    "start": "2023-04-06T04:00:00.000Z",
+    "end": "2023-04-07T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T04:00:00.000Z",
+    "end": "2023-04-08T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-12 00:00:00",
+    "start": "2023-04-12T04:00:00.000Z",
+    "end": "2023-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T04:00:00.000Z",
+    "end": "2023-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-27 00:00:00",
+    "start": "2023-05-27T04:00:00.000Z",
+    "end": "2023-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-06-06 00:00:00",
+    "start": "2023-06-06T04:00:00.000Z",
+    "end": "2023-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T04:00:00.000Z",
+    "end": "2023-06-09T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-21 00:00:00",
+    "start": "2023-06-21T04:00:00.000Z",
+    "end": "2023-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T04:00:00.000Z",
+    "end": "2023-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-17T04:00:00.000Z",
+    "end": "2023-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-21 00:00:00",
+    "start": "2023-09-21T04:00:00.000Z",
+    "end": "2023-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-11 00:00:00",
+    "start": "2023-10-11T04:00:00.000Z",
+    "end": "2023-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-11-01T04:00:00.000Z",
+    "end": "2023-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T04:00:00.000Z",
+    "end": "2023-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-11-10 00:00:00",
+    "start": "2023-11-10T04:00:00.000Z",
+    "end": "2023-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T04:00:00.000Z",
+    "end": "2023-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-P-2024.json
+++ b/test/fixtures/BO-P-2024.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T04:00:00.000Z",
+    "end": "2024-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-22 00:00:00",
+    "start": "2024-01-22T04:00:00.000Z",
+    "end": "2024-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-02 00:00:00",
+    "start": "2024-02-02T04:00:00.000Z",
+    "end": "2024-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-19 00:00:00",
+    "start": "2024-03-19T04:00:00.000Z",
+    "end": "2024-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-23 00:00:00",
+    "start": "2024-03-23T04:00:00.000Z",
+    "end": "2024-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-28 00:00:00",
+    "start": "2024-03-28T04:00:00.000Z",
+    "end": "2024-03-29T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T04:00:00.000Z",
+    "end": "2024-03-30T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-04-12 00:00:00",
+    "start": "2024-04-12T04:00:00.000Z",
+    "end": "2024-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T04:00:00.000Z",
+    "end": "2024-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-27 00:00:00",
+    "start": "2024-05-27T04:00:00.000Z",
+    "end": "2024-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T04:00:00.000Z",
+    "end": "2024-05-31T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-06 00:00:00",
+    "start": "2024-06-06T04:00:00.000Z",
+    "end": "2024-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-21T04:00:00.000Z",
+    "end": "2024-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T04:00:00.000Z",
+    "end": "2024-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T04:00:00.000Z",
+    "end": "2024-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-21 00:00:00",
+    "start": "2024-09-21T04:00:00.000Z",
+    "end": "2024-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T04:00:00.000Z",
+    "end": "2024-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-11-01T04:00:00.000Z",
+    "end": "2024-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T04:00:00.000Z",
+    "end": "2024-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-11-10 00:00:00",
+    "start": "2024-11-10T04:00:00.000Z",
+    "end": "2024-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-11-11 00:00:00",
+    "start": "2024-11-11T04:00:00.000Z",
+    "end": "2024-11-12T04:00:00.000Z",
+    "name": "Efemérides de Potosí (substituto)",
+    "type": "public",
+    "rule": "substitutes 11-10 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T04:00:00.000Z",
+    "end": "2024-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-P-2025.json
+++ b/test/fixtures/BO-P-2025.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T04:00:00.000Z",
+    "end": "2025-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-22 00:00:00",
+    "start": "2025-01-22T04:00:00.000Z",
+    "end": "2025-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-02-02 00:00:00",
+    "start": "2025-02-02T04:00:00.000Z",
+    "end": "2025-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-19 00:00:00",
+    "start": "2025-03-19T04:00:00.000Z",
+    "end": "2025-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-23 00:00:00",
+    "start": "2025-03-23T04:00:00.000Z",
+    "end": "2025-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-12 00:00:00",
+    "start": "2025-04-12T04:00:00.000Z",
+    "end": "2025-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-17 00:00:00",
+    "start": "2025-04-17T04:00:00.000Z",
+    "end": "2025-04-18T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T04:00:00.000Z",
+    "end": "2025-04-19T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T04:00:00.000Z",
+    "end": "2025-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-27 00:00:00",
+    "start": "2025-05-27T04:00:00.000Z",
+    "end": "2025-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-06-06 00:00:00",
+    "start": "2025-06-06T04:00:00.000Z",
+    "end": "2025-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T04:00:00.000Z",
+    "end": "2025-06-20T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-21 00:00:00",
+    "start": "2025-06-21T04:00:00.000Z",
+    "end": "2025-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T04:00:00.000Z",
+    "end": "2025-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T04:00:00.000Z",
+    "end": "2025-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-21 00:00:00",
+    "start": "2025-09-21T04:00:00.000Z",
+    "end": "2025-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-11 00:00:00",
+    "start": "2025-10-11T04:00:00.000Z",
+    "end": "2025-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-11-01T04:00:00.000Z",
+    "end": "2025-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T04:00:00.000Z",
+    "end": "2025-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-11-10 00:00:00",
+    "start": "2025-11-10T04:00:00.000Z",
+    "end": "2025-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T04:00:00.000Z",
+    "end": "2025-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BO-P-2026.json
+++ b/test/fixtures/BO-P-2026.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T04:00:00.000Z",
+    "end": "2026-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-22 00:00:00",
+    "start": "2026-01-22T04:00:00.000Z",
+    "end": "2026-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-02 00:00:00",
+    "start": "2026-02-02T04:00:00.000Z",
+    "end": "2026-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-03-19 00:00:00",
+    "start": "2026-03-19T04:00:00.000Z",
+    "end": "2026-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T04:00:00.000Z",
+    "end": "2026-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-02 00:00:00",
+    "start": "2026-04-02T04:00:00.000Z",
+    "end": "2026-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T04:00:00.000Z",
+    "end": "2026-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-12 00:00:00",
+    "start": "2026-04-12T04:00:00.000Z",
+    "end": "2026-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T04:00:00.000Z",
+    "end": "2026-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-27 00:00:00",
+    "start": "2026-05-27T04:00:00.000Z",
+    "end": "2026-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T04:00:00.000Z",
+    "end": "2026-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-06 00:00:00",
+    "start": "2026-06-06T04:00:00.000Z",
+    "end": "2026-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-06-21 00:00:00",
+    "start": "2026-06-21T04:00:00.000Z",
+    "end": "2026-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-22 00:00:00",
+    "start": "2026-06-22T04:00:00.000Z",
+    "end": "2026-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T04:00:00.000Z",
+    "end": "2026-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-17T04:00:00.000Z",
+    "end": "2026-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-21 00:00:00",
+    "start": "2026-09-21T04:00:00.000Z",
+    "end": "2026-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-11 00:00:00",
+    "start": "2026-10-11T04:00:00.000Z",
+    "end": "2026-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-11-01T04:00:00.000Z",
+    "end": "2026-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T04:00:00.000Z",
+    "end": "2026-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-11-10 00:00:00",
+    "start": "2026-11-10T04:00:00.000Z",
+    "end": "2026-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T04:00:00.000Z",
+    "end": "2026-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-P-2027.json
+++ b/test/fixtures/BO-P-2027.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T04:00:00.000Z",
+    "end": "2027-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-22 00:00:00",
+    "start": "2027-01-22T04:00:00.000Z",
+    "end": "2027-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-02 00:00:00",
+    "start": "2027-02-02T04:00:00.000Z",
+    "end": "2027-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-19 00:00:00",
+    "start": "2027-03-19T04:00:00.000Z",
+    "end": "2027-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-23 00:00:00",
+    "start": "2027-03-23T04:00:00.000Z",
+    "end": "2027-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-25 00:00:00",
+    "start": "2027-03-25T04:00:00.000Z",
+    "end": "2027-03-26T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T04:00:00.000Z",
+    "end": "2027-03-27T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-04-12 00:00:00",
+    "start": "2027-04-12T04:00:00.000Z",
+    "end": "2027-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T04:00:00.000Z",
+    "end": "2027-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-06 00:00:00",
+    "start": "2027-06-06T04:00:00.000Z",
+    "end": "2027-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T04:00:00.000Z",
+    "end": "2027-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T04:00:00.000Z",
+    "end": "2027-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-08-17 00:00:00",
+    "start": "2027-08-17T04:00:00.000Z",
+    "end": "2027-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-21 00:00:00",
+    "start": "2027-09-21T04:00:00.000Z",
+    "end": "2027-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-11-01T04:00:00.000Z",
+    "end": "2027-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T04:00:00.000Z",
+    "end": "2027-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-11-10 00:00:00",
+    "start": "2027-11-10T04:00:00.000Z",
+    "end": "2027-11-11T04:00:00.000Z",
+    "name": "Efemérides de Potosí",
+    "type": "public",
+    "rule": "11-10",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T04:00:00.000Z",
+    "end": "2027-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-S-2015.json
+++ b/test/fixtures/BO-S-2015.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T04:00:00.000Z",
+    "end": "2015-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-22 00:00:00",
+    "start": "2015-01-22T04:00:00.000Z",
+    "end": "2015-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-02 00:00:00",
+    "start": "2015-02-02T04:00:00.000Z",
+    "end": "2015-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-03-19 00:00:00",
+    "start": "2015-03-19T04:00:00.000Z",
+    "end": "2015-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-03-23 00:00:00",
+    "start": "2015-03-23T04:00:00.000Z",
+    "end": "2015-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-02 00:00:00",
+    "start": "2015-04-02T04:00:00.000Z",
+    "end": "2015-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T04:00:00.000Z",
+    "end": "2015-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-12 00:00:00",
+    "start": "2015-04-12T04:00:00.000Z",
+    "end": "2015-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T04:00:00.000Z",
+    "end": "2015-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-27 00:00:00",
+    "start": "2015-05-27T04:00:00.000Z",
+    "end": "2015-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T04:00:00.000Z",
+    "end": "2015-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-06 00:00:00",
+    "start": "2015-06-06T04:00:00.000Z",
+    "end": "2015-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-21T04:00:00.000Z",
+    "end": "2015-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-22 00:00:00",
+    "start": "2015-06-22T04:00:00.000Z",
+    "end": "2015-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-06 00:00:00",
+    "start": "2015-08-06T04:00:00.000Z",
+    "end": "2015-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-17T04:00:00.000Z",
+    "end": "2015-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-21 00:00:00",
+    "start": "2015-09-21T04:00:00.000Z",
+    "end": "2015-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-24 00:00:00",
+    "start": "2015-09-24T04:00:00.000Z",
+    "end": "2015-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-10-11 00:00:00",
+    "start": "2015-10-11T04:00:00.000Z",
+    "end": "2015-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-11-01T04:00:00.000Z",
+    "end": "2015-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T04:00:00.000Z",
+    "end": "2015-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T04:00:00.000Z",
+    "end": "2015-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-S-2016.json
+++ b/test/fixtures/BO-S-2016.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T04:00:00.000Z",
+    "end": "2016-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-22 00:00:00",
+    "start": "2016-01-22T04:00:00.000Z",
+    "end": "2016-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-02 00:00:00",
+    "start": "2016-02-02T04:00:00.000Z",
+    "end": "2016-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-03-19 00:00:00",
+    "start": "2016-03-19T04:00:00.000Z",
+    "end": "2016-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-03-23 00:00:00",
+    "start": "2016-03-23T04:00:00.000Z",
+    "end": "2016-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-24 00:00:00",
+    "start": "2016-03-24T04:00:00.000Z",
+    "end": "2016-03-25T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T04:00:00.000Z",
+    "end": "2016-03-26T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-04-12 00:00:00",
+    "start": "2016-04-12T04:00:00.000Z",
+    "end": "2016-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T04:00:00.000Z",
+    "end": "2016-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-02 00:00:00",
+    "start": "2016-05-02T04:00:00.000Z",
+    "end": "2016-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T04:00:00.000Z",
+    "end": "2016-05-27T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-27 00:00:00",
+    "start": "2016-05-27T04:00:00.000Z",
+    "end": "2016-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-06-06 00:00:00",
+    "start": "2016-06-06T04:00:00.000Z",
+    "end": "2016-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-06-21 00:00:00",
+    "start": "2016-06-21T04:00:00.000Z",
+    "end": "2016-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-08-06 00:00:00",
+    "start": "2016-08-06T04:00:00.000Z",
+    "end": "2016-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-17T04:00:00.000Z",
+    "end": "2016-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-21 00:00:00",
+    "start": "2016-09-21T04:00:00.000Z",
+    "end": "2016-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-24 00:00:00",
+    "start": "2016-09-24T04:00:00.000Z",
+    "end": "2016-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-10-11 00:00:00",
+    "start": "2016-10-11T04:00:00.000Z",
+    "end": "2016-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-11-01T04:00:00.000Z",
+    "end": "2016-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T04:00:00.000Z",
+    "end": "2016-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T04:00:00.000Z",
+    "end": "2016-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-26T04:00:00.000Z",
+    "end": "2016-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-S-2017.json
+++ b/test/fixtures/BO-S-2017.json
@@ -1,0 +1,245 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T04:00:00.000Z",
+    "end": "2017-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T04:00:00.000Z",
+    "end": "2017-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-01-22 00:00:00",
+    "start": "2017-01-22T04:00:00.000Z",
+    "end": "2017-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-23 00:00:00",
+    "start": "2017-01-23T04:00:00.000Z",
+    "end": "2017-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-02 00:00:00",
+    "start": "2017-02-02T04:00:00.000Z",
+    "end": "2017-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-19 00:00:00",
+    "start": "2017-03-19T04:00:00.000Z",
+    "end": "2017-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-23 00:00:00",
+    "start": "2017-03-23T04:00:00.000Z",
+    "end": "2017-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-12 00:00:00",
+    "start": "2017-04-12T04:00:00.000Z",
+    "end": "2017-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-13 00:00:00",
+    "start": "2017-04-13T04:00:00.000Z",
+    "end": "2017-04-14T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T04:00:00.000Z",
+    "end": "2017-04-15T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T04:00:00.000Z",
+    "end": "2017-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-27 00:00:00",
+    "start": "2017-05-27T04:00:00.000Z",
+    "end": "2017-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-06-06 00:00:00",
+    "start": "2017-06-06T04:00:00.000Z",
+    "end": "2017-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T04:00:00.000Z",
+    "end": "2017-06-16T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-06-21 00:00:00",
+    "start": "2017-06-21T04:00:00.000Z",
+    "end": "2017-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-08-06 00:00:00",
+    "start": "2017-08-06T04:00:00.000Z",
+    "end": "2017-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-17T04:00:00.000Z",
+    "end": "2017-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-21 00:00:00",
+    "start": "2017-09-21T04:00:00.000Z",
+    "end": "2017-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-24 00:00:00",
+    "start": "2017-09-24T04:00:00.000Z",
+    "end": "2017-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-09-25 00:00:00",
+    "start": "2017-09-25T04:00:00.000Z",
+    "end": "2017-09-26T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz (substituto)",
+    "type": "public",
+    "rule": "substitutes 09-24 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-10-11 00:00:00",
+    "start": "2017-10-11T04:00:00.000Z",
+    "end": "2017-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-11-01T04:00:00.000Z",
+    "end": "2017-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T04:00:00.000Z",
+    "end": "2017-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T04:00:00.000Z",
+    "end": "2017-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-S-2018.json
+++ b/test/fixtures/BO-S-2018.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T04:00:00.000Z",
+    "end": "2018-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-22 00:00:00",
+    "start": "2018-01-22T04:00:00.000Z",
+    "end": "2018-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-02 00:00:00",
+    "start": "2018-02-02T04:00:00.000Z",
+    "end": "2018-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T04:00:00.000Z",
+    "end": "2018-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-03-23 00:00:00",
+    "start": "2018-03-23T04:00:00.000Z",
+    "end": "2018-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-03-29 00:00:00",
+    "start": "2018-03-29T04:00:00.000Z",
+    "end": "2018-03-30T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T04:00:00.000Z",
+    "end": "2018-03-31T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-12 00:00:00",
+    "start": "2018-04-12T04:00:00.000Z",
+    "end": "2018-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T04:00:00.000Z",
+    "end": "2018-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-27T04:00:00.000Z",
+    "end": "2018-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T04:00:00.000Z",
+    "end": "2018-06-01T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-06 00:00:00",
+    "start": "2018-06-06T04:00:00.000Z",
+    "end": "2018-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-06-21 00:00:00",
+    "start": "2018-06-21T04:00:00.000Z",
+    "end": "2018-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T04:00:00.000Z",
+    "end": "2018-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-17T04:00:00.000Z",
+    "end": "2018-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-21 00:00:00",
+    "start": "2018-09-21T04:00:00.000Z",
+    "end": "2018-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-24 00:00:00",
+    "start": "2018-09-24T04:00:00.000Z",
+    "end": "2018-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-10-11 00:00:00",
+    "start": "2018-10-11T04:00:00.000Z",
+    "end": "2018-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-11-01T04:00:00.000Z",
+    "end": "2018-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T04:00:00.000Z",
+    "end": "2018-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T04:00:00.000Z",
+    "end": "2018-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BO-S-2019.json
+++ b/test/fixtures/BO-S-2019.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T04:00:00.000Z",
+    "end": "2019-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-22 00:00:00",
+    "start": "2019-01-22T04:00:00.000Z",
+    "end": "2019-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-02-02 00:00:00",
+    "start": "2019-02-02T04:00:00.000Z",
+    "end": "2019-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-19 00:00:00",
+    "start": "2019-03-19T04:00:00.000Z",
+    "end": "2019-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-23 00:00:00",
+    "start": "2019-03-23T04:00:00.000Z",
+    "end": "2019-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-04-12 00:00:00",
+    "start": "2019-04-12T04:00:00.000Z",
+    "end": "2019-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-18 00:00:00",
+    "start": "2019-04-18T04:00:00.000Z",
+    "end": "2019-04-19T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T04:00:00.000Z",
+    "end": "2019-04-20T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T04:00:00.000Z",
+    "end": "2019-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-27 00:00:00",
+    "start": "2019-05-27T04:00:00.000Z",
+    "end": "2019-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-06-06 00:00:00",
+    "start": "2019-06-06T04:00:00.000Z",
+    "end": "2019-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T04:00:00.000Z",
+    "end": "2019-06-21T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-21T04:00:00.000Z",
+    "end": "2019-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-08-06 00:00:00",
+    "start": "2019-08-06T04:00:00.000Z",
+    "end": "2019-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T04:00:00.000Z",
+    "end": "2019-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-21 00:00:00",
+    "start": "2019-09-21T04:00:00.000Z",
+    "end": "2019-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-24 00:00:00",
+    "start": "2019-09-24T04:00:00.000Z",
+    "end": "2019-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-10-11 00:00:00",
+    "start": "2019-10-11T04:00:00.000Z",
+    "end": "2019-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-11-01T04:00:00.000Z",
+    "end": "2019-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T04:00:00.000Z",
+    "end": "2019-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T04:00:00.000Z",
+    "end": "2019-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-S-2020.json
+++ b/test/fixtures/BO-S-2020.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T04:00:00.000Z",
+    "end": "2020-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-22 00:00:00",
+    "start": "2020-01-22T04:00:00.000Z",
+    "end": "2020-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-02 00:00:00",
+    "start": "2020-02-02T04:00:00.000Z",
+    "end": "2020-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-03-19 00:00:00",
+    "start": "2020-03-19T04:00:00.000Z",
+    "end": "2020-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-03-23 00:00:00",
+    "start": "2020-03-23T04:00:00.000Z",
+    "end": "2020-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-09 00:00:00",
+    "start": "2020-04-09T04:00:00.000Z",
+    "end": "2020-04-10T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T04:00:00.000Z",
+    "end": "2020-04-11T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T04:00:00.000Z",
+    "end": "2020-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T04:00:00.000Z",
+    "end": "2020-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-27 00:00:00",
+    "start": "2020-05-27T04:00:00.000Z",
+    "end": "2020-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-06-06 00:00:00",
+    "start": "2020-06-06T04:00:00.000Z",
+    "end": "2020-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T04:00:00.000Z",
+    "end": "2020-06-12T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-21T04:00:00.000Z",
+    "end": "2020-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-22 00:00:00",
+    "start": "2020-06-22T04:00:00.000Z",
+    "end": "2020-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-06 00:00:00",
+    "start": "2020-08-06T04:00:00.000Z",
+    "end": "2020-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-17T04:00:00.000Z",
+    "end": "2020-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-21 00:00:00",
+    "start": "2020-09-21T04:00:00.000Z",
+    "end": "2020-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-24 00:00:00",
+    "start": "2020-09-24T04:00:00.000Z",
+    "end": "2020-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-10-11 00:00:00",
+    "start": "2020-10-11T04:00:00.000Z",
+    "end": "2020-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-11-01T04:00:00.000Z",
+    "end": "2020-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T04:00:00.000Z",
+    "end": "2020-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T04:00:00.000Z",
+    "end": "2020-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-S-2021.json
+++ b/test/fixtures/BO-S-2021.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T04:00:00.000Z",
+    "end": "2021-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-22 00:00:00",
+    "start": "2021-01-22T04:00:00.000Z",
+    "end": "2021-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-02 00:00:00",
+    "start": "2021-02-02T04:00:00.000Z",
+    "end": "2021-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-03-19 00:00:00",
+    "start": "2021-03-19T04:00:00.000Z",
+    "end": "2021-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-03-23 00:00:00",
+    "start": "2021-03-23T04:00:00.000Z",
+    "end": "2021-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-04-01T04:00:00.000Z",
+    "end": "2021-04-02T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T04:00:00.000Z",
+    "end": "2021-04-03T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T04:00:00.000Z",
+    "end": "2021-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T04:00:00.000Z",
+    "end": "2021-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-27 00:00:00",
+    "start": "2021-05-27T04:00:00.000Z",
+    "end": "2021-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T04:00:00.000Z",
+    "end": "2021-06-04T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-06 00:00:00",
+    "start": "2021-06-06T04:00:00.000Z",
+    "end": "2021-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T04:00:00.000Z",
+    "end": "2021-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-06 00:00:00",
+    "start": "2021-08-06T04:00:00.000Z",
+    "end": "2021-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-17T04:00:00.000Z",
+    "end": "2021-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-21 00:00:00",
+    "start": "2021-09-21T04:00:00.000Z",
+    "end": "2021-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-24 00:00:00",
+    "start": "2021-09-24T04:00:00.000Z",
+    "end": "2021-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-11-01T04:00:00.000Z",
+    "end": "2021-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T04:00:00.000Z",
+    "end": "2021-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T04:00:00.000Z",
+    "end": "2021-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-S-2022.json
+++ b/test/fixtures/BO-S-2022.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T04:00:00.000Z",
+    "end": "2022-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-22 00:00:00",
+    "start": "2022-01-22T04:00:00.000Z",
+    "end": "2022-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-02 00:00:00",
+    "start": "2022-02-02T04:00:00.000Z",
+    "end": "2022-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-19 00:00:00",
+    "start": "2022-03-19T04:00:00.000Z",
+    "end": "2022-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-03-23 00:00:00",
+    "start": "2022-03-23T04:00:00.000Z",
+    "end": "2022-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-12 00:00:00",
+    "start": "2022-04-12T04:00:00.000Z",
+    "end": "2022-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-14 00:00:00",
+    "start": "2022-04-14T04:00:00.000Z",
+    "end": "2022-04-15T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T04:00:00.000Z",
+    "end": "2022-04-16T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T04:00:00.000Z",
+    "end": "2022-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-02T04:00:00.000Z",
+    "end": "2022-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-27 00:00:00",
+    "start": "2022-05-27T04:00:00.000Z",
+    "end": "2022-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-06-06 00:00:00",
+    "start": "2022-06-06T04:00:00.000Z",
+    "end": "2022-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T04:00:00.000Z",
+    "end": "2022-06-17T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-06-21 00:00:00",
+    "start": "2022-06-21T04:00:00.000Z",
+    "end": "2022-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T04:00:00.000Z",
+    "end": "2022-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-17T04:00:00.000Z",
+    "end": "2022-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-21 00:00:00",
+    "start": "2022-09-21T04:00:00.000Z",
+    "end": "2022-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-24 00:00:00",
+    "start": "2022-09-24T04:00:00.000Z",
+    "end": "2022-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-10-11 00:00:00",
+    "start": "2022-10-11T04:00:00.000Z",
+    "end": "2022-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-11-01T04:00:00.000Z",
+    "end": "2022-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T04:00:00.000Z",
+    "end": "2022-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T04:00:00.000Z",
+    "end": "2022-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-26T04:00:00.000Z",
+    "end": "2022-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-S-2023.json
+++ b/test/fixtures/BO-S-2023.json
@@ -1,0 +1,245 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T04:00:00.000Z",
+    "end": "2023-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T04:00:00.000Z",
+    "end": "2023-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-01-22 00:00:00",
+    "start": "2023-01-22T04:00:00.000Z",
+    "end": "2023-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-23 00:00:00",
+    "start": "2023-01-23T04:00:00.000Z",
+    "end": "2023-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-02 00:00:00",
+    "start": "2023-02-02T04:00:00.000Z",
+    "end": "2023-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-03-19 00:00:00",
+    "start": "2023-03-19T04:00:00.000Z",
+    "end": "2023-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-03-23 00:00:00",
+    "start": "2023-03-23T04:00:00.000Z",
+    "end": "2023-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-06 00:00:00",
+    "start": "2023-04-06T04:00:00.000Z",
+    "end": "2023-04-07T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T04:00:00.000Z",
+    "end": "2023-04-08T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-12 00:00:00",
+    "start": "2023-04-12T04:00:00.000Z",
+    "end": "2023-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T04:00:00.000Z",
+    "end": "2023-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-27 00:00:00",
+    "start": "2023-05-27T04:00:00.000Z",
+    "end": "2023-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-06-06 00:00:00",
+    "start": "2023-06-06T04:00:00.000Z",
+    "end": "2023-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T04:00:00.000Z",
+    "end": "2023-06-09T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-21 00:00:00",
+    "start": "2023-06-21T04:00:00.000Z",
+    "end": "2023-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T04:00:00.000Z",
+    "end": "2023-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-17T04:00:00.000Z",
+    "end": "2023-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-21 00:00:00",
+    "start": "2023-09-21T04:00:00.000Z",
+    "end": "2023-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-24 00:00:00",
+    "start": "2023-09-24T04:00:00.000Z",
+    "end": "2023-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-09-25 00:00:00",
+    "start": "2023-09-25T04:00:00.000Z",
+    "end": "2023-09-26T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz (substituto)",
+    "type": "public",
+    "rule": "substitutes 09-24 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-10-11 00:00:00",
+    "start": "2023-10-11T04:00:00.000Z",
+    "end": "2023-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-11-01T04:00:00.000Z",
+    "end": "2023-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T04:00:00.000Z",
+    "end": "2023-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T04:00:00.000Z",
+    "end": "2023-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-S-2024.json
+++ b/test/fixtures/BO-S-2024.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T04:00:00.000Z",
+    "end": "2024-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-22 00:00:00",
+    "start": "2024-01-22T04:00:00.000Z",
+    "end": "2024-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-02 00:00:00",
+    "start": "2024-02-02T04:00:00.000Z",
+    "end": "2024-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-19 00:00:00",
+    "start": "2024-03-19T04:00:00.000Z",
+    "end": "2024-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-23 00:00:00",
+    "start": "2024-03-23T04:00:00.000Z",
+    "end": "2024-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-28 00:00:00",
+    "start": "2024-03-28T04:00:00.000Z",
+    "end": "2024-03-29T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T04:00:00.000Z",
+    "end": "2024-03-30T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-04-12 00:00:00",
+    "start": "2024-04-12T04:00:00.000Z",
+    "end": "2024-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T04:00:00.000Z",
+    "end": "2024-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-27 00:00:00",
+    "start": "2024-05-27T04:00:00.000Z",
+    "end": "2024-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T04:00:00.000Z",
+    "end": "2024-05-31T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-06 00:00:00",
+    "start": "2024-06-06T04:00:00.000Z",
+    "end": "2024-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-21T04:00:00.000Z",
+    "end": "2024-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T04:00:00.000Z",
+    "end": "2024-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T04:00:00.000Z",
+    "end": "2024-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-21 00:00:00",
+    "start": "2024-09-21T04:00:00.000Z",
+    "end": "2024-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-24 00:00:00",
+    "start": "2024-09-24T04:00:00.000Z",
+    "end": "2024-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T04:00:00.000Z",
+    "end": "2024-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-11-01T04:00:00.000Z",
+    "end": "2024-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T04:00:00.000Z",
+    "end": "2024-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T04:00:00.000Z",
+    "end": "2024-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-S-2025.json
+++ b/test/fixtures/BO-S-2025.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T04:00:00.000Z",
+    "end": "2025-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-22 00:00:00",
+    "start": "2025-01-22T04:00:00.000Z",
+    "end": "2025-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-02-02 00:00:00",
+    "start": "2025-02-02T04:00:00.000Z",
+    "end": "2025-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-19 00:00:00",
+    "start": "2025-03-19T04:00:00.000Z",
+    "end": "2025-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-23 00:00:00",
+    "start": "2025-03-23T04:00:00.000Z",
+    "end": "2025-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-12 00:00:00",
+    "start": "2025-04-12T04:00:00.000Z",
+    "end": "2025-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-17 00:00:00",
+    "start": "2025-04-17T04:00:00.000Z",
+    "end": "2025-04-18T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T04:00:00.000Z",
+    "end": "2025-04-19T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T04:00:00.000Z",
+    "end": "2025-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-27 00:00:00",
+    "start": "2025-05-27T04:00:00.000Z",
+    "end": "2025-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-06-06 00:00:00",
+    "start": "2025-06-06T04:00:00.000Z",
+    "end": "2025-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T04:00:00.000Z",
+    "end": "2025-06-20T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-21 00:00:00",
+    "start": "2025-06-21T04:00:00.000Z",
+    "end": "2025-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T04:00:00.000Z",
+    "end": "2025-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T04:00:00.000Z",
+    "end": "2025-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-21 00:00:00",
+    "start": "2025-09-21T04:00:00.000Z",
+    "end": "2025-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-24 00:00:00",
+    "start": "2025-09-24T04:00:00.000Z",
+    "end": "2025-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-10-11 00:00:00",
+    "start": "2025-10-11T04:00:00.000Z",
+    "end": "2025-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-11-01T04:00:00.000Z",
+    "end": "2025-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T04:00:00.000Z",
+    "end": "2025-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T04:00:00.000Z",
+    "end": "2025-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BO-S-2026.json
+++ b/test/fixtures/BO-S-2026.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T04:00:00.000Z",
+    "end": "2026-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-22 00:00:00",
+    "start": "2026-01-22T04:00:00.000Z",
+    "end": "2026-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-02 00:00:00",
+    "start": "2026-02-02T04:00:00.000Z",
+    "end": "2026-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-03-19 00:00:00",
+    "start": "2026-03-19T04:00:00.000Z",
+    "end": "2026-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T04:00:00.000Z",
+    "end": "2026-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-02 00:00:00",
+    "start": "2026-04-02T04:00:00.000Z",
+    "end": "2026-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T04:00:00.000Z",
+    "end": "2026-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-12 00:00:00",
+    "start": "2026-04-12T04:00:00.000Z",
+    "end": "2026-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T04:00:00.000Z",
+    "end": "2026-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-27 00:00:00",
+    "start": "2026-05-27T04:00:00.000Z",
+    "end": "2026-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T04:00:00.000Z",
+    "end": "2026-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-06 00:00:00",
+    "start": "2026-06-06T04:00:00.000Z",
+    "end": "2026-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-06-21 00:00:00",
+    "start": "2026-06-21T04:00:00.000Z",
+    "end": "2026-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-22 00:00:00",
+    "start": "2026-06-22T04:00:00.000Z",
+    "end": "2026-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T04:00:00.000Z",
+    "end": "2026-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-17T04:00:00.000Z",
+    "end": "2026-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-21 00:00:00",
+    "start": "2026-09-21T04:00:00.000Z",
+    "end": "2026-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-24 00:00:00",
+    "start": "2026-09-24T04:00:00.000Z",
+    "end": "2026-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-10-11 00:00:00",
+    "start": "2026-10-11T04:00:00.000Z",
+    "end": "2026-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-11-01T04:00:00.000Z",
+    "end": "2026-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T04:00:00.000Z",
+    "end": "2026-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T04:00:00.000Z",
+    "end": "2026-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-S-2027.json
+++ b/test/fixtures/BO-S-2027.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T04:00:00.000Z",
+    "end": "2027-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-22 00:00:00",
+    "start": "2027-01-22T04:00:00.000Z",
+    "end": "2027-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-02 00:00:00",
+    "start": "2027-02-02T04:00:00.000Z",
+    "end": "2027-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-19 00:00:00",
+    "start": "2027-03-19T04:00:00.000Z",
+    "end": "2027-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-23 00:00:00",
+    "start": "2027-03-23T04:00:00.000Z",
+    "end": "2027-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-25 00:00:00",
+    "start": "2027-03-25T04:00:00.000Z",
+    "end": "2027-03-26T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T04:00:00.000Z",
+    "end": "2027-03-27T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-04-12 00:00:00",
+    "start": "2027-04-12T04:00:00.000Z",
+    "end": "2027-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T04:00:00.000Z",
+    "end": "2027-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-06 00:00:00",
+    "start": "2027-06-06T04:00:00.000Z",
+    "end": "2027-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T04:00:00.000Z",
+    "end": "2027-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T04:00:00.000Z",
+    "end": "2027-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-08-17 00:00:00",
+    "start": "2027-08-17T04:00:00.000Z",
+    "end": "2027-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-21 00:00:00",
+    "start": "2027-09-21T04:00:00.000Z",
+    "end": "2027-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-24 00:00:00",
+    "start": "2027-09-24T04:00:00.000Z",
+    "end": "2027-09-25T04:00:00.000Z",
+    "name": "Efemérides de Santa Cruz",
+    "type": "public",
+    "rule": "09-24",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-11-01T04:00:00.000Z",
+    "end": "2027-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T04:00:00.000Z",
+    "end": "2027-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T04:00:00.000Z",
+    "end": "2027-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-T-2015.json
+++ b/test/fixtures/BO-T-2015.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T04:00:00.000Z",
+    "end": "2015-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-22 00:00:00",
+    "start": "2015-01-22T04:00:00.000Z",
+    "end": "2015-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-02 00:00:00",
+    "start": "2015-02-02T04:00:00.000Z",
+    "end": "2015-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-03-19 00:00:00",
+    "start": "2015-03-19T04:00:00.000Z",
+    "end": "2015-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-03-23 00:00:00",
+    "start": "2015-03-23T04:00:00.000Z",
+    "end": "2015-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-02 00:00:00",
+    "start": "2015-04-02T04:00:00.000Z",
+    "end": "2015-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T04:00:00.000Z",
+    "end": "2015-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-12 00:00:00",
+    "start": "2015-04-12T04:00:00.000Z",
+    "end": "2015-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-04-15 00:00:00",
+    "start": "2015-04-15T04:00:00.000Z",
+    "end": "2015-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T04:00:00.000Z",
+    "end": "2015-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-27 00:00:00",
+    "start": "2015-05-27T04:00:00.000Z",
+    "end": "2015-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T04:00:00.000Z",
+    "end": "2015-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-06 00:00:00",
+    "start": "2015-06-06T04:00:00.000Z",
+    "end": "2015-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-06-21 00:00:00",
+    "start": "2015-06-21T04:00:00.000Z",
+    "end": "2015-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-22 00:00:00",
+    "start": "2015-06-22T04:00:00.000Z",
+    "end": "2015-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-06 00:00:00",
+    "start": "2015-08-06T04:00:00.000Z",
+    "end": "2015-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-08-17 00:00:00",
+    "start": "2015-08-17T04:00:00.000Z",
+    "end": "2015-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-09-21 00:00:00",
+    "start": "2015-09-21T04:00:00.000Z",
+    "end": "2015-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-11 00:00:00",
+    "start": "2015-10-11T04:00:00.000Z",
+    "end": "2015-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-11-01T04:00:00.000Z",
+    "end": "2015-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T04:00:00.000Z",
+    "end": "2015-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T04:00:00.000Z",
+    "end": "2015-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-T-2016.json
+++ b/test/fixtures/BO-T-2016.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T04:00:00.000Z",
+    "end": "2016-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-22 00:00:00",
+    "start": "2016-01-22T04:00:00.000Z",
+    "end": "2016-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-02 00:00:00",
+    "start": "2016-02-02T04:00:00.000Z",
+    "end": "2016-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-03-19 00:00:00",
+    "start": "2016-03-19T04:00:00.000Z",
+    "end": "2016-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-03-23 00:00:00",
+    "start": "2016-03-23T04:00:00.000Z",
+    "end": "2016-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-24 00:00:00",
+    "start": "2016-03-24T04:00:00.000Z",
+    "end": "2016-03-25T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T04:00:00.000Z",
+    "end": "2016-03-26T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-04-12 00:00:00",
+    "start": "2016-04-12T04:00:00.000Z",
+    "end": "2016-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-04-15 00:00:00",
+    "start": "2016-04-15T04:00:00.000Z",
+    "end": "2016-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T04:00:00.000Z",
+    "end": "2016-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-02 00:00:00",
+    "start": "2016-05-02T04:00:00.000Z",
+    "end": "2016-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T04:00:00.000Z",
+    "end": "2016-05-27T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-27 00:00:00",
+    "start": "2016-05-27T04:00:00.000Z",
+    "end": "2016-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-06-06 00:00:00",
+    "start": "2016-06-06T04:00:00.000Z",
+    "end": "2016-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-06-21 00:00:00",
+    "start": "2016-06-21T04:00:00.000Z",
+    "end": "2016-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-08-06 00:00:00",
+    "start": "2016-08-06T04:00:00.000Z",
+    "end": "2016-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-08-17 00:00:00",
+    "start": "2016-08-17T04:00:00.000Z",
+    "end": "2016-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-09-21 00:00:00",
+    "start": "2016-09-21T04:00:00.000Z",
+    "end": "2016-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-11 00:00:00",
+    "start": "2016-10-11T04:00:00.000Z",
+    "end": "2016-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-11-01T04:00:00.000Z",
+    "end": "2016-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T04:00:00.000Z",
+    "end": "2016-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T04:00:00.000Z",
+    "end": "2016-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-26T04:00:00.000Z",
+    "end": "2016-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-T-2017.json
+++ b/test/fixtures/BO-T-2017.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T04:00:00.000Z",
+    "end": "2017-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-02 00:00:00",
+    "start": "2017-01-02T04:00:00.000Z",
+    "end": "2017-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-01-22 00:00:00",
+    "start": "2017-01-22T04:00:00.000Z",
+    "end": "2017-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-23 00:00:00",
+    "start": "2017-01-23T04:00:00.000Z",
+    "end": "2017-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-02 00:00:00",
+    "start": "2017-02-02T04:00:00.000Z",
+    "end": "2017-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-19 00:00:00",
+    "start": "2017-03-19T04:00:00.000Z",
+    "end": "2017-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-03-23 00:00:00",
+    "start": "2017-03-23T04:00:00.000Z",
+    "end": "2017-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-12 00:00:00",
+    "start": "2017-04-12T04:00:00.000Z",
+    "end": "2017-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-13 00:00:00",
+    "start": "2017-04-13T04:00:00.000Z",
+    "end": "2017-04-14T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T04:00:00.000Z",
+    "end": "2017-04-15T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-04-15 00:00:00",
+    "start": "2017-04-15T04:00:00.000Z",
+    "end": "2017-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T04:00:00.000Z",
+    "end": "2017-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-27 00:00:00",
+    "start": "2017-05-27T04:00:00.000Z",
+    "end": "2017-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-06-06 00:00:00",
+    "start": "2017-06-06T04:00:00.000Z",
+    "end": "2017-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T04:00:00.000Z",
+    "end": "2017-06-16T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-06-21 00:00:00",
+    "start": "2017-06-21T04:00:00.000Z",
+    "end": "2017-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-08-06 00:00:00",
+    "start": "2017-08-06T04:00:00.000Z",
+    "end": "2017-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-17 00:00:00",
+    "start": "2017-08-17T04:00:00.000Z",
+    "end": "2017-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-09-21 00:00:00",
+    "start": "2017-09-21T04:00:00.000Z",
+    "end": "2017-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-11 00:00:00",
+    "start": "2017-10-11T04:00:00.000Z",
+    "end": "2017-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-11-01T04:00:00.000Z",
+    "end": "2017-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T04:00:00.000Z",
+    "end": "2017-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T04:00:00.000Z",
+    "end": "2017-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-T-2018.json
+++ b/test/fixtures/BO-T-2018.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T04:00:00.000Z",
+    "end": "2018-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-22 00:00:00",
+    "start": "2018-01-22T04:00:00.000Z",
+    "end": "2018-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-02 00:00:00",
+    "start": "2018-02-02T04:00:00.000Z",
+    "end": "2018-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-03-19 00:00:00",
+    "start": "2018-03-19T04:00:00.000Z",
+    "end": "2018-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-03-23 00:00:00",
+    "start": "2018-03-23T04:00:00.000Z",
+    "end": "2018-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-03-29 00:00:00",
+    "start": "2018-03-29T04:00:00.000Z",
+    "end": "2018-03-30T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T04:00:00.000Z",
+    "end": "2018-03-31T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-12 00:00:00",
+    "start": "2018-04-12T04:00:00.000Z",
+    "end": "2018-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-04-15 00:00:00",
+    "start": "2018-04-15T04:00:00.000Z",
+    "end": "2018-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-04-16 00:00:00",
+    "start": "2018-04-16T04:00:00.000Z",
+    "end": "2018-04-17T04:00:00.000Z",
+    "name": "Efemérides de Tarija (substituto)",
+    "type": "public",
+    "rule": "substitutes 04-15 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T04:00:00.000Z",
+    "end": "2018-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-27T04:00:00.000Z",
+    "end": "2018-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T04:00:00.000Z",
+    "end": "2018-06-01T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-06 00:00:00",
+    "start": "2018-06-06T04:00:00.000Z",
+    "end": "2018-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-06-21 00:00:00",
+    "start": "2018-06-21T04:00:00.000Z",
+    "end": "2018-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T04:00:00.000Z",
+    "end": "2018-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-17 00:00:00",
+    "start": "2018-08-17T04:00:00.000Z",
+    "end": "2018-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-09-21 00:00:00",
+    "start": "2018-09-21T04:00:00.000Z",
+    "end": "2018-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-11 00:00:00",
+    "start": "2018-10-11T04:00:00.000Z",
+    "end": "2018-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-11-01T04:00:00.000Z",
+    "end": "2018-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T04:00:00.000Z",
+    "end": "2018-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T04:00:00.000Z",
+    "end": "2018-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BO-T-2019.json
+++ b/test/fixtures/BO-T-2019.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T04:00:00.000Z",
+    "end": "2019-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-22 00:00:00",
+    "start": "2019-01-22T04:00:00.000Z",
+    "end": "2019-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-02-02 00:00:00",
+    "start": "2019-02-02T04:00:00.000Z",
+    "end": "2019-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-19 00:00:00",
+    "start": "2019-03-19T04:00:00.000Z",
+    "end": "2019-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-23 00:00:00",
+    "start": "2019-03-23T04:00:00.000Z",
+    "end": "2019-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-04-12 00:00:00",
+    "start": "2019-04-12T04:00:00.000Z",
+    "end": "2019-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-15 00:00:00",
+    "start": "2019-04-15T04:00:00.000Z",
+    "end": "2019-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-04-18 00:00:00",
+    "start": "2019-04-18T04:00:00.000Z",
+    "end": "2019-04-19T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T04:00:00.000Z",
+    "end": "2019-04-20T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T04:00:00.000Z",
+    "end": "2019-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-27 00:00:00",
+    "start": "2019-05-27T04:00:00.000Z",
+    "end": "2019-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-06-06 00:00:00",
+    "start": "2019-06-06T04:00:00.000Z",
+    "end": "2019-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T04:00:00.000Z",
+    "end": "2019-06-21T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-21T04:00:00.000Z",
+    "end": "2019-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-08-06 00:00:00",
+    "start": "2019-08-06T04:00:00.000Z",
+    "end": "2019-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T04:00:00.000Z",
+    "end": "2019-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-09-21 00:00:00",
+    "start": "2019-09-21T04:00:00.000Z",
+    "end": "2019-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-11 00:00:00",
+    "start": "2019-10-11T04:00:00.000Z",
+    "end": "2019-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-11-01T04:00:00.000Z",
+    "end": "2019-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T04:00:00.000Z",
+    "end": "2019-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T04:00:00.000Z",
+    "end": "2019-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-T-2020.json
+++ b/test/fixtures/BO-T-2020.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T04:00:00.000Z",
+    "end": "2020-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-22 00:00:00",
+    "start": "2020-01-22T04:00:00.000Z",
+    "end": "2020-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-02 00:00:00",
+    "start": "2020-02-02T04:00:00.000Z",
+    "end": "2020-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-03-19 00:00:00",
+    "start": "2020-03-19T04:00:00.000Z",
+    "end": "2020-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-03-23 00:00:00",
+    "start": "2020-03-23T04:00:00.000Z",
+    "end": "2020-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-09 00:00:00",
+    "start": "2020-04-09T04:00:00.000Z",
+    "end": "2020-04-10T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T04:00:00.000Z",
+    "end": "2020-04-11T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T04:00:00.000Z",
+    "end": "2020-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-04-15 00:00:00",
+    "start": "2020-04-15T04:00:00.000Z",
+    "end": "2020-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T04:00:00.000Z",
+    "end": "2020-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-27 00:00:00",
+    "start": "2020-05-27T04:00:00.000Z",
+    "end": "2020-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-06-06 00:00:00",
+    "start": "2020-06-06T04:00:00.000Z",
+    "end": "2020-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T04:00:00.000Z",
+    "end": "2020-06-12T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-21T04:00:00.000Z",
+    "end": "2020-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-22 00:00:00",
+    "start": "2020-06-22T04:00:00.000Z",
+    "end": "2020-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-06 00:00:00",
+    "start": "2020-08-06T04:00:00.000Z",
+    "end": "2020-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-08-17 00:00:00",
+    "start": "2020-08-17T04:00:00.000Z",
+    "end": "2020-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-09-21 00:00:00",
+    "start": "2020-09-21T04:00:00.000Z",
+    "end": "2020-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-11 00:00:00",
+    "start": "2020-10-11T04:00:00.000Z",
+    "end": "2020-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-11-01T04:00:00.000Z",
+    "end": "2020-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T04:00:00.000Z",
+    "end": "2020-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T04:00:00.000Z",
+    "end": "2020-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-T-2021.json
+++ b/test/fixtures/BO-T-2021.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T04:00:00.000Z",
+    "end": "2021-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-22 00:00:00",
+    "start": "2021-01-22T04:00:00.000Z",
+    "end": "2021-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-02 00:00:00",
+    "start": "2021-02-02T04:00:00.000Z",
+    "end": "2021-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-03-19 00:00:00",
+    "start": "2021-03-19T04:00:00.000Z",
+    "end": "2021-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-03-23 00:00:00",
+    "start": "2021-03-23T04:00:00.000Z",
+    "end": "2021-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-04-01 00:00:00",
+    "start": "2021-04-01T04:00:00.000Z",
+    "end": "2021-04-02T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T04:00:00.000Z",
+    "end": "2021-04-03T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T04:00:00.000Z",
+    "end": "2021-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-04-15 00:00:00",
+    "start": "2021-04-15T04:00:00.000Z",
+    "end": "2021-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T04:00:00.000Z",
+    "end": "2021-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-27 00:00:00",
+    "start": "2021-05-27T04:00:00.000Z",
+    "end": "2021-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T04:00:00.000Z",
+    "end": "2021-06-04T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-06 00:00:00",
+    "start": "2021-06-06T04:00:00.000Z",
+    "end": "2021-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T04:00:00.000Z",
+    "end": "2021-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-06 00:00:00",
+    "start": "2021-08-06T04:00:00.000Z",
+    "end": "2021-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-08-17 00:00:00",
+    "start": "2021-08-17T04:00:00.000Z",
+    "end": "2021-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-09-21 00:00:00",
+    "start": "2021-09-21T04:00:00.000Z",
+    "end": "2021-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-11T04:00:00.000Z",
+    "end": "2021-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-11-01T04:00:00.000Z",
+    "end": "2021-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T04:00:00.000Z",
+    "end": "2021-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T04:00:00.000Z",
+    "end": "2021-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BO-T-2022.json
+++ b/test/fixtures/BO-T-2022.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T04:00:00.000Z",
+    "end": "2022-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-22 00:00:00",
+    "start": "2022-01-22T04:00:00.000Z",
+    "end": "2022-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-02 00:00:00",
+    "start": "2022-02-02T04:00:00.000Z",
+    "end": "2022-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-19 00:00:00",
+    "start": "2022-03-19T04:00:00.000Z",
+    "end": "2022-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-03-23 00:00:00",
+    "start": "2022-03-23T04:00:00.000Z",
+    "end": "2022-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-12 00:00:00",
+    "start": "2022-04-12T04:00:00.000Z",
+    "end": "2022-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-04-14 00:00:00",
+    "start": "2022-04-14T04:00:00.000Z",
+    "end": "2022-04-15T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T04:00:00.000Z",
+    "end": "2022-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T04:00:00.000Z",
+    "end": "2022-04-16T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T04:00:00.000Z",
+    "end": "2022-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-02 00:00:00",
+    "start": "2022-05-02T04:00:00.000Z",
+    "end": "2022-05-03T04:00:00.000Z",
+    "name": "Día del Trabajo (substituto)",
+    "type": "public",
+    "rule": "substitutes 05-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-27 00:00:00",
+    "start": "2022-05-27T04:00:00.000Z",
+    "end": "2022-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-06-06 00:00:00",
+    "start": "2022-06-06T04:00:00.000Z",
+    "end": "2022-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T04:00:00.000Z",
+    "end": "2022-06-17T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-06-21 00:00:00",
+    "start": "2022-06-21T04:00:00.000Z",
+    "end": "2022-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T04:00:00.000Z",
+    "end": "2022-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-08-17 00:00:00",
+    "start": "2022-08-17T04:00:00.000Z",
+    "end": "2022-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-09-21 00:00:00",
+    "start": "2022-09-21T04:00:00.000Z",
+    "end": "2022-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-11 00:00:00",
+    "start": "2022-10-11T04:00:00.000Z",
+    "end": "2022-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-11-01T04:00:00.000Z",
+    "end": "2022-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T04:00:00.000Z",
+    "end": "2022-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T04:00:00.000Z",
+    "end": "2022-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-26T04:00:00.000Z",
+    "end": "2022-12-27T04:00:00.000Z",
+    "name": "Navidad (substituto)",
+    "type": "public",
+    "rule": "substitutes 12-25 if sunday then next monday",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-T-2023.json
+++ b/test/fixtures/BO-T-2023.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T04:00:00.000Z",
+    "end": "2023-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-02 00:00:00",
+    "start": "2023-01-02T04:00:00.000Z",
+    "end": "2023-01-03T04:00:00.000Z",
+    "name": "Año Nuevo (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-01 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-01-22 00:00:00",
+    "start": "2023-01-22T04:00:00.000Z",
+    "end": "2023-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-23 00:00:00",
+    "start": "2023-01-23T04:00:00.000Z",
+    "end": "2023-01-24T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia (substituto)",
+    "type": "public",
+    "rule": "substitutes 01-22 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-02 00:00:00",
+    "start": "2023-02-02T04:00:00.000Z",
+    "end": "2023-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-03-19 00:00:00",
+    "start": "2023-03-19T04:00:00.000Z",
+    "end": "2023-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-03-23 00:00:00",
+    "start": "2023-03-23T04:00:00.000Z",
+    "end": "2023-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-06 00:00:00",
+    "start": "2023-04-06T04:00:00.000Z",
+    "end": "2023-04-07T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T04:00:00.000Z",
+    "end": "2023-04-08T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-12 00:00:00",
+    "start": "2023-04-12T04:00:00.000Z",
+    "end": "2023-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-04-15 00:00:00",
+    "start": "2023-04-15T04:00:00.000Z",
+    "end": "2023-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T04:00:00.000Z",
+    "end": "2023-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-27 00:00:00",
+    "start": "2023-05-27T04:00:00.000Z",
+    "end": "2023-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-06-06 00:00:00",
+    "start": "2023-06-06T04:00:00.000Z",
+    "end": "2023-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T04:00:00.000Z",
+    "end": "2023-06-09T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-21 00:00:00",
+    "start": "2023-06-21T04:00:00.000Z",
+    "end": "2023-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T04:00:00.000Z",
+    "end": "2023-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Día de la Independencia (substituto)",
+    "type": "public",
+    "rule": "substitutes 08-06 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-17 00:00:00",
+    "start": "2023-08-17T04:00:00.000Z",
+    "end": "2023-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-09-21 00:00:00",
+    "start": "2023-09-21T04:00:00.000Z",
+    "end": "2023-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-11 00:00:00",
+    "start": "2023-10-11T04:00:00.000Z",
+    "end": "2023-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-11-01T04:00:00.000Z",
+    "end": "2023-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T04:00:00.000Z",
+    "end": "2023-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T04:00:00.000Z",
+    "end": "2023-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BO-T-2024.json
+++ b/test/fixtures/BO-T-2024.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T04:00:00.000Z",
+    "end": "2024-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-22 00:00:00",
+    "start": "2024-01-22T04:00:00.000Z",
+    "end": "2024-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-02 00:00:00",
+    "start": "2024-02-02T04:00:00.000Z",
+    "end": "2024-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-19 00:00:00",
+    "start": "2024-03-19T04:00:00.000Z",
+    "end": "2024-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-03-23 00:00:00",
+    "start": "2024-03-23T04:00:00.000Z",
+    "end": "2024-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-28 00:00:00",
+    "start": "2024-03-28T04:00:00.000Z",
+    "end": "2024-03-29T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T04:00:00.000Z",
+    "end": "2024-03-30T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-04-12 00:00:00",
+    "start": "2024-04-12T04:00:00.000Z",
+    "end": "2024-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-04-15 00:00:00",
+    "start": "2024-04-15T04:00:00.000Z",
+    "end": "2024-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T04:00:00.000Z",
+    "end": "2024-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-27 00:00:00",
+    "start": "2024-05-27T04:00:00.000Z",
+    "end": "2024-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T04:00:00.000Z",
+    "end": "2024-05-31T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-06 00:00:00",
+    "start": "2024-06-06T04:00:00.000Z",
+    "end": "2024-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-21T04:00:00.000Z",
+    "end": "2024-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T04:00:00.000Z",
+    "end": "2024-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T04:00:00.000Z",
+    "end": "2024-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-09-21 00:00:00",
+    "start": "2024-09-21T04:00:00.000Z",
+    "end": "2024-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T04:00:00.000Z",
+    "end": "2024-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-11-01T04:00:00.000Z",
+    "end": "2024-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T04:00:00.000Z",
+    "end": "2024-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T04:00:00.000Z",
+    "end": "2024-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BO-T-2025.json
+++ b/test/fixtures/BO-T-2025.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T04:00:00.000Z",
+    "end": "2025-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-22 00:00:00",
+    "start": "2025-01-22T04:00:00.000Z",
+    "end": "2025-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-02-02 00:00:00",
+    "start": "2025-02-02T04:00:00.000Z",
+    "end": "2025-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-19 00:00:00",
+    "start": "2025-03-19T04:00:00.000Z",
+    "end": "2025-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-23 00:00:00",
+    "start": "2025-03-23T04:00:00.000Z",
+    "end": "2025-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-12 00:00:00",
+    "start": "2025-04-12T04:00:00.000Z",
+    "end": "2025-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-04-15 00:00:00",
+    "start": "2025-04-15T04:00:00.000Z",
+    "end": "2025-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-04-17 00:00:00",
+    "start": "2025-04-17T04:00:00.000Z",
+    "end": "2025-04-18T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T04:00:00.000Z",
+    "end": "2025-04-19T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T04:00:00.000Z",
+    "end": "2025-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-27 00:00:00",
+    "start": "2025-05-27T04:00:00.000Z",
+    "end": "2025-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-06-06 00:00:00",
+    "start": "2025-06-06T04:00:00.000Z",
+    "end": "2025-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T04:00:00.000Z",
+    "end": "2025-06-20T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-21 00:00:00",
+    "start": "2025-06-21T04:00:00.000Z",
+    "end": "2025-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T04:00:00.000Z",
+    "end": "2025-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T04:00:00.000Z",
+    "end": "2025-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-21 00:00:00",
+    "start": "2025-09-21T04:00:00.000Z",
+    "end": "2025-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-11 00:00:00",
+    "start": "2025-10-11T04:00:00.000Z",
+    "end": "2025-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-11-01T04:00:00.000Z",
+    "end": "2025-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T04:00:00.000Z",
+    "end": "2025-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T04:00:00.000Z",
+    "end": "2025-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BO-T-2026.json
+++ b/test/fixtures/BO-T-2026.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T04:00:00.000Z",
+    "end": "2026-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-22 00:00:00",
+    "start": "2026-01-22T04:00:00.000Z",
+    "end": "2026-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-02 00:00:00",
+    "start": "2026-02-02T04:00:00.000Z",
+    "end": "2026-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-03-19 00:00:00",
+    "start": "2026-03-19T04:00:00.000Z",
+    "end": "2026-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T04:00:00.000Z",
+    "end": "2026-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-02 00:00:00",
+    "start": "2026-04-02T04:00:00.000Z",
+    "end": "2026-04-03T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T04:00:00.000Z",
+    "end": "2026-04-04T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-12 00:00:00",
+    "start": "2026-04-12T04:00:00.000Z",
+    "end": "2026-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-04-15 00:00:00",
+    "start": "2026-04-15T04:00:00.000Z",
+    "end": "2026-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T04:00:00.000Z",
+    "end": "2026-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-27 00:00:00",
+    "start": "2026-05-27T04:00:00.000Z",
+    "end": "2026-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T04:00:00.000Z",
+    "end": "2026-06-05T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-06 00:00:00",
+    "start": "2026-06-06T04:00:00.000Z",
+    "end": "2026-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-06-21 00:00:00",
+    "start": "2026-06-21T04:00:00.000Z",
+    "end": "2026-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-22 00:00:00",
+    "start": "2026-06-22T04:00:00.000Z",
+    "end": "2026-06-23T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño (substituto)",
+    "type": "public",
+    "rule": "substitutes 06-21 if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T04:00:00.000Z",
+    "end": "2026-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-17T04:00:00.000Z",
+    "end": "2026-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-09-21 00:00:00",
+    "start": "2026-09-21T04:00:00.000Z",
+    "end": "2026-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-11 00:00:00",
+    "start": "2026-10-11T04:00:00.000Z",
+    "end": "2026-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-11-01T04:00:00.000Z",
+    "end": "2026-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T04:00:00.000Z",
+    "end": "2026-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T04:00:00.000Z",
+    "end": "2026-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BO-T-2027.json
+++ b/test/fixtures/BO-T-2027.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T04:00:00.000Z",
+    "end": "2027-01-02T04:00:00.000Z",
+    "name": "Año Nuevo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-22 00:00:00",
+    "start": "2027-01-22T04:00:00.000Z",
+    "end": "2027-01-23T04:00:00.000Z",
+    "name": "Día de la Creación del Estado Plurinacional de Bolivia",
+    "type": "public",
+    "rule": "01-22",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-02 00:00:00",
+    "start": "2027-02-02T04:00:00.000Z",
+    "end": "2027-02-03T04:00:00.000Z",
+    "name": "Fiesta de la Virgen de Candelaria",
+    "type": "observance",
+    "rule": "02-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Lunes de Carnaval",
+    "type": "public",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Martes de Carnaval",
+    "type": "public",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-19 00:00:00",
+    "start": "2027-03-19T04:00:00.000Z",
+    "end": "2027-03-20T04:00:00.000Z",
+    "name": "Día del Padre",
+    "type": "observance",
+    "rule": "03-19",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-23 00:00:00",
+    "start": "2027-03-23T04:00:00.000Z",
+    "end": "2027-03-24T04:00:00.000Z",
+    "name": "Día del Mar",
+    "type": "observance",
+    "rule": "03-23",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-03-25 00:00:00",
+    "start": "2027-03-25T04:00:00.000Z",
+    "end": "2027-03-26T04:00:00.000Z",
+    "name": "Jueves Santo",
+    "type": "observance",
+    "rule": "easter -3",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T04:00:00.000Z",
+    "end": "2027-03-27T04:00:00.000Z",
+    "name": "Viernes Santo",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-04-12 00:00:00",
+    "start": "2027-04-12T04:00:00.000Z",
+    "end": "2027-04-13T04:00:00.000Z",
+    "name": "Día del Niño",
+    "type": "observance",
+    "rule": "04-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-04-15 00:00:00",
+    "start": "2027-04-15T04:00:00.000Z",
+    "end": "2027-04-16T04:00:00.000Z",
+    "name": "Efemérides de Tarija",
+    "type": "public",
+    "rule": "04-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T04:00:00.000Z",
+    "end": "2027-05-02T04:00:00.000Z",
+    "name": "Día del trabajador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Corpus Christi",
+    "type": "public",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T04:00:00.000Z",
+    "end": "2027-05-28T04:00:00.000Z",
+    "name": "Día de la Madre",
+    "type": "observance",
+    "rule": "05-27",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-06 00:00:00",
+    "start": "2027-06-06T04:00:00.000Z",
+    "end": "2027-06-07T04:00:00.000Z",
+    "name": "Día del Maestro",
+    "type": "observance",
+    "rule": "06-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T04:00:00.000Z",
+    "end": "2027-06-22T04:00:00.000Z",
+    "name": "Año Nuevo Andino Amazónico Chaqueño",
+    "type": "public",
+    "rule": "06-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T04:00:00.000Z",
+    "end": "2027-08-07T04:00:00.000Z",
+    "name": "Día de la Independencia",
+    "type": "public",
+    "rule": "08-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-08-17 00:00:00",
+    "start": "2027-08-17T04:00:00.000Z",
+    "end": "2027-08-18T04:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "08-17",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-09-21 00:00:00",
+    "start": "2027-09-21T04:00:00.000Z",
+    "end": "2027-09-22T04:00:00.000Z",
+    "name": "Día del Estudiante",
+    "type": "observance",
+    "rule": "09-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-11T04:00:00.000Z",
+    "end": "2027-10-12T04:00:00.000Z",
+    "name": "Día de la Mujer Boliviana",
+    "type": "public",
+    "rule": "10-11",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-11-01T04:00:00.000Z",
+    "end": "2027-11-02T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "observance",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T04:00:00.000Z",
+    "end": "2027-11-03T04:00:00.000Z",
+    "name": "Todos Santos",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T04:00:00.000Z",
+    "end": "2027-12-26T04:00:00.000Z",
+    "name": "Navidad",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  }
+]


### PR DESCRIPTION
- Included substitute holidays
- Added the most commonly observed days
- Removed Easter Sunday, Ascension Day, and Agrarian Reform Day
- Updated with commonly used names
- Added state-specific holidays