### PR TITLE
add Corpus Christi holiday in São Paulo, SP, BR! 🇻🇦✝️

### DIFF
--- a/data/countries/BR.yaml
+++ b/data/countries/BR.yaml
@@ -471,6 +471,9 @@ holidays:
           SP:
             name: São Paulo
             days:
+              easter 60:
+                _name: easter 60
+                type: public
               01-25:
                 name:
                   pt: Aniversário da Cidade

--- a/test/fixtures/BR-SP-SP-2015.json
+++ b/test/fixtures/BR-SP-SP-2015.json
@@ -76,7 +76,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2016.json
+++ b/test/fixtures/BR-SP-SP-2016.json
@@ -76,7 +76,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2017.json
+++ b/test/fixtures/BR-SP-SP-2017.json
@@ -85,7 +85,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2018.json
+++ b/test/fixtures/BR-SP-SP-2018.json
@@ -76,7 +76,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2019.json
+++ b/test/fixtures/BR-SP-SP-2019.json
@@ -85,7 +85,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2020.json
+++ b/test/fixtures/BR-SP-SP-2020.json
@@ -76,7 +76,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2021.json
+++ b/test/fixtures/BR-SP-SP-2021.json
@@ -76,7 +76,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2022.json
+++ b/test/fixtures/BR-SP-SP-2022.json
@@ -85,7 +85,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2023.json
+++ b/test/fixtures/BR-SP-SP-2023.json
@@ -76,7 +76,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2024.json
+++ b/test/fixtures/BR-SP-SP-2024.json
@@ -76,7 +76,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2025.json
+++ b/test/fixtures/BR-SP-SP-2025.json
@@ -85,7 +85,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2026.json
+++ b/test/fixtures/BR-SP-SP-2026.json
@@ -76,7 +76,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2027.json
+++ b/test/fixtures/BR-SP-SP-2027.json
@@ -76,7 +76,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "public",
     "rule": "easter 60",
     "_weekday": "Thu"
   },


### PR DESCRIPTION
In São Paulo, Corpus Christi is a municipal holiday, source: https://g1.globo.com/trabalho-e-carreira/noticia/2023/06/02/corpus-christi-e-feriado-entenda-regras-sobre-trabalho-na-data.ghtml