### PR TITLE
feat: remove bank holiday and update test fixtures

### DIFF
--- a/data/countries/IE.yaml
+++ b/data/countries/IE.yaml
@@ -16,10 +16,6 @@ holidays:
     days:
       01-01:
         _name: 01-01
-      1st monday in January:
-        name:
-          en: Bank Holiday
-        type: bank
       # Official Rule: First Monday in February, or 1 February if the date falls on a Friday
       02-01 if Tuesday,Wednesday,Thursday,Saturday,Sunday then next Monday since 2023:
         name:

--- a/test/fixtures/IE-2015.json
+++ b/test/fixtures/IE-2015.json
@@ -9,15 +9,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2015-01-05 00:00:00",
-    "start": "2015-01-05T00:00:00.000Z",
-    "end": "2015-01-06T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2015-03-15 00:00:00",
     "start": "2015-03-15T00:00:00.000Z",
     "end": "2015-03-16T00:00:00.000Z",

--- a/test/fixtures/IE-2016.json
+++ b/test/fixtures/IE-2016.json
@@ -9,15 +9,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-01-04 00:00:00",
-    "start": "2016-01-04T00:00:00.000Z",
-    "end": "2016-01-05T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2016-03-06 00:00:00",
     "start": "2016-03-06T00:00:00.000Z",
     "end": "2016-03-07T00:00:00.000Z",

--- a/test/fixtures/IE-2017.json
+++ b/test/fixtures/IE-2017.json
@@ -9,15 +9,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2017-01-02 00:00:00",
-    "start": "2017-01-02T00:00:00.000Z",
-    "end": "2017-01-03T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2017-03-17 00:00:00",
     "start": "2017-03-17T00:00:00.000Z",
     "end": "2017-03-18T00:00:00.000Z",

--- a/test/fixtures/IE-2018.json
+++ b/test/fixtures/IE-2018.json
@@ -3,15 +3,6 @@
     "date": "2018-01-01 00:00:00",
     "start": "2018-01-01T00:00:00.000Z",
     "end": "2018-01-02T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2018-01-01 00:00:00",
-    "start": "2018-01-01T00:00:00.000Z",
-    "end": "2018-01-02T00:00:00.000Z",
     "name": "New Year's Day",
     "type": "public",
     "rule": "01-01",

--- a/test/fixtures/IE-2019.json
+++ b/test/fixtures/IE-2019.json
@@ -9,15 +9,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2019-01-07 00:00:00",
-    "start": "2019-01-07T00:00:00.000Z",
-    "end": "2019-01-08T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2019-03-17 00:00:00",
     "start": "2019-03-17T00:00:00.000Z",
     "end": "2019-03-18T00:00:00.000Z",

--- a/test/fixtures/IE-2020.json
+++ b/test/fixtures/IE-2020.json
@@ -9,15 +9,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2020-01-06 00:00:00",
-    "start": "2020-01-06T00:00:00.000Z",
-    "end": "2020-01-07T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2020-03-17 00:00:00",
     "start": "2020-03-17T00:00:00.000Z",
     "end": "2020-03-18T00:00:00.000Z",

--- a/test/fixtures/IE-2021.json
+++ b/test/fixtures/IE-2021.json
@@ -9,15 +9,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-01-04 00:00:00",
-    "start": "2021-01-04T00:00:00.000Z",
-    "end": "2021-01-05T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2021-03-14 00:00:00",
     "start": "2021-03-14T00:00:00.000Z",
     "end": "2021-03-15T00:00:00.000Z",

--- a/test/fixtures/IE-2022.json
+++ b/test/fixtures/IE-2022.json
@@ -9,15 +9,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2022-01-03 00:00:00",
-    "start": "2022-01-03T00:00:00.000Z",
-    "end": "2022-01-04T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2022-03-17 00:00:00",
     "start": "2022-03-17T00:00:00.000Z",
     "end": "2022-03-18T00:00:00.000Z",

--- a/test/fixtures/IE-2023.json
+++ b/test/fixtures/IE-2023.json
@@ -9,15 +9,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2023-01-02 00:00:00",
-    "start": "2023-01-02T00:00:00.000Z",
-    "end": "2023-01-03T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2023-02-06 00:00:00",
     "start": "2023-02-06T00:00:00.000Z",
     "end": "2023-02-07T00:00:00.000Z",

--- a/test/fixtures/IE-2024.json
+++ b/test/fixtures/IE-2024.json
@@ -3,15 +3,6 @@
     "date": "2024-01-01 00:00:00",
     "start": "2024-01-01T00:00:00.000Z",
     "end": "2024-01-02T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2024-01-01 00:00:00",
-    "start": "2024-01-01T00:00:00.000Z",
-    "end": "2024-01-02T00:00:00.000Z",
     "name": "New Year's Day",
     "type": "public",
     "rule": "01-01",

--- a/test/fixtures/IE-2025.json
+++ b/test/fixtures/IE-2025.json
@@ -9,15 +9,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2025-01-06 00:00:00",
-    "start": "2025-01-06T00:00:00.000Z",
-    "end": "2025-01-07T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2025-02-03 00:00:00",
     "start": "2025-02-03T00:00:00.000Z",
     "end": "2025-02-04T00:00:00.000Z",

--- a/test/fixtures/IE-2026.json
+++ b/test/fixtures/IE-2026.json
@@ -9,15 +9,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2026-01-05 00:00:00",
-    "start": "2026-01-05T00:00:00.000Z",
-    "end": "2026-01-06T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2026-02-02 00:00:00",
     "start": "2026-02-02T00:00:00.000Z",
     "end": "2026-02-03T00:00:00.000Z",

--- a/test/fixtures/IE-2027.json
+++ b/test/fixtures/IE-2027.json
@@ -9,15 +9,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-01-04 00:00:00",
-    "start": "2027-01-04T00:00:00.000Z",
-    "end": "2027-01-05T00:00:00.000Z",
-    "name": "Bank Holiday",
-    "type": "bank",
-    "rule": "1st monday in January",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2027-02-01 00:00:00",
     "start": "2027-02-01T00:00:00.000Z",
     "end": "2027-02-02T00:00:00.000Z",


### PR DESCRIPTION
The first Monday in January is not a bank holiday in Ireland.

I checked this website all the way back to 2015 and it has not been one in at least that long: https://www.timeanddate.com/holidays/ireland/2025 