### PR TITLE
fix(#452): replace lodash.pick with lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,8 +219,7 @@
   "dependencies": {
     "date-holidays-parser": "^3.4.4",
     "js-yaml": "^4.1.0",
-    "lodash.omit": "^4.5.0",
-    "lodash.pick": "^4.4.0",
+    "lodash": "^4.17.21",
     "prepin": "^1.0.3"
   },
   "devDependencies": {

--- a/scripts/holidays2json.cjs
+++ b/scripts/holidays2json.cjs
@@ -7,8 +7,7 @@ const path = require('path')
 const resolve = path.resolve
 const jsyaml = require('js-yaml')
 const PrePin = require('prepin')
-const _pick = require('lodash.pick')
-const _omit = require('lodash.omit')
+const { pick: _pick, omit: _omit } = require('lodash')
 
 const REGEX = /^([A-Z]+)\.yaml$/
 


### PR DESCRIPTION
Use of lodash instead of lodash.pick, lodash.omit since the modularised versions haven't been updated in many years.