### PR TITLE
fix(AT,#455): josefitag set to type school

### DIFF
--- a/data/countries/AT.yaml
+++ b/data/countries/AT.yaml
@@ -73,6 +73,7 @@ holidays:
         days:
           03-19:
             _name: 03-19
+            type: school
           10-10:
             name:
               de-at: Tag der Volksabstimmung
@@ -110,6 +111,7 @@ holidays:
         days:
           03-19:
             _name: 03-19
+            type: school
       "7":
         names:
           de: Tirol
@@ -117,11 +119,13 @@ holidays:
         days:
           03-19:
             _name: 03-19
+            type: school
       "8":
         name: Vorarlberg
         days:
           03-19:
             _name: 03-19
+            type: school
       "9":
         names:
           de: Wien

--- a/test/fixtures/AT-2-2015.json
+++ b/test/fixtures/AT-2-2015.json
@@ -22,7 +22,7 @@
     "start": "2015-03-18T23:00:00.000Z",
     "end": "2015-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-2-2016.json
+++ b/test/fixtures/AT-2-2016.json
@@ -22,7 +22,7 @@
     "start": "2016-03-18T23:00:00.000Z",
     "end": "2016-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-2-2017.json
+++ b/test/fixtures/AT-2-2017.json
@@ -22,7 +22,7 @@
     "start": "2017-03-18T23:00:00.000Z",
     "end": "2017-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-2-2018.json
+++ b/test/fixtures/AT-2-2018.json
@@ -22,7 +22,7 @@
     "start": "2018-03-18T23:00:00.000Z",
     "end": "2018-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-2-2019.json
+++ b/test/fixtures/AT-2-2019.json
@@ -22,7 +22,7 @@
     "start": "2019-03-18T23:00:00.000Z",
     "end": "2019-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-2-2020.json
+++ b/test/fixtures/AT-2-2020.json
@@ -22,7 +22,7 @@
     "start": "2020-03-18T23:00:00.000Z",
     "end": "2020-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-2-2021.json
+++ b/test/fixtures/AT-2-2021.json
@@ -22,7 +22,7 @@
     "start": "2021-03-18T23:00:00.000Z",
     "end": "2021-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-2-2022.json
+++ b/test/fixtures/AT-2-2022.json
@@ -22,7 +22,7 @@
     "start": "2022-03-18T23:00:00.000Z",
     "end": "2022-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-2-2023.json
+++ b/test/fixtures/AT-2-2023.json
@@ -22,7 +22,7 @@
     "start": "2023-03-18T23:00:00.000Z",
     "end": "2023-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-2-2024.json
+++ b/test/fixtures/AT-2-2024.json
@@ -22,7 +22,7 @@
     "start": "2024-03-18T23:00:00.000Z",
     "end": "2024-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-2-2025.json
+++ b/test/fixtures/AT-2-2025.json
@@ -22,7 +22,7 @@
     "start": "2025-03-18T23:00:00.000Z",
     "end": "2025-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-2-2026.json
+++ b/test/fixtures/AT-2-2026.json
@@ -22,7 +22,7 @@
     "start": "2026-03-18T23:00:00.000Z",
     "end": "2026-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-2-2027.json
+++ b/test/fixtures/AT-2-2027.json
@@ -22,7 +22,7 @@
     "start": "2027-03-18T23:00:00.000Z",
     "end": "2027-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-6-2015.json
+++ b/test/fixtures/AT-6-2015.json
@@ -22,7 +22,7 @@
     "start": "2015-03-18T23:00:00.000Z",
     "end": "2015-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-6-2016.json
+++ b/test/fixtures/AT-6-2016.json
@@ -22,7 +22,7 @@
     "start": "2016-03-18T23:00:00.000Z",
     "end": "2016-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-6-2017.json
+++ b/test/fixtures/AT-6-2017.json
@@ -22,7 +22,7 @@
     "start": "2017-03-18T23:00:00.000Z",
     "end": "2017-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-6-2018.json
+++ b/test/fixtures/AT-6-2018.json
@@ -22,7 +22,7 @@
     "start": "2018-03-18T23:00:00.000Z",
     "end": "2018-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-6-2019.json
+++ b/test/fixtures/AT-6-2019.json
@@ -22,7 +22,7 @@
     "start": "2019-03-18T23:00:00.000Z",
     "end": "2019-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-6-2020.json
+++ b/test/fixtures/AT-6-2020.json
@@ -22,7 +22,7 @@
     "start": "2020-03-18T23:00:00.000Z",
     "end": "2020-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-6-2021.json
+++ b/test/fixtures/AT-6-2021.json
@@ -22,7 +22,7 @@
     "start": "2021-03-18T23:00:00.000Z",
     "end": "2021-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-6-2022.json
+++ b/test/fixtures/AT-6-2022.json
@@ -22,7 +22,7 @@
     "start": "2022-03-18T23:00:00.000Z",
     "end": "2022-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-6-2023.json
+++ b/test/fixtures/AT-6-2023.json
@@ -22,7 +22,7 @@
     "start": "2023-03-18T23:00:00.000Z",
     "end": "2023-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-6-2024.json
+++ b/test/fixtures/AT-6-2024.json
@@ -22,7 +22,7 @@
     "start": "2024-03-18T23:00:00.000Z",
     "end": "2024-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-6-2025.json
+++ b/test/fixtures/AT-6-2025.json
@@ -22,7 +22,7 @@
     "start": "2025-03-18T23:00:00.000Z",
     "end": "2025-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-6-2026.json
+++ b/test/fixtures/AT-6-2026.json
@@ -22,7 +22,7 @@
     "start": "2026-03-18T23:00:00.000Z",
     "end": "2026-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-6-2027.json
+++ b/test/fixtures/AT-6-2027.json
@@ -22,7 +22,7 @@
     "start": "2027-03-18T23:00:00.000Z",
     "end": "2027-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-7-2015.json
+++ b/test/fixtures/AT-7-2015.json
@@ -22,7 +22,7 @@
     "start": "2015-03-18T23:00:00.000Z",
     "end": "2015-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-7-2016.json
+++ b/test/fixtures/AT-7-2016.json
@@ -22,7 +22,7 @@
     "start": "2016-03-18T23:00:00.000Z",
     "end": "2016-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-7-2017.json
+++ b/test/fixtures/AT-7-2017.json
@@ -22,7 +22,7 @@
     "start": "2017-03-18T23:00:00.000Z",
     "end": "2017-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-7-2018.json
+++ b/test/fixtures/AT-7-2018.json
@@ -22,7 +22,7 @@
     "start": "2018-03-18T23:00:00.000Z",
     "end": "2018-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-7-2019.json
+++ b/test/fixtures/AT-7-2019.json
@@ -22,7 +22,7 @@
     "start": "2019-03-18T23:00:00.000Z",
     "end": "2019-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-7-2020.json
+++ b/test/fixtures/AT-7-2020.json
@@ -22,7 +22,7 @@
     "start": "2020-03-18T23:00:00.000Z",
     "end": "2020-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-7-2021.json
+++ b/test/fixtures/AT-7-2021.json
@@ -22,7 +22,7 @@
     "start": "2021-03-18T23:00:00.000Z",
     "end": "2021-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-7-2022.json
+++ b/test/fixtures/AT-7-2022.json
@@ -22,7 +22,7 @@
     "start": "2022-03-18T23:00:00.000Z",
     "end": "2022-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-7-2023.json
+++ b/test/fixtures/AT-7-2023.json
@@ -22,7 +22,7 @@
     "start": "2023-03-18T23:00:00.000Z",
     "end": "2023-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-7-2024.json
+++ b/test/fixtures/AT-7-2024.json
@@ -22,7 +22,7 @@
     "start": "2024-03-18T23:00:00.000Z",
     "end": "2024-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-7-2025.json
+++ b/test/fixtures/AT-7-2025.json
@@ -22,7 +22,7 @@
     "start": "2025-03-18T23:00:00.000Z",
     "end": "2025-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-7-2026.json
+++ b/test/fixtures/AT-7-2026.json
@@ -22,7 +22,7 @@
     "start": "2026-03-18T23:00:00.000Z",
     "end": "2026-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-7-2027.json
+++ b/test/fixtures/AT-7-2027.json
@@ -22,7 +22,7 @@
     "start": "2027-03-18T23:00:00.000Z",
     "end": "2027-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-8-2015.json
+++ b/test/fixtures/AT-8-2015.json
@@ -22,7 +22,7 @@
     "start": "2015-03-18T23:00:00.000Z",
     "end": "2015-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-8-2016.json
+++ b/test/fixtures/AT-8-2016.json
@@ -22,7 +22,7 @@
     "start": "2016-03-18T23:00:00.000Z",
     "end": "2016-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-8-2017.json
+++ b/test/fixtures/AT-8-2017.json
@@ -22,7 +22,7 @@
     "start": "2017-03-18T23:00:00.000Z",
     "end": "2017-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-8-2018.json
+++ b/test/fixtures/AT-8-2018.json
@@ -22,7 +22,7 @@
     "start": "2018-03-18T23:00:00.000Z",
     "end": "2018-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-8-2019.json
+++ b/test/fixtures/AT-8-2019.json
@@ -22,7 +22,7 @@
     "start": "2019-03-18T23:00:00.000Z",
     "end": "2019-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-8-2020.json
+++ b/test/fixtures/AT-8-2020.json
@@ -22,7 +22,7 @@
     "start": "2020-03-18T23:00:00.000Z",
     "end": "2020-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-8-2021.json
+++ b/test/fixtures/AT-8-2021.json
@@ -22,7 +22,7 @@
     "start": "2021-03-18T23:00:00.000Z",
     "end": "2021-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-8-2022.json
+++ b/test/fixtures/AT-8-2022.json
@@ -22,7 +22,7 @@
     "start": "2022-03-18T23:00:00.000Z",
     "end": "2022-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-8-2023.json
+++ b/test/fixtures/AT-8-2023.json
@@ -22,7 +22,7 @@
     "start": "2023-03-18T23:00:00.000Z",
     "end": "2023-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-8-2024.json
+++ b/test/fixtures/AT-8-2024.json
@@ -22,7 +22,7 @@
     "start": "2024-03-18T23:00:00.000Z",
     "end": "2024-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-8-2025.json
+++ b/test/fixtures/AT-8-2025.json
@@ -22,7 +22,7 @@
     "start": "2025-03-18T23:00:00.000Z",
     "end": "2025-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-8-2026.json
+++ b/test/fixtures/AT-8-2026.json
@@ -22,7 +22,7 @@
     "start": "2026-03-18T23:00:00.000Z",
     "end": "2026-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-8-2027.json
+++ b/test/fixtures/AT-8-2027.json
@@ -22,7 +22,7 @@
     "start": "2027-03-18T23:00:00.000Z",
     "end": "2027-03-19T23:00:00.000Z",
     "name": "Josefitag",
-    "type": "public",
+    "type": "school",
     "rule": "03-19",
     "_weekday": "Fri"
   },


### PR DESCRIPTION
According to https://de.wikipedia.org/wiki/Josefstag#Gesetzlicher_Feiertag the day is not a public holiday in Austria but schools are off.