### PR TITLE
fix: correct Kings Birthday in Western Australia for 2024

### DIFF
--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -312,4 +312,8 @@ holidays:
             note: Might be on a different day; is proclaimed by Governor
             active:
               - from: "2022-09-09"
+            disable:
+              - "2024-09-30"
+            enable:
+              - "2024-09-23"
           1st monday in October: false

--- a/test/fixtures/AU-WA-2024.json
+++ b/test/fixtures/AU-WA-2024.json
@@ -81,9 +81,9 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2024-09-30 00:00:00",
-    "start": "2024-09-29T16:00:00.000Z",
-    "end": "2024-09-30T16:00:00.000Z",
+    "date": "2024-09-23 00:00:00",
+    "start": "2024-09-22T16:00:00.000Z",
+    "end": "2024-09-23T16:00:00.000Z",
     "name": "King's Birthday",
     "type": "public",
     "note": "Might be on a different day; is proclaimed by Governor",


### PR DESCRIPTION
In Western Australia the King's Birthday is `2024-09-23` instead of the expected date of `2024-09-30`.

Just for this year it seems. There's no particular reason or rule that could be amended going forward.

Source: https://www.commerce.wa.gov.au/labour-relations/public-holidays-western-australia