### PR TITLE
fix(HU,#464): update the name of the public holiday on March 15

### DIFF
--- a/data/countries/HU.yaml
+++ b/data/countries/HU.yaml
@@ -28,7 +28,7 @@ holidays:
         type: observance
       03-15:
         name:
-          hu: 1948-as forradalom
+          hu: 1848-as forradalom
           en: National Day
         type: public
       04-16:

--- a/test/fixtures/HU-2015.json
+++ b/test/fixtures/HU-2015.json
@@ -39,7 +39,7 @@
     "date": "2015-03-15 00:00:00",
     "start": "2015-03-14T23:00:00.000Z",
     "end": "2015-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Sun"

--- a/test/fixtures/HU-2016.json
+++ b/test/fixtures/HU-2016.json
@@ -39,7 +39,7 @@
     "date": "2016-03-15 00:00:00",
     "start": "2016-03-14T23:00:00.000Z",
     "end": "2016-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Tue"

--- a/test/fixtures/HU-2017.json
+++ b/test/fixtures/HU-2017.json
@@ -39,7 +39,7 @@
     "date": "2017-03-15 00:00:00",
     "start": "2017-03-14T23:00:00.000Z",
     "end": "2017-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Wed"

--- a/test/fixtures/HU-2018.json
+++ b/test/fixtures/HU-2018.json
@@ -39,7 +39,7 @@
     "date": "2018-03-15 00:00:00",
     "start": "2018-03-14T23:00:00.000Z",
     "end": "2018-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Thu"

--- a/test/fixtures/HU-2019.json
+++ b/test/fixtures/HU-2019.json
@@ -39,7 +39,7 @@
     "date": "2019-03-15 00:00:00",
     "start": "2019-03-14T23:00:00.000Z",
     "end": "2019-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Fri"

--- a/test/fixtures/HU-2020.json
+++ b/test/fixtures/HU-2020.json
@@ -39,7 +39,7 @@
     "date": "2020-03-15 00:00:00",
     "start": "2020-03-14T23:00:00.000Z",
     "end": "2020-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Sun"

--- a/test/fixtures/HU-2021.json
+++ b/test/fixtures/HU-2021.json
@@ -39,7 +39,7 @@
     "date": "2021-03-15 00:00:00",
     "start": "2021-03-14T23:00:00.000Z",
     "end": "2021-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Mon"

--- a/test/fixtures/HU-2022.json
+++ b/test/fixtures/HU-2022.json
@@ -39,7 +39,7 @@
     "date": "2022-03-15 00:00:00",
     "start": "2022-03-14T23:00:00.000Z",
     "end": "2022-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Tue"

--- a/test/fixtures/HU-2023.json
+++ b/test/fixtures/HU-2023.json
@@ -39,7 +39,7 @@
     "date": "2023-03-15 00:00:00",
     "start": "2023-03-14T23:00:00.000Z",
     "end": "2023-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Wed"

--- a/test/fixtures/HU-2024.json
+++ b/test/fixtures/HU-2024.json
@@ -75,7 +75,7 @@
     "date": "2024-03-15 00:00:00",
     "start": "2024-03-14T23:00:00.000Z",
     "end": "2024-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Fri"

--- a/test/fixtures/HU-2025.json
+++ b/test/fixtures/HU-2025.json
@@ -39,7 +39,7 @@
     "date": "2025-03-15 00:00:00",
     "start": "2025-03-14T23:00:00.000Z",
     "end": "2025-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Sat"

--- a/test/fixtures/HU-2026.json
+++ b/test/fixtures/HU-2026.json
@@ -39,7 +39,7 @@
     "date": "2026-03-15 00:00:00",
     "start": "2026-03-14T23:00:00.000Z",
     "end": "2026-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Sun"

--- a/test/fixtures/HU-2027.json
+++ b/test/fixtures/HU-2027.json
@@ -39,7 +39,7 @@
     "date": "2027-03-15 00:00:00",
     "start": "2027-03-14T23:00:00.000Z",
     "end": "2027-03-15T23:00:00.000Z",
-    "name": "1948-as forradalom",
+    "name": "1848-as forradalom",
     "type": "public",
     "rule": "03-15",
     "_weekday": "Mon"


### PR DESCRIPTION
Hello,

this PR should resolve this issue https://github.com/commenthol/date-holidays/issues/464.

Info sources:
- https://studyinhungary.hu/living-in-hungary/menu/national-holidays.html
- https://en.wikipedia.org/wiki/Public_holidays_in_Hungary
- https://publicholidays.hu/revolution-day/