### PR TITLE
Update RO data 

### DIFF
--- a/data/countries/RO.yaml
+++ b/data/countries/RO.yaml
@@ -12,15 +12,26 @@ holidays:
     zones:
       - Europe/Bucharest
     days:
-      01-01:
-        _name: 01-01
+      01-01 P2DT:
+        name:
+          ro: Anul nou
+          en: New Year's Day
+      01-06:
+        name:
+          ro: Bobotează
+          en: Epiphany
+      01-07:
+        name:
+          ro: Sfântul Ion
+          en: Saint John the Baptist
       01-24:
         name:
-          ro: Ziua Unirii
-          en: Unification Day
+          ro: Ziua Unirii Principatelor Române
+          en: Day of the Unification of the Romanian Principalities
       03-08:
         name:
           ro: Ziua Mamei
+          en: Mother's Day
         type: observance
       orthodox -2:
         _name: easter -2
@@ -37,8 +48,10 @@ holidays:
         _name: easter 49
       orthodox 50:
         _name: easter 50
-      1st sunday in May:
-        _name: Mothers Day
+      Sunday before 06-01:
+        name:
+          ro: Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni
+          en: Day of the Romanians Everywhere, Romanian Businessperson Day
         type: observance
       06-01:
         name:

--- a/test/fixtures/RO-2015.json
+++ b/test/fixtures/RO-2015.json
@@ -2,17 +2,35 @@
   {
     "date": "2015-01-01 00:00:00",
     "start": "2014-12-31T22:00:00.000Z",
-    "end": "2015-01-01T22:00:00.000Z",
+    "end": "2015-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-06 00:00:00",
+    "start": "2015-01-05T22:00:00.000Z",
+    "end": "2015-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-01-07 00:00:00",
+    "start": "2015-01-06T22:00:00.000Z",
+    "end": "2015-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-01-24 00:00:00",
     "start": "2015-01-23T22:00:00.000Z",
     "end": "2015-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Sat"
@@ -63,15 +81,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-05-03 00:00:00",
-    "start": "2015-05-02T21:00:00.000Z",
-    "end": "2015-05-03T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-05-21 00:00:00",
     "start": "2015-05-20T21:00:00.000Z",
     "end": "2015-05-21T21:00:00.000Z",
@@ -90,13 +99,13 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2015-06-01 00:00:00",
-    "start": "2015-05-31T21:00:00.000Z",
-    "end": "2015-06-01T21:00:00.000Z",
-    "name": "A doua zi de Rusalii",
-    "type": "public",
-    "rule": "orthodox 50",
-    "_weekday": "Mon"
+    "date": "2015-05-31 00:00:00",
+    "start": "2015-05-30T21:00:00.000Z",
+    "end": "2015-05-31T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
+    "_weekday": "Sun"
   },
   {
     "date": "2015-06-01 00:00:00",
@@ -105,6 +114,15 @@
     "name": "Ziua Copilului",
     "type": "public",
     "rule": "06-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-06-01 00:00:00",
+    "start": "2015-05-31T21:00:00.000Z",
+    "end": "2015-06-01T21:00:00.000Z",
+    "name": "A doua zi de Rusalii",
+    "type": "public",
+    "rule": "orthodox 50",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/RO-2015.json
+++ b/test/fixtures/RO-2015.json
@@ -111,18 +111,18 @@
     "date": "2015-06-01 00:00:00",
     "start": "2015-05-31T21:00:00.000Z",
     "end": "2015-06-01T21:00:00.000Z",
-    "name": "Ziua Copilului",
+    "name": "A doua zi de Rusalii",
     "type": "public",
-    "rule": "06-01",
+    "rule": "orthodox 50",
     "_weekday": "Mon"
   },
   {
     "date": "2015-06-01 00:00:00",
     "start": "2015-05-31T21:00:00.000Z",
     "end": "2015-06-01T21:00:00.000Z",
-    "name": "A doua zi de Rusalii",
+    "name": "Ziua Copilului",
     "type": "public",
-    "rule": "orthodox 50",
+    "rule": "06-01",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/RO-2016.json
+++ b/test/fixtures/RO-2016.json
@@ -2,17 +2,35 @@
   {
     "date": "2016-01-01 00:00:00",
     "start": "2015-12-31T22:00:00.000Z",
-    "end": "2016-01-01T22:00:00.000Z",
+    "end": "2016-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-06 00:00:00",
+    "start": "2016-01-05T22:00:00.000Z",
+    "end": "2016-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-01-07 00:00:00",
+    "start": "2016-01-06T22:00:00.000Z",
+    "end": "2016-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Thu"
   },
   {
     "date": "2016-01-24 00:00:00",
     "start": "2016-01-23T22:00:00.000Z",
     "end": "2016-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Sun"
@@ -39,27 +57,18 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T21:00:00.000Z",
     "end": "2016-05-01T21:00:00.000Z",
-    "name": "Paștele",
-    "type": "public",
-    "rule": "orthodox",
-    "_weekday": "Sun"
-  },
-  {
-    "date": "2016-05-01 00:00:00",
-    "start": "2016-04-30T21:00:00.000Z",
-    "end": "2016-05-01T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
-    "date": "2016-05-01 00:00:00",
-    "start": "2016-04-30T21:00:00.000Z",
-    "end": "2016-05-01T21:00:00.000Z",
     "name": "Ziua muncii",
     "type": "public",
     "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-04-30T21:00:00.000Z",
+    "end": "2016-05-01T21:00:00.000Z",
+    "name": "Paștele",
+    "type": "public",
+    "rule": "orthodox",
     "_weekday": "Sun"
   },
   {
@@ -70,6 +79,15 @@
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-29 00:00:00",
+    "start": "2016-05-28T21:00:00.000Z",
+    "end": "2016-05-29T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
+    "_weekday": "Sun"
   },
   {
     "date": "2016-06-01 00:00:00",

--- a/test/fixtures/RO-2016.json
+++ b/test/fixtures/RO-2016.json
@@ -57,18 +57,18 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T21:00:00.000Z",
     "end": "2016-05-01T21:00:00.000Z",
-    "name": "Ziua muncii",
+    "name": "Paștele",
     "type": "public",
-    "rule": "05-01",
+    "rule": "orthodox",
     "_weekday": "Sun"
   },
   {
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T21:00:00.000Z",
     "end": "2016-05-01T21:00:00.000Z",
-    "name": "Paștele",
+    "name": "Ziua muncii",
     "type": "public",
-    "rule": "orthodox",
+    "rule": "05-01",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/RO-2017.json
+++ b/test/fixtures/RO-2017.json
@@ -2,17 +2,35 @@
   {
     "date": "2017-01-01 00:00:00",
     "start": "2016-12-31T22:00:00.000Z",
-    "end": "2017-01-01T22:00:00.000Z",
+    "end": "2017-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-06 00:00:00",
+    "start": "2017-01-05T22:00:00.000Z",
+    "end": "2017-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-01-07 00:00:00",
+    "start": "2017-01-06T22:00:00.000Z",
+    "end": "2017-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Sat"
   },
   {
     "date": "2017-01-24 00:00:00",
     "start": "2017-01-23T22:00:00.000Z",
     "end": "2017-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Tue"
@@ -63,15 +81,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2017-05-07 00:00:00",
-    "start": "2017-05-06T21:00:00.000Z",
-    "end": "2017-05-07T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-05-25 00:00:00",
     "start": "2017-05-24T21:00:00.000Z",
     "end": "2017-05-25T21:00:00.000Z",
@@ -79,6 +88,15 @@
     "type": "observance",
     "rule": "orthodox 39",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2017-05-28 00:00:00",
+    "start": "2017-05-27T21:00:00.000Z",
+    "end": "2017-05-28T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
+    "_weekday": "Sun"
   },
   {
     "date": "2017-06-01 00:00:00",

--- a/test/fixtures/RO-2018.json
+++ b/test/fixtures/RO-2018.json
@@ -2,17 +2,35 @@
   {
     "date": "2018-01-01 00:00:00",
     "start": "2017-12-31T22:00:00.000Z",
-    "end": "2018-01-01T22:00:00.000Z",
+    "end": "2018-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-06 00:00:00",
+    "start": "2018-01-05T22:00:00.000Z",
+    "end": "2018-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-01-07 00:00:00",
+    "start": "2018-01-06T22:00:00.000Z",
+    "end": "2018-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Sun"
   },
   {
     "date": "2018-01-24 00:00:00",
     "start": "2018-01-23T22:00:00.000Z",
     "end": "2018-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Wed"
@@ -63,15 +81,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2018-05-06 00:00:00",
-    "start": "2018-05-05T21:00:00.000Z",
-    "end": "2018-05-06T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-05-17 00:00:00",
     "start": "2018-05-16T21:00:00.000Z",
     "end": "2018-05-17T21:00:00.000Z",
@@ -87,6 +96,15 @@
     "name": "Rusaliile",
     "type": "public",
     "rule": "orthodox 49",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-27 00:00:00",
+    "start": "2018-05-26T21:00:00.000Z",
+    "end": "2018-05-27T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/RO-2019.json
+++ b/test/fixtures/RO-2019.json
@@ -2,17 +2,35 @@
   {
     "date": "2019-01-01 00:00:00",
     "start": "2018-12-31T22:00:00.000Z",
-    "end": "2019-01-01T22:00:00.000Z",
+    "end": "2019-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-06 00:00:00",
+    "start": "2019-01-05T22:00:00.000Z",
+    "end": "2019-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-01-07 00:00:00",
+    "start": "2019-01-06T22:00:00.000Z",
+    "end": "2019-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Mon"
   },
   {
     "date": "2019-01-24 00:00:00",
     "start": "2019-01-23T22:00:00.000Z",
     "end": "2019-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Thu"
@@ -63,12 +81,12 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2019-05-05 00:00:00",
-    "start": "2019-05-04T21:00:00.000Z",
-    "end": "2019-05-05T21:00:00.000Z",
-    "name": "Ziua Mamei",
+    "date": "2019-05-26 00:00:00",
+    "start": "2019-05-25T21:00:00.000Z",
+    "end": "2019-05-26T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
     "type": "observance",
-    "rule": "1st sunday in May",
+    "rule": "Sunday before 06-01",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/RO-2020.json
+++ b/test/fixtures/RO-2020.json
@@ -2,17 +2,35 @@
   {
     "date": "2020-01-01 00:00:00",
     "start": "2019-12-31T22:00:00.000Z",
-    "end": "2020-01-01T22:00:00.000Z",
+    "end": "2020-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-06 00:00:00",
+    "start": "2020-01-05T22:00:00.000Z",
+    "end": "2020-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-01-07 00:00:00",
+    "start": "2020-01-06T22:00:00.000Z",
+    "end": "2020-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Tue"
   },
   {
     "date": "2020-01-24 00:00:00",
     "start": "2020-01-23T22:00:00.000Z",
     "end": "2020-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Fri"
@@ -63,15 +81,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-05-03 00:00:00",
-    "start": "2020-05-02T21:00:00.000Z",
-    "end": "2020-05-03T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-05-28 00:00:00",
     "start": "2020-05-27T21:00:00.000Z",
     "end": "2020-05-28T21:00:00.000Z",
@@ -79,6 +88,15 @@
     "type": "observance",
     "rule": "orthodox 39",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2020-05-31 00:00:00",
+    "start": "2020-05-30T21:00:00.000Z",
+    "end": "2020-05-31T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
+    "_weekday": "Sun"
   },
   {
     "date": "2020-06-01 00:00:00",

--- a/test/fixtures/RO-2021.json
+++ b/test/fixtures/RO-2021.json
@@ -2,17 +2,35 @@
   {
     "date": "2021-01-01 00:00:00",
     "start": "2020-12-31T22:00:00.000Z",
-    "end": "2021-01-01T22:00:00.000Z",
+    "end": "2021-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-06 00:00:00",
+    "start": "2021-01-05T22:00:00.000Z",
+    "end": "2021-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-01-07 00:00:00",
+    "start": "2021-01-06T22:00:00.000Z",
+    "end": "2021-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Thu"
   },
   {
     "date": "2021-01-24 00:00:00",
     "start": "2021-01-23T22:00:00.000Z",
     "end": "2021-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Sun"
@@ -54,15 +72,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2021-05-02 00:00:00",
-    "start": "2021-05-01T21:00:00.000Z",
-    "end": "2021-05-02T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-05-03 00:00:00",
     "start": "2021-05-02T21:00:00.000Z",
     "end": "2021-05-03T21:00:00.000Z",
@@ -70,6 +79,15 @@
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2021-05-30 00:00:00",
+    "start": "2021-05-29T21:00:00.000Z",
+    "end": "2021-05-30T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
+    "_weekday": "Sun"
   },
   {
     "date": "2021-06-01 00:00:00",

--- a/test/fixtures/RO-2022.json
+++ b/test/fixtures/RO-2022.json
@@ -2,17 +2,35 @@
   {
     "date": "2022-01-01 00:00:00",
     "start": "2021-12-31T22:00:00.000Z",
-    "end": "2022-01-01T22:00:00.000Z",
+    "end": "2022-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-06 00:00:00",
+    "start": "2022-01-05T22:00:00.000Z",
+    "end": "2022-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-01-07 00:00:00",
+    "start": "2022-01-06T22:00:00.000Z",
+    "end": "2022-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Fri"
   },
   {
     "date": "2022-01-24 00:00:00",
     "start": "2022-01-23T22:00:00.000Z",
     "end": "2022-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Mon"
@@ -57,18 +75,18 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T21:00:00.000Z",
     "end": "2022-05-01T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
-    "date": "2022-05-01 00:00:00",
-    "start": "2022-04-30T21:00:00.000Z",
-    "end": "2022-05-01T21:00:00.000Z",
     "name": "Ziua muncii",
     "type": "public",
     "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-29 00:00:00",
+    "start": "2022-05-28T21:00:00.000Z",
+    "end": "2022-05-29T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/RO-2023.json
+++ b/test/fixtures/RO-2023.json
@@ -2,17 +2,35 @@
   {
     "date": "2023-01-01 00:00:00",
     "start": "2022-12-31T22:00:00.000Z",
-    "end": "2023-01-01T22:00:00.000Z",
+    "end": "2023-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-06 00:00:00",
+    "start": "2023-01-05T22:00:00.000Z",
+    "end": "2023-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-01-07 00:00:00",
+    "start": "2023-01-06T22:00:00.000Z",
+    "end": "2023-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Sat"
   },
   {
     "date": "2023-01-24 00:00:00",
     "start": "2023-01-23T22:00:00.000Z",
     "end": "2023-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Tue"
@@ -63,15 +81,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2023-05-07 00:00:00",
-    "start": "2023-05-06T21:00:00.000Z",
-    "end": "2023-05-07T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-05-25 00:00:00",
     "start": "2023-05-24T21:00:00.000Z",
     "end": "2023-05-25T21:00:00.000Z",
@@ -79,6 +88,15 @@
     "type": "observance",
     "rule": "orthodox 39",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2023-05-28 00:00:00",
+    "start": "2023-05-27T21:00:00.000Z",
+    "end": "2023-05-28T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
+    "_weekday": "Sun"
   },
   {
     "date": "2023-06-01 00:00:00",

--- a/test/fixtures/RO-2024.json
+++ b/test/fixtures/RO-2024.json
@@ -2,17 +2,35 @@
   {
     "date": "2024-01-01 00:00:00",
     "start": "2023-12-31T22:00:00.000Z",
-    "end": "2024-01-01T22:00:00.000Z",
+    "end": "2024-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-06 00:00:00",
+    "start": "2024-01-05T22:00:00.000Z",
+    "end": "2024-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-01-07 00:00:00",
+    "start": "2024-01-06T22:00:00.000Z",
+    "end": "2024-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Sun"
   },
   {
     "date": "2024-01-24 00:00:00",
     "start": "2024-01-23T22:00:00.000Z",
     "end": "2024-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Wed"
@@ -54,15 +72,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2024-05-05 00:00:00",
-    "start": "2024-05-04T21:00:00.000Z",
-    "end": "2024-05-05T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-05-06 00:00:00",
     "start": "2024-05-05T21:00:00.000Z",
     "end": "2024-05-06T21:00:00.000Z",
@@ -70,6 +79,15 @@
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2024-05-26 00:00:00",
+    "start": "2024-05-25T21:00:00.000Z",
+    "end": "2024-05-26T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
+    "_weekday": "Sun"
   },
   {
     "date": "2024-06-01 00:00:00",

--- a/test/fixtures/RO-2025.json
+++ b/test/fixtures/RO-2025.json
@@ -2,17 +2,35 @@
   {
     "date": "2025-01-01 00:00:00",
     "start": "2024-12-31T22:00:00.000Z",
-    "end": "2025-01-01T22:00:00.000Z",
+    "end": "2025-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-06 00:00:00",
+    "start": "2025-01-05T22:00:00.000Z",
+    "end": "2025-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-01-07 00:00:00",
+    "start": "2025-01-06T22:00:00.000Z",
+    "end": "2025-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Tue"
   },
   {
     "date": "2025-01-24 00:00:00",
     "start": "2025-01-23T22:00:00.000Z",
     "end": "2025-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Fri"
@@ -63,12 +81,12 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2025-05-04 00:00:00",
-    "start": "2025-05-03T21:00:00.000Z",
-    "end": "2025-05-04T21:00:00.000Z",
-    "name": "Ziua Mamei",
+    "date": "2025-05-25 00:00:00",
+    "start": "2025-05-24T21:00:00.000Z",
+    "end": "2025-05-25T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
     "type": "observance",
-    "rule": "1st sunday in May",
+    "rule": "Sunday before 06-01",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/RO-2026.json
+++ b/test/fixtures/RO-2026.json
@@ -2,17 +2,35 @@
   {
     "date": "2026-01-01 00:00:00",
     "start": "2025-12-31T22:00:00.000Z",
-    "end": "2026-01-01T22:00:00.000Z",
+    "end": "2026-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-06 00:00:00",
+    "start": "2026-01-05T22:00:00.000Z",
+    "end": "2026-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-01-07 00:00:00",
+    "start": "2026-01-06T22:00:00.000Z",
+    "end": "2026-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-01-24 00:00:00",
     "start": "2026-01-23T22:00:00.000Z",
     "end": "2026-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Sat"
@@ -63,15 +81,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-05-03 00:00:00",
-    "start": "2026-05-02T21:00:00.000Z",
-    "end": "2026-05-03T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-05-21 00:00:00",
     "start": "2026-05-20T21:00:00.000Z",
     "end": "2026-05-21T21:00:00.000Z",
@@ -87,6 +96,15 @@
     "name": "Rusaliile",
     "type": "public",
     "rule": "orthodox 49",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-31 00:00:00",
+    "start": "2026-05-30T21:00:00.000Z",
+    "end": "2026-05-31T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/RO-2027.json
+++ b/test/fixtures/RO-2027.json
@@ -2,17 +2,35 @@
   {
     "date": "2027-01-01 00:00:00",
     "start": "2026-12-31T22:00:00.000Z",
-    "end": "2027-01-01T22:00:00.000Z",
+    "end": "2027-01-02T22:00:00.000Z",
     "name": "Anul nou",
     "type": "public",
-    "rule": "01-01",
+    "rule": "01-01 P2DT",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-06 00:00:00",
+    "start": "2027-01-05T22:00:00.000Z",
+    "end": "2027-01-06T22:00:00.000Z",
+    "name": "Bobotează",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-01-07 00:00:00",
+    "start": "2027-01-06T22:00:00.000Z",
+    "end": "2027-01-07T22:00:00.000Z",
+    "name": "Sfântul Ion",
+    "type": "public",
+    "rule": "01-07",
+    "_weekday": "Thu"
   },
   {
     "date": "2027-01-24 00:00:00",
     "start": "2027-01-23T22:00:00.000Z",
     "end": "2027-01-24T22:00:00.000Z",
-    "name": "Ziua Unirii",
+    "name": "Ziua Unirii Principatelor Române",
     "type": "public",
     "rule": "01-24",
     "_weekday": "Sun"
@@ -54,15 +72,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2027-05-02 00:00:00",
-    "start": "2027-05-01T21:00:00.000Z",
-    "end": "2027-05-02T21:00:00.000Z",
-    "name": "Ziua Mamei",
-    "type": "observance",
-    "rule": "1st sunday in May",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-05-03 00:00:00",
     "start": "2027-05-02T21:00:00.000Z",
     "end": "2027-05-03T21:00:00.000Z",
@@ -70,6 +79,15 @@
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2027-05-30 00:00:00",
+    "start": "2027-05-29T21:00:00.000Z",
+    "end": "2027-05-30T21:00:00.000Z",
+    "name": "Ziua Românilor de Pretutindeni, Ziua Românului de Pretutindeni",
+    "type": "observance",
+    "rule": "Sunday before 06-01",
+    "_weekday": "Sun"
   },
   {
     "date": "2027-06-01 00:00:00",


### PR DESCRIPTION
Update public holidays for RO country.
Source: https://en.wikipedia.org/wiki/Public_holidays_in_Romania