### PR TITLE
Remove gb wls empty regions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,12 @@ If you like to add or change data please take a look at [holidays.yaml specifica
 
 1. Fork the project
 2. Create a branch for your changes
-3. Build the project:
+3. Create Json file and build the project:
    ```
-   npm run build
+   npm run yaml && npm run build
    ```
 4. Modify the yaml file for the country your changes apply in `./data/countries/<code>.yaml` for holiday data and/or `./data/names.yaml` for translations as appropriate
-5. Generate the Json file from the yaml files with
+5. Generate the new Json file from the yaml files with
    ```
    npm run yaml
    ```

--- a/data/countries/GB.yaml
+++ b/data/countries/GB.yaml
@@ -548,7 +548,7 @@ holidays:
           1st monday before 09-01:
             name:
               en: Summer bank holiday
-        regions: {}
+        # regions:
         # AGY:
         #   name: Anglesey
         # BGE:


### PR DESCRIPTION
Fix for empty object in GB - WLS regions.
Fix failing build when Json file is missing