### PR TITLE
Add Special Public Holiday for South Africa on 15 Dec 2023 in Celebration of Rugby World Cup Victory

### DIFF
--- a/data/countries/ZA.yaml
+++ b/data/countries/ZA.yaml
@@ -90,3 +90,7 @@ holidays:
       substitutes 12-26 if sunday then next monday:
         name:
           en: Public Holiday
+      2023-12-15:
+        _name: 12-15
+        name:
+          en: Rugby World Cup Win Public Holiday

--- a/data/countries/ZA.yaml
+++ b/data/countries/ZA.yaml
@@ -90,7 +90,7 @@ holidays:
       substitutes 12-26 if sunday then next monday:
         name:
           en: Public Holiday
-      2023-12-15:
+      "2023-12-15":
         _name: 12-15
         name:
           en: Rugby World Cup Win Public Holiday


### PR DESCRIPTION
This pull request adds an entry to the `ZA.yaml` file, introducing a new public holiday on December 15, 2023. This date has been declared as a public holiday by President Cyril Ramaphosa to celebrate the Springboks' victory in the 2023 Rugby World Cup.

### Changes Made:
- Inserted a new date for the once-off public holiday on 15 December 2023 as "Rugby World Cup Win Public Holiday."

This update reflects the official declaration made by the South African government, as published in the Government Gazette, and further communicated through a news bulletin by SAnews, the official South African Government News Agency. The announcement is a mark of national celebration, honoring the Springboks' triumph at the Rugby World Cup and the unifying effect it has had on the nation.

For further reference, you can find the official government notice here: [South African Government Gazette](https://www.gov.za/documents/notices/public-holidays-act-declaration-15th-day-december-2023-public-holiday-28-nov-2023), and a detailed news article discussing the event and its significance here: [SAnews](https://www.sanews.gov.za/south-africa/president-ramaphosa-declares-15-december-public-holiday).

Please review the changes for inclusion in the `date-holidays` repository.

Thank you for the consideration of this pull request.
