### PR TITLE
fix: Correct holiday type for Bolivia

### DIFF
--- a/data/countries/BO.yaml
+++ b/data/countries/BO.yaml
@@ -111,7 +111,7 @@ holidays:
         name:
           es: Día de la Mujer Boliviana
           en: Bolivian Woman's Day
-          type: observance
+        type: observance
       11-01:
         _name: 11-01
         name:

--- a/test/fixtures/BO-2015.json
+++ b/test/fixtures/BO-2015.json
@@ -175,7 +175,7 @@
     "start": "2015-10-11T04:00:00.000Z",
     "end": "2015-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-2016.json
+++ b/test/fixtures/BO-2016.json
@@ -175,7 +175,7 @@
     "start": "2016-10-11T04:00:00.000Z",
     "end": "2016-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-2017.json
+++ b/test/fixtures/BO-2017.json
@@ -193,7 +193,7 @@
     "start": "2017-10-11T04:00:00.000Z",
     "end": "2017-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-2018.json
+++ b/test/fixtures/BO-2018.json
@@ -166,7 +166,7 @@
     "start": "2018-10-11T04:00:00.000Z",
     "end": "2018-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BO-2019.json
+++ b/test/fixtures/BO-2019.json
@@ -166,7 +166,7 @@
     "start": "2019-10-11T04:00:00.000Z",
     "end": "2019-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-2020.json
+++ b/test/fixtures/BO-2020.json
@@ -175,7 +175,7 @@
     "start": "2020-10-11T04:00:00.000Z",
     "end": "2020-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-2021.json
+++ b/test/fixtures/BO-2021.json
@@ -166,7 +166,7 @@
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-2022.json
+++ b/test/fixtures/BO-2022.json
@@ -175,7 +175,7 @@
     "start": "2022-10-11T04:00:00.000Z",
     "end": "2022-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-2023.json
+++ b/test/fixtures/BO-2023.json
@@ -193,7 +193,7 @@
     "start": "2023-10-11T04:00:00.000Z",
     "end": "2023-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-2024.json
+++ b/test/fixtures/BO-2024.json
@@ -166,7 +166,7 @@
     "start": "2024-10-11T04:00:00.000Z",
     "end": "2024-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-2025.json
+++ b/test/fixtures/BO-2025.json
@@ -166,7 +166,7 @@
     "start": "2025-10-11T04:00:00.000Z",
     "end": "2025-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/BO-2026.json
+++ b/test/fixtures/BO-2026.json
@@ -175,7 +175,7 @@
     "start": "2026-10-11T04:00:00.000Z",
     "end": "2026-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-2027.json
+++ b/test/fixtures/BO-2027.json
@@ -166,7 +166,7 @@
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-B-2015.json
+++ b/test/fixtures/BO-B-2015.json
@@ -175,7 +175,7 @@
     "start": "2015-10-11T04:00:00.000Z",
     "end": "2015-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-B-2016.json
+++ b/test/fixtures/BO-B-2016.json
@@ -175,7 +175,7 @@
     "start": "2016-10-11T04:00:00.000Z",
     "end": "2016-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-B-2017.json
+++ b/test/fixtures/BO-B-2017.json
@@ -193,7 +193,7 @@
     "start": "2017-10-11T04:00:00.000Z",
     "end": "2017-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-B-2018.json
+++ b/test/fixtures/BO-B-2018.json
@@ -166,7 +166,7 @@
     "start": "2018-10-11T04:00:00.000Z",
     "end": "2018-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BO-B-2019.json
+++ b/test/fixtures/BO-B-2019.json
@@ -166,7 +166,7 @@
     "start": "2019-10-11T04:00:00.000Z",
     "end": "2019-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-B-2020.json
+++ b/test/fixtures/BO-B-2020.json
@@ -175,7 +175,7 @@
     "start": "2020-10-11T04:00:00.000Z",
     "end": "2020-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-B-2021.json
+++ b/test/fixtures/BO-B-2021.json
@@ -166,7 +166,7 @@
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-B-2022.json
+++ b/test/fixtures/BO-B-2022.json
@@ -175,7 +175,7 @@
     "start": "2022-10-11T04:00:00.000Z",
     "end": "2022-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-B-2023.json
+++ b/test/fixtures/BO-B-2023.json
@@ -193,7 +193,7 @@
     "start": "2023-10-11T04:00:00.000Z",
     "end": "2023-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-B-2024.json
+++ b/test/fixtures/BO-B-2024.json
@@ -166,7 +166,7 @@
     "start": "2024-10-11T04:00:00.000Z",
     "end": "2024-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-B-2025.json
+++ b/test/fixtures/BO-B-2025.json
@@ -166,7 +166,7 @@
     "start": "2025-10-11T04:00:00.000Z",
     "end": "2025-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/BO-B-2026.json
+++ b/test/fixtures/BO-B-2026.json
@@ -175,7 +175,7 @@
     "start": "2026-10-11T04:00:00.000Z",
     "end": "2026-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-B-2027.json
+++ b/test/fixtures/BO-B-2027.json
@@ -166,7 +166,7 @@
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-C-2015.json
+++ b/test/fixtures/BO-C-2015.json
@@ -184,7 +184,7 @@
     "start": "2015-10-11T04:00:00.000Z",
     "end": "2015-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-C-2016.json
+++ b/test/fixtures/BO-C-2016.json
@@ -184,7 +184,7 @@
     "start": "2016-10-11T04:00:00.000Z",
     "end": "2016-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-C-2017.json
+++ b/test/fixtures/BO-C-2017.json
@@ -202,7 +202,7 @@
     "start": "2017-10-11T04:00:00.000Z",
     "end": "2017-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-C-2018.json
+++ b/test/fixtures/BO-C-2018.json
@@ -175,7 +175,7 @@
     "start": "2018-10-11T04:00:00.000Z",
     "end": "2018-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BO-C-2019.json
+++ b/test/fixtures/BO-C-2019.json
@@ -175,7 +175,7 @@
     "start": "2019-10-11T04:00:00.000Z",
     "end": "2019-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-C-2020.json
+++ b/test/fixtures/BO-C-2020.json
@@ -184,7 +184,7 @@
     "start": "2020-10-11T04:00:00.000Z",
     "end": "2020-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-C-2021.json
+++ b/test/fixtures/BO-C-2021.json
@@ -175,7 +175,7 @@
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-C-2022.json
+++ b/test/fixtures/BO-C-2022.json
@@ -184,7 +184,7 @@
     "start": "2022-10-11T04:00:00.000Z",
     "end": "2022-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-C-2023.json
+++ b/test/fixtures/BO-C-2023.json
@@ -202,7 +202,7 @@
     "start": "2023-10-11T04:00:00.000Z",
     "end": "2023-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-C-2024.json
+++ b/test/fixtures/BO-C-2024.json
@@ -175,7 +175,7 @@
     "start": "2024-10-11T04:00:00.000Z",
     "end": "2024-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-C-2025.json
+++ b/test/fixtures/BO-C-2025.json
@@ -184,7 +184,7 @@
     "start": "2025-10-11T04:00:00.000Z",
     "end": "2025-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/BO-C-2026.json
+++ b/test/fixtures/BO-C-2026.json
@@ -184,7 +184,7 @@
     "start": "2026-10-11T04:00:00.000Z",
     "end": "2026-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-C-2027.json
+++ b/test/fixtures/BO-C-2027.json
@@ -175,7 +175,7 @@
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-H-2015.json
+++ b/test/fixtures/BO-H-2015.json
@@ -184,7 +184,7 @@
     "start": "2015-10-11T04:00:00.000Z",
     "end": "2015-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-H-2016.json
+++ b/test/fixtures/BO-H-2016.json
@@ -184,7 +184,7 @@
     "start": "2016-10-11T04:00:00.000Z",
     "end": "2016-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-H-2017.json
+++ b/test/fixtures/BO-H-2017.json
@@ -202,7 +202,7 @@
     "start": "2017-10-11T04:00:00.000Z",
     "end": "2017-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-H-2018.json
+++ b/test/fixtures/BO-H-2018.json
@@ -175,7 +175,7 @@
     "start": "2018-10-11T04:00:00.000Z",
     "end": "2018-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BO-H-2019.json
+++ b/test/fixtures/BO-H-2019.json
@@ -175,7 +175,7 @@
     "start": "2019-10-11T04:00:00.000Z",
     "end": "2019-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-H-2020.json
+++ b/test/fixtures/BO-H-2020.json
@@ -184,7 +184,7 @@
     "start": "2020-10-11T04:00:00.000Z",
     "end": "2020-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-H-2021.json
+++ b/test/fixtures/BO-H-2021.json
@@ -175,7 +175,7 @@
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-H-2022.json
+++ b/test/fixtures/BO-H-2022.json
@@ -184,7 +184,7 @@
     "start": "2022-10-11T04:00:00.000Z",
     "end": "2022-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-H-2023.json
+++ b/test/fixtures/BO-H-2023.json
@@ -202,7 +202,7 @@
     "start": "2023-10-11T04:00:00.000Z",
     "end": "2023-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-H-2024.json
+++ b/test/fixtures/BO-H-2024.json
@@ -175,7 +175,7 @@
     "start": "2024-10-11T04:00:00.000Z",
     "end": "2024-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-H-2025.json
+++ b/test/fixtures/BO-H-2025.json
@@ -184,7 +184,7 @@
     "start": "2025-10-11T04:00:00.000Z",
     "end": "2025-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/BO-H-2026.json
+++ b/test/fixtures/BO-H-2026.json
@@ -184,7 +184,7 @@
     "start": "2026-10-11T04:00:00.000Z",
     "end": "2026-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-H-2027.json
+++ b/test/fixtures/BO-H-2027.json
@@ -175,7 +175,7 @@
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-L-2015.json
+++ b/test/fixtures/BO-L-2015.json
@@ -184,7 +184,7 @@
     "start": "2015-10-11T04:00:00.000Z",
     "end": "2015-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-L-2016.json
+++ b/test/fixtures/BO-L-2016.json
@@ -184,7 +184,7 @@
     "start": "2016-10-11T04:00:00.000Z",
     "end": "2016-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-L-2017.json
+++ b/test/fixtures/BO-L-2017.json
@@ -211,7 +211,7 @@
     "start": "2017-10-11T04:00:00.000Z",
     "end": "2017-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-L-2018.json
+++ b/test/fixtures/BO-L-2018.json
@@ -175,7 +175,7 @@
     "start": "2018-10-11T04:00:00.000Z",
     "end": "2018-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BO-L-2019.json
+++ b/test/fixtures/BO-L-2019.json
@@ -175,7 +175,7 @@
     "start": "2019-10-11T04:00:00.000Z",
     "end": "2019-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-L-2020.json
+++ b/test/fixtures/BO-L-2020.json
@@ -184,7 +184,7 @@
     "start": "2020-10-11T04:00:00.000Z",
     "end": "2020-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-L-2021.json
+++ b/test/fixtures/BO-L-2021.json
@@ -175,7 +175,7 @@
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-L-2022.json
+++ b/test/fixtures/BO-L-2022.json
@@ -184,7 +184,7 @@
     "start": "2022-10-11T04:00:00.000Z",
     "end": "2022-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-L-2023.json
+++ b/test/fixtures/BO-L-2023.json
@@ -211,7 +211,7 @@
     "start": "2023-10-11T04:00:00.000Z",
     "end": "2023-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-L-2024.json
+++ b/test/fixtures/BO-L-2024.json
@@ -175,7 +175,7 @@
     "start": "2024-10-11T04:00:00.000Z",
     "end": "2024-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-L-2025.json
+++ b/test/fixtures/BO-L-2025.json
@@ -175,7 +175,7 @@
     "start": "2025-10-11T04:00:00.000Z",
     "end": "2025-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/BO-L-2026.json
+++ b/test/fixtures/BO-L-2026.json
@@ -184,7 +184,7 @@
     "start": "2026-10-11T04:00:00.000Z",
     "end": "2026-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-L-2027.json
+++ b/test/fixtures/BO-L-2027.json
@@ -175,7 +175,7 @@
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-N-2015.json
+++ b/test/fixtures/BO-N-2015.json
@@ -184,7 +184,7 @@
     "start": "2015-10-11T04:00:00.000Z",
     "end": "2015-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-N-2016.json
+++ b/test/fixtures/BO-N-2016.json
@@ -184,7 +184,7 @@
     "start": "2016-10-11T04:00:00.000Z",
     "end": "2016-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-N-2017.json
+++ b/test/fixtures/BO-N-2017.json
@@ -211,7 +211,7 @@
     "start": "2017-10-11T04:00:00.000Z",
     "end": "2017-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-N-2018.json
+++ b/test/fixtures/BO-N-2018.json
@@ -175,7 +175,7 @@
     "start": "2018-10-11T04:00:00.000Z",
     "end": "2018-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BO-N-2019.json
+++ b/test/fixtures/BO-N-2019.json
@@ -175,7 +175,7 @@
     "start": "2019-10-11T04:00:00.000Z",
     "end": "2019-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-N-2020.json
+++ b/test/fixtures/BO-N-2020.json
@@ -184,7 +184,7 @@
     "start": "2020-10-11T04:00:00.000Z",
     "end": "2020-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-N-2021.json
+++ b/test/fixtures/BO-N-2021.json
@@ -175,7 +175,7 @@
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-N-2022.json
+++ b/test/fixtures/BO-N-2022.json
@@ -184,7 +184,7 @@
     "start": "2022-10-11T04:00:00.000Z",
     "end": "2022-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-N-2023.json
+++ b/test/fixtures/BO-N-2023.json
@@ -211,7 +211,7 @@
     "start": "2023-10-11T04:00:00.000Z",
     "end": "2023-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-N-2024.json
+++ b/test/fixtures/BO-N-2024.json
@@ -175,7 +175,7 @@
     "start": "2024-10-11T04:00:00.000Z",
     "end": "2024-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-N-2025.json
+++ b/test/fixtures/BO-N-2025.json
@@ -175,7 +175,7 @@
     "start": "2025-10-11T04:00:00.000Z",
     "end": "2025-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/BO-N-2026.json
+++ b/test/fixtures/BO-N-2026.json
@@ -184,7 +184,7 @@
     "start": "2026-10-11T04:00:00.000Z",
     "end": "2026-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-N-2027.json
+++ b/test/fixtures/BO-N-2027.json
@@ -175,7 +175,7 @@
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-O-2015.json
+++ b/test/fixtures/BO-O-2015.json
@@ -184,7 +184,7 @@
     "start": "2015-10-11T04:00:00.000Z",
     "end": "2015-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-O-2016.json
+++ b/test/fixtures/BO-O-2016.json
@@ -184,7 +184,7 @@
     "start": "2016-10-11T04:00:00.000Z",
     "end": "2016-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-O-2017.json
+++ b/test/fixtures/BO-O-2017.json
@@ -202,7 +202,7 @@
     "start": "2017-10-11T04:00:00.000Z",
     "end": "2017-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-O-2018.json
+++ b/test/fixtures/BO-O-2018.json
@@ -175,7 +175,7 @@
     "start": "2018-10-11T04:00:00.000Z",
     "end": "2018-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BO-O-2019.json
+++ b/test/fixtures/BO-O-2019.json
@@ -184,7 +184,7 @@
     "start": "2019-10-11T04:00:00.000Z",
     "end": "2019-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-O-2020.json
+++ b/test/fixtures/BO-O-2020.json
@@ -184,7 +184,7 @@
     "start": "2020-10-11T04:00:00.000Z",
     "end": "2020-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-O-2021.json
+++ b/test/fixtures/BO-O-2021.json
@@ -175,7 +175,7 @@
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-O-2022.json
+++ b/test/fixtures/BO-O-2022.json
@@ -184,7 +184,7 @@
     "start": "2022-10-11T04:00:00.000Z",
     "end": "2022-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-O-2023.json
+++ b/test/fixtures/BO-O-2023.json
@@ -202,7 +202,7 @@
     "start": "2023-10-11T04:00:00.000Z",
     "end": "2023-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-O-2024.json
+++ b/test/fixtures/BO-O-2024.json
@@ -175,7 +175,7 @@
     "start": "2024-10-11T04:00:00.000Z",
     "end": "2024-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-O-2025.json
+++ b/test/fixtures/BO-O-2025.json
@@ -175,7 +175,7 @@
     "start": "2025-10-11T04:00:00.000Z",
     "end": "2025-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/BO-O-2026.json
+++ b/test/fixtures/BO-O-2026.json
@@ -184,7 +184,7 @@
     "start": "2026-10-11T04:00:00.000Z",
     "end": "2026-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-O-2027.json
+++ b/test/fixtures/BO-O-2027.json
@@ -175,7 +175,7 @@
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-P-2015.json
+++ b/test/fixtures/BO-P-2015.json
@@ -175,7 +175,7 @@
     "start": "2015-10-11T04:00:00.000Z",
     "end": "2015-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-P-2016.json
+++ b/test/fixtures/BO-P-2016.json
@@ -175,7 +175,7 @@
     "start": "2016-10-11T04:00:00.000Z",
     "end": "2016-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-P-2017.json
+++ b/test/fixtures/BO-P-2017.json
@@ -193,7 +193,7 @@
     "start": "2017-10-11T04:00:00.000Z",
     "end": "2017-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-P-2018.json
+++ b/test/fixtures/BO-P-2018.json
@@ -166,7 +166,7 @@
     "start": "2018-10-11T04:00:00.000Z",
     "end": "2018-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BO-P-2019.json
+++ b/test/fixtures/BO-P-2019.json
@@ -166,7 +166,7 @@
     "start": "2019-10-11T04:00:00.000Z",
     "end": "2019-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-P-2020.json
+++ b/test/fixtures/BO-P-2020.json
@@ -175,7 +175,7 @@
     "start": "2020-10-11T04:00:00.000Z",
     "end": "2020-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-P-2021.json
+++ b/test/fixtures/BO-P-2021.json
@@ -166,7 +166,7 @@
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-P-2022.json
+++ b/test/fixtures/BO-P-2022.json
@@ -175,7 +175,7 @@
     "start": "2022-10-11T04:00:00.000Z",
     "end": "2022-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-P-2023.json
+++ b/test/fixtures/BO-P-2023.json
@@ -193,7 +193,7 @@
     "start": "2023-10-11T04:00:00.000Z",
     "end": "2023-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-P-2024.json
+++ b/test/fixtures/BO-P-2024.json
@@ -166,7 +166,7 @@
     "start": "2024-10-11T04:00:00.000Z",
     "end": "2024-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-P-2025.json
+++ b/test/fixtures/BO-P-2025.json
@@ -166,7 +166,7 @@
     "start": "2025-10-11T04:00:00.000Z",
     "end": "2025-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/BO-P-2026.json
+++ b/test/fixtures/BO-P-2026.json
@@ -175,7 +175,7 @@
     "start": "2026-10-11T04:00:00.000Z",
     "end": "2026-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-P-2027.json
+++ b/test/fixtures/BO-P-2027.json
@@ -166,7 +166,7 @@
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-S-2015.json
+++ b/test/fixtures/BO-S-2015.json
@@ -184,7 +184,7 @@
     "start": "2015-10-11T04:00:00.000Z",
     "end": "2015-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-S-2016.json
+++ b/test/fixtures/BO-S-2016.json
@@ -184,7 +184,7 @@
     "start": "2016-10-11T04:00:00.000Z",
     "end": "2016-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-S-2017.json
+++ b/test/fixtures/BO-S-2017.json
@@ -211,7 +211,7 @@
     "start": "2017-10-11T04:00:00.000Z",
     "end": "2017-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-S-2018.json
+++ b/test/fixtures/BO-S-2018.json
@@ -175,7 +175,7 @@
     "start": "2018-10-11T04:00:00.000Z",
     "end": "2018-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BO-S-2019.json
+++ b/test/fixtures/BO-S-2019.json
@@ -175,7 +175,7 @@
     "start": "2019-10-11T04:00:00.000Z",
     "end": "2019-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-S-2020.json
+++ b/test/fixtures/BO-S-2020.json
@@ -184,7 +184,7 @@
     "start": "2020-10-11T04:00:00.000Z",
     "end": "2020-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-S-2021.json
+++ b/test/fixtures/BO-S-2021.json
@@ -175,7 +175,7 @@
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-S-2022.json
+++ b/test/fixtures/BO-S-2022.json
@@ -184,7 +184,7 @@
     "start": "2022-10-11T04:00:00.000Z",
     "end": "2022-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-S-2023.json
+++ b/test/fixtures/BO-S-2023.json
@@ -211,7 +211,7 @@
     "start": "2023-10-11T04:00:00.000Z",
     "end": "2023-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-S-2024.json
+++ b/test/fixtures/BO-S-2024.json
@@ -175,7 +175,7 @@
     "start": "2024-10-11T04:00:00.000Z",
     "end": "2024-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-S-2025.json
+++ b/test/fixtures/BO-S-2025.json
@@ -175,7 +175,7 @@
     "start": "2025-10-11T04:00:00.000Z",
     "end": "2025-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/BO-S-2026.json
+++ b/test/fixtures/BO-S-2026.json
@@ -184,7 +184,7 @@
     "start": "2026-10-11T04:00:00.000Z",
     "end": "2026-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-S-2027.json
+++ b/test/fixtures/BO-S-2027.json
@@ -175,7 +175,7 @@
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-T-2015.json
+++ b/test/fixtures/BO-T-2015.json
@@ -184,7 +184,7 @@
     "start": "2015-10-11T04:00:00.000Z",
     "end": "2015-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-T-2016.json
+++ b/test/fixtures/BO-T-2016.json
@@ -184,7 +184,7 @@
     "start": "2016-10-11T04:00:00.000Z",
     "end": "2016-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-T-2017.json
+++ b/test/fixtures/BO-T-2017.json
@@ -202,7 +202,7 @@
     "start": "2017-10-11T04:00:00.000Z",
     "end": "2017-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-T-2018.json
+++ b/test/fixtures/BO-T-2018.json
@@ -184,7 +184,7 @@
     "start": "2018-10-11T04:00:00.000Z",
     "end": "2018-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BO-T-2019.json
+++ b/test/fixtures/BO-T-2019.json
@@ -175,7 +175,7 @@
     "start": "2019-10-11T04:00:00.000Z",
     "end": "2019-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-T-2020.json
+++ b/test/fixtures/BO-T-2020.json
@@ -184,7 +184,7 @@
     "start": "2020-10-11T04:00:00.000Z",
     "end": "2020-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-T-2021.json
+++ b/test/fixtures/BO-T-2021.json
@@ -175,7 +175,7 @@
     "start": "2021-10-11T04:00:00.000Z",
     "end": "2021-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/BO-T-2022.json
+++ b/test/fixtures/BO-T-2022.json
@@ -184,7 +184,7 @@
     "start": "2022-10-11T04:00:00.000Z",
     "end": "2022-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/BO-T-2023.json
+++ b/test/fixtures/BO-T-2023.json
@@ -202,7 +202,7 @@
     "start": "2023-10-11T04:00:00.000Z",
     "end": "2023-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/BO-T-2024.json
+++ b/test/fixtures/BO-T-2024.json
@@ -175,7 +175,7 @@
     "start": "2024-10-11T04:00:00.000Z",
     "end": "2024-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/BO-T-2025.json
+++ b/test/fixtures/BO-T-2025.json
@@ -175,7 +175,7 @@
     "start": "2025-10-11T04:00:00.000Z",
     "end": "2025-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/BO-T-2026.json
+++ b/test/fixtures/BO-T-2026.json
@@ -184,7 +184,7 @@
     "start": "2026-10-11T04:00:00.000Z",
     "end": "2026-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/BO-T-2027.json
+++ b/test/fixtures/BO-T-2027.json
@@ -175,7 +175,7 @@
     "start": "2027-10-11T04:00:00.000Z",
     "end": "2027-10-12T04:00:00.000Z",
     "name": "Día de la Mujer Boliviana",
-    "type": "public",
+    "type": "observance",
     "rule": "10-11",
     "_weekday": "Mon"
   },


### PR DESCRIPTION
The type of holiday for a specific date in Bolivia was corrected. The problem was fixed by removing unnecessary spaces.