### PR TITLE
fix(IE,#495): removal of Christmas bank holiday

### DIFF
--- a/data/countries/IE.yaml
+++ b/data/countries/IE.yaml
@@ -67,10 +67,6 @@ holidays:
           en: St. Stephen's Day
         substitute: true
         type: bank
-      12-27 and if saturday then next monday if sunday then next tuesday:
-        name:
-          en: Christmas Bank Holiday
-        type: bank
       3rd sunday in June:
         _name: Fathers Day
         type: observance

--- a/test/fixtures/IE-2015.json
+++ b/test/fixtures/IE-2015.json
@@ -126,15 +126,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2015-12-27 00:00:00",
-    "start": "2015-12-27T00:00:00.000Z",
-    "end": "2015-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-12-28 00:00:00",
     "start": "2015-12-28T00:00:00.000Z",
     "end": "2015-12-29T00:00:00.000Z",
@@ -143,14 +134,5 @@
     "substitute": true,
     "rule": "12-26 and if saturday then next monday if sunday then next monday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2015-12-29 00:00:00",
-    "start": "2015-12-29T00:00:00.000Z",
-    "end": "2015-12-30T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2016.json
+++ b/test/fixtures/IE-2016.json
@@ -124,14 +124,5 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2016-12-27 00:00:00",
-    "start": "2016-12-27T00:00:00.000Z",
-    "end": "2016-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2017.json
+++ b/test/fixtures/IE-2017.json
@@ -124,14 +124,5 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2017-12-27 00:00:00",
-    "start": "2017-12-27T00:00:00.000Z",
-    "end": "2017-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/IE-2018.json
+++ b/test/fixtures/IE-2018.json
@@ -134,14 +134,5 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2018-12-27 00:00:00",
-    "start": "2018-12-27T00:00:00.000Z",
-    "end": "2018-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/IE-2019.json
+++ b/test/fixtures/IE-2019.json
@@ -134,14 +134,5 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2019-12-27 00:00:00",
-    "start": "2019-12-27T00:00:00.000Z",
-    "end": "2019-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/IE-2020.json
+++ b/test/fixtures/IE-2020.json
@@ -126,15 +126,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2020-12-27 00:00:00",
-    "start": "2020-12-27T00:00:00.000Z",
-    "end": "2020-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-12-28 00:00:00",
     "start": "2020-12-28T00:00:00.000Z",
     "end": "2020-12-29T00:00:00.000Z",
@@ -143,14 +134,5 @@
     "substitute": true,
     "rule": "12-26 and if saturday then next monday if sunday then next monday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2020-12-29 00:00:00",
-    "start": "2020-12-29T00:00:00.000Z",
-    "end": "2020-12-30T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2021.json
+++ b/test/fixtures/IE-2021.json
@@ -129,15 +129,6 @@
     "date": "2021-12-27 00:00:00",
     "start": "2021-12-27T00:00:00.000Z",
     "end": "2021-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2021-12-27 00:00:00",
-    "start": "2021-12-27T00:00:00.000Z",
-    "end": "2021-12-28T00:00:00.000Z",
     "name": "St. Stephen's Day (substitute day)",
     "type": "bank",
     "substitute": true,

--- a/test/fixtures/IE-2022.json
+++ b/test/fixtures/IE-2022.json
@@ -124,14 +124,5 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2022-12-27 00:00:00",
-    "start": "2022-12-27T00:00:00.000Z",
-    "end": "2022-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2023.json
+++ b/test/fixtures/IE-2023.json
@@ -133,14 +133,5 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2023-12-27 00:00:00",
-    "start": "2023-12-27T00:00:00.000Z",
-    "end": "2023-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/IE-2024.json
+++ b/test/fixtures/IE-2024.json
@@ -143,14 +143,5 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2024-12-27 00:00:00",
-    "start": "2024-12-27T00:00:00.000Z",
-    "end": "2024-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/IE-2025.json
+++ b/test/fixtures/IE-2025.json
@@ -133,23 +133,5 @@
     "type": "public",
     "rule": "12-26",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2025-12-27 00:00:00",
-    "start": "2025-12-27T00:00:00.000Z",
-    "end": "2025-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Sat"
-  },
-  {
-    "date": "2025-12-29 00:00:00",
-    "start": "2025-12-29T00:00:00.000Z",
-    "end": "2025-12-30T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/IE-2026.json
+++ b/test/fixtures/IE-2026.json
@@ -135,15 +135,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2026-12-27 00:00:00",
-    "start": "2026-12-27T00:00:00.000Z",
-    "end": "2026-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-12-28 00:00:00",
     "start": "2026-12-28T00:00:00.000Z",
     "end": "2026-12-29T00:00:00.000Z",
@@ -152,14 +143,5 @@
     "substitute": true,
     "rule": "12-26 and if saturday then next monday if sunday then next monday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2026-12-29 00:00:00",
-    "start": "2026-12-29T00:00:00.000Z",
-    "end": "2026-12-30T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/IE-2027.json
+++ b/test/fixtures/IE-2027.json
@@ -138,15 +138,6 @@
     "date": "2027-12-27 00:00:00",
     "start": "2027-12-27T00:00:00.000Z",
     "end": "2027-12-28T00:00:00.000Z",
-    "name": "Christmas Bank Holiday",
-    "type": "bank",
-    "rule": "12-27 and if saturday then next monday if sunday then next tuesday",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2027-12-27 00:00:00",
-    "start": "2027-12-27T00:00:00.000Z",
-    "end": "2027-12-28T00:00:00.000Z",
     "name": "St. Stephen's Day (substitute day)",
     "type": "bank",
     "substitute": true,


### PR DESCRIPTION
According to https://www.bankholidays.ie/bank-holiday-dates-ireland-2024 there is no bank holiday on December 27th.

Fixes issue #495 