### PR TITLE
Remove Lovers' day from BR holidays

### DIFF
--- a/data/countries/BR.yaml
+++ b/data/countries/BR.yaml
@@ -50,11 +50,6 @@ holidays:
       easter 60:
         _name: easter 60
         type: optional
-      06-12:
-        name:
-          pt: Dia dos Namorados
-          en: Lovers' Day
-        type: observance
       2nd sunday in August:
         _name: Fathers Day
         type: observance


### PR DESCRIPTION
Lovers' Day was never a holiday in Brazil. 
You can check the brazilian wiki page for Holidays: https://pt.wikipedia.org/wiki/Feriados_no_Brasil. 
There is no mention at all to `June 12` (or `12 de Junho` in portuguese). 