### PR TITLE
Improve holiday definitions for The Netherlands

### DIFF
--- a/data/countries/NL.yaml
+++ b/data/countries/NL.yaml
@@ -1,7 +1,9 @@
 holidays:
   # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_the_Netherlands
   # @attrib https://nl.wikipedia.org/wiki/Feestdagen_in_Nederland
+  # @attrib https://nl.wikipedia.org/wiki/Koningsdag_(Nederland)
   # @source https://www.rijksoverheid.nl/onderwerpen/arbeidsovereenkomst-en-cao/vraag-en-antwoord/officiele-feestdagen
+  # @source https://www.government.nl/topics/working-hours/question-and-answer/public-holidays-in-the-netherlands
   # @source https://www.government.nl/topics/school-holidays/question-and-answer/on-which-public-holidays-are-schools-closed-in-the-netherlands
   NL:
     names:
@@ -15,39 +17,65 @@ holidays:
     days:
       01-01:
         _name: 01-01
+      # @source https://www.rijksoverheid.nl/onderwerpen/arbeidsovereenkomst-en-cao/vraag-en-antwoord/goede-vrijdag-vrije-dag
       easter -2:
         _name: easter -2
+        type: school
       easter:
         _name: easter
       easter 1:
         _name: easter 1
-      04-27 if sunday then previous saturday:
+      # @source https://www.rijksoverheid.nl/onderwerpen/arbeidsovereenkomst-en-cao/vraag-en-antwoord/koningsdag-27-april-vrije-dag
+      04-27 if sunday then previous saturday since 2014:
         name:
           nl: Koningsdag
+          en: King's Day
+      04-30 if sunday then next monday since 1949 and prior to 1980:
+        name:
+          nl: Koninginnedag
+          en: Queen's Day
+      04-30 if sunday then previous saturday since 1980 and prior to 2014:
+        name:
+          nl: Koninginnedag
+          en: Queen's Day
       05-04:
         name:
           nl: Nationale Dodenherdenking
         type: observance
-      # @source https://www.rijksoverheid.nl/onderwerpen/tweede-wereldoorlog/vraag-en-antwoord/bevrijdingsdag-5-mei-vrije-dag
+      # @source https://www.rijksoverheid.nl/onderwerpen/arbeidsovereenkomst-en-cao/vraag-en-antwoord/bevrijdingsdag-5-mei-vrije-dag
       05-05:
         name:
           nl: Bevrijdingsdag
-        type: observance
+          en: Liberation Day
+        type: school
       2nd sunday in May:
         _name: Mothers Day
         type: observance
+      # @source https://www.rijksoverheid.nl/onderwerpen/arbeidsovereenkomst-en-cao/vraag-en-antwoord/hemelvaartsdag-vrije-dag
+      easter 39:
+        _name: easter 39
+        name:
+          nl: Hemelvaartsdag
+      easter 49:
+        _name: easter 49
+      # @source https://www.rijksoverheid.nl/onderwerpen/arbeidsovereenkomst-en-cao/vraag-en-antwoord/is-tweede-pinksterdag-een-vrije-dag
+      easter 50:
+        _name: easter 50
       3rd sunday in June:
         _name: Fathers Day
         type: observance
-      easter 39:
-        _name: easter 39
-      easter 49:
-        _name: easter 49
-      easter 50:
-        _name: easter 50
+      08-31 since 1885 and prior to 1891:
+        name:
+          nl: Princessedag
+          en: Princess Day
+      08-31 since 1891 and prior to 1949:
+        name:
+          nl: Koninginnedag
+          en: Queen's Day
       3rd tuesday in September:
         name:
           nl: Prinsjesdag
+          en: Prince's Day
         note: Scholen in Den Haag geven meestal 1 dag vrij
         type: observance
       11-11:

--- a/test/fixtures/NL-2015.json
+++ b/test/fixtures/NL-2015.json
@@ -13,7 +13,7 @@
     "start": "2015-04-02T22:00:00.000Z",
     "end": "2015-04-03T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2015-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Mon"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2015-05-04T22:00:00.000Z",
     "end": "2015-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Tue"
   },
@@ -75,7 +75,7 @@
     "date": "2015-05-14 00:00:00",
     "start": "2015-05-13T22:00:00.000Z",
     "end": "2015-05-14T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2016.json
+++ b/test/fixtures/NL-2016.json
@@ -13,7 +13,7 @@
     "start": "2016-03-24T23:00:00.000Z",
     "end": "2016-03-25T23:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2016-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Wed"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2016-05-04T22:00:00.000Z",
     "end": "2016-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Thu"
   },
@@ -66,7 +66,7 @@
     "date": "2016-05-05 00:00:00",
     "start": "2016-05-04T22:00:00.000Z",
     "end": "2016-05-05T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2017.json
+++ b/test/fixtures/NL-2017.json
@@ -13,7 +13,7 @@
     "start": "2017-04-13T22:00:00.000Z",
     "end": "2017-04-14T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2017-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Thu"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2017-05-04T22:00:00.000Z",
     "end": "2017-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Fri"
   },
@@ -75,7 +75,7 @@
     "date": "2017-05-25 00:00:00",
     "start": "2017-05-24T22:00:00.000Z",
     "end": "2017-05-25T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2018.json
+++ b/test/fixtures/NL-2018.json
@@ -13,7 +13,7 @@
     "start": "2018-03-29T22:00:00.000Z",
     "end": "2018-03-30T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2018-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Fri"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2018-05-04T22:00:00.000Z",
     "end": "2018-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Sat"
   },
@@ -66,7 +66,7 @@
     "date": "2018-05-10 00:00:00",
     "start": "2018-05-09T22:00:00.000Z",
     "end": "2018-05-10T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2019.json
+++ b/test/fixtures/NL-2019.json
@@ -13,7 +13,7 @@
     "start": "2019-04-18T22:00:00.000Z",
     "end": "2019-04-19T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2019-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Sat"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2019-05-04T22:00:00.000Z",
     "end": "2019-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Sun"
   },
@@ -75,7 +75,7 @@
     "date": "2019-05-30 00:00:00",
     "start": "2019-05-29T22:00:00.000Z",
     "end": "2019-05-30T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2020.json
+++ b/test/fixtures/NL-2020.json
@@ -13,7 +13,7 @@
     "start": "2020-04-09T22:00:00.000Z",
     "end": "2020-04-10T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2020-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Mon"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2020-05-04T22:00:00.000Z",
     "end": "2020-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Tue"
   },
@@ -75,7 +75,7 @@
     "date": "2020-05-21 00:00:00",
     "start": "2020-05-20T22:00:00.000Z",
     "end": "2020-05-21T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2021.json
+++ b/test/fixtures/NL-2021.json
@@ -13,7 +13,7 @@
     "start": "2021-04-01T22:00:00.000Z",
     "end": "2021-04-02T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2021-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Tue"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2021-05-04T22:00:00.000Z",
     "end": "2021-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Wed"
   },
@@ -75,7 +75,7 @@
     "date": "2021-05-13 00:00:00",
     "start": "2021-05-12T22:00:00.000Z",
     "end": "2021-05-13T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2022.json
+++ b/test/fixtures/NL-2022.json
@@ -13,7 +13,7 @@
     "start": "2022-04-14T22:00:00.000Z",
     "end": "2022-04-15T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2022-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Wed"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2022-05-04T22:00:00.000Z",
     "end": "2022-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Thu"
   },
@@ -75,7 +75,7 @@
     "date": "2022-05-26 00:00:00",
     "start": "2022-05-25T22:00:00.000Z",
     "end": "2022-05-26T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2023.json
+++ b/test/fixtures/NL-2023.json
@@ -13,7 +13,7 @@
     "start": "2023-04-06T22:00:00.000Z",
     "end": "2023-04-07T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2023-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Thu"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2023-05-04T22:00:00.000Z",
     "end": "2023-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Fri"
   },
@@ -75,7 +75,7 @@
     "date": "2023-05-18 00:00:00",
     "start": "2023-05-17T22:00:00.000Z",
     "end": "2023-05-18T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2024.json
+++ b/test/fixtures/NL-2024.json
@@ -13,7 +13,7 @@
     "start": "2024-03-28T23:00:00.000Z",
     "end": "2024-03-29T23:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2024-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Sat"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2024-05-04T22:00:00.000Z",
     "end": "2024-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Sun"
   },
@@ -66,7 +66,7 @@
     "date": "2024-05-09 00:00:00",
     "start": "2024-05-08T22:00:00.000Z",
     "end": "2024-05-09T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2025.json
+++ b/test/fixtures/NL-2025.json
@@ -13,7 +13,7 @@
     "start": "2025-04-17T22:00:00.000Z",
     "end": "2025-04-18T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2025-04-26T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Sat"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2025-05-04T22:00:00.000Z",
     "end": "2025-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Mon"
   },
@@ -75,7 +75,7 @@
     "date": "2025-05-29 00:00:00",
     "start": "2025-05-28T22:00:00.000Z",
     "end": "2025-05-29T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2026.json
+++ b/test/fixtures/NL-2026.json
@@ -13,7 +13,7 @@
     "start": "2026-04-02T22:00:00.000Z",
     "end": "2026-04-03T22:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2026-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Mon"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2026-05-04T22:00:00.000Z",
     "end": "2026-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Tue"
   },
@@ -75,7 +75,7 @@
     "date": "2026-05-14 00:00:00",
     "start": "2026-05-13T22:00:00.000Z",
     "end": "2026-05-14T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"

--- a/test/fixtures/NL-2027.json
+++ b/test/fixtures/NL-2027.json
@@ -13,7 +13,7 @@
     "start": "2027-03-25T23:00:00.000Z",
     "end": "2027-03-26T23:00:00.000Z",
     "name": "Goede Vrijdag",
-    "type": "public",
+    "type": "school",
     "rule": "easter -2",
     "_weekday": "Fri"
   },
@@ -41,7 +41,7 @@
     "end": "2027-04-27T22:00:00.000Z",
     "name": "Koningsdag",
     "type": "public",
-    "rule": "04-27 if sunday then previous saturday",
+    "rule": "04-27 if sunday then previous saturday since 2014",
     "_weekday": "Tue"
   },
   {
@@ -58,7 +58,7 @@
     "start": "2027-05-04T22:00:00.000Z",
     "end": "2027-05-05T22:00:00.000Z",
     "name": "Bevrijdingsdag",
-    "type": "observance",
+    "type": "school",
     "rule": "05-05",
     "_weekday": "Wed"
   },
@@ -66,7 +66,7 @@
     "date": "2027-05-06 00:00:00",
     "start": "2027-05-05T22:00:00.000Z",
     "end": "2027-05-06T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"


### PR DESCRIPTION
* Changed type of Goede Vrijdag (Good Friday) from public to school
* Changed type of Bevrijdingsdag (Liberation Day) from observance to school
* Set name of Ascension Day to Hemelvaartsdag as an override
  * Belgium has O.L.H. Hemelvaart and O.L.V. Hemelvaart, but in the Netherlands we only have the former and it's called Hemelvaartsdag in official sources.
  * The official Belgian names are unclear as Hemelvaartsdag and Maria-Hemelvaart are also used in official sources (compare https://www.belgium.be/nl/over_belgie/land/belgie_in_een_notendop/feestdagen and https://www.belgium.be/nl/werk/verlof_en_loopbaanonderbrekingen/feestdagen). I decided not to mess with the overall Dutch translation for Ascension Day.
* Add historical definitions for Koninginnedag (Queen's Day) and Princessedag (Princess Day)
  * Queen's Day was celebrated prior to 2014 so it might have real world relevance. I added the older variants for completeness.
* Add English translations for Bevrijdingsdag (Liberation Day) and Prinsjesdag (Prince's Day)

Technically several of these holidays can be seen as "optional" as there's no legal requirement, but most people are free and they're school holidays as well, so I left them as public. Let me know if it would be better to change them.

Fixes #434.