### PR TITLE
Feature/sk update constitution day is not public holiday anymore

### DIFF
--- a/data/countries/SK.yaml
+++ b/data/countries/SK.yaml
@@ -42,6 +42,7 @@ holidays:
           en: Slovak National Uprising anniversary
       09-01:
         _name: Constitution Day
+        type: observance
       09-15:
         name:
           sk: Sviatok Panny Márie Sedembolestnej

--- a/data/countries/SK.yaml
+++ b/data/countries/SK.yaml
@@ -40,8 +40,14 @@ holidays:
         name:
           sk: Výročie Slovenského národného povstania
           en: Slovak National Uprising anniversary
-      09-01:
-        _name: Constitution Day
+      09-01 since 1994 and prior to 2024:
+        name: 
+          en: Constitution Day
+          sk: Deň Ústavy Slovenskej republiky
+      09-01 since 2024:
+        name: 
+          en: Constitution Day
+          sk: Deň Ústavy Slovenskej republiky
         type: observance
       09-15:
         name:

--- a/data/countries/SK.yaml
+++ b/data/countries/SK.yaml
@@ -41,13 +41,9 @@ holidays:
           sk: Výročie Slovenského národného povstania
           en: Slovak National Uprising anniversary
       09-01 since 1994 and prior to 2024:
-        name: 
-          en: Constitution Day
-          sk: Deň Ústavy Slovenskej republiky
+        _name: Constitution Day
       09-01 since 2024:
-        name: 
-          en: Constitution Day
-          sk: Deň Ústavy Slovenskej republiky
+        _name: Constitution Day
         type: observance
       09-15:
         name:

--- a/test/fixtures/SK-2015.json
+++ b/test/fixtures/SK-2015.json
@@ -95,7 +95,7 @@
     "end": "2015-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
     "type": "public",
-    "rule": "09-01",
+    "rule": "09-01 since 1994 and prior to 2024",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/SK-2016.json
+++ b/test/fixtures/SK-2016.json
@@ -95,7 +95,7 @@
     "end": "2016-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
     "type": "public",
-    "rule": "09-01",
+    "rule": "09-01 since 1994 and prior to 2024",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/SK-2017.json
+++ b/test/fixtures/SK-2017.json
@@ -95,7 +95,7 @@
     "end": "2017-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
     "type": "public",
-    "rule": "09-01",
+    "rule": "09-01 since 1994 and prior to 2024",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SK-2018.json
+++ b/test/fixtures/SK-2018.json
@@ -95,7 +95,7 @@
     "end": "2018-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
     "type": "public",
-    "rule": "09-01",
+    "rule": "09-01 since 1994 and prior to 2024",
     "_weekday": "Sat"
   },
   {

--- a/test/fixtures/SK-2019.json
+++ b/test/fixtures/SK-2019.json
@@ -95,7 +95,7 @@
     "end": "2019-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
     "type": "public",
-    "rule": "09-01",
+    "rule": "09-01 since 1994 and prior to 2024",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/SK-2020.json
+++ b/test/fixtures/SK-2020.json
@@ -95,7 +95,7 @@
     "end": "2020-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
     "type": "public",
-    "rule": "09-01",
+    "rule": "09-01 since 1994 and prior to 2024",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/SK-2021.json
+++ b/test/fixtures/SK-2021.json
@@ -95,7 +95,7 @@
     "end": "2021-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
     "type": "public",
-    "rule": "09-01",
+    "rule": "09-01 since 1994 and prior to 2024",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/SK-2022.json
+++ b/test/fixtures/SK-2022.json
@@ -95,7 +95,7 @@
     "end": "2022-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
     "type": "public",
-    "rule": "09-01",
+    "rule": "09-01 since 1994 and prior to 2024",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/SK-2023.json
+++ b/test/fixtures/SK-2023.json
@@ -95,7 +95,7 @@
     "end": "2023-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
     "type": "public",
-    "rule": "09-01",
+    "rule": "09-01 since 1994 and prior to 2024",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SK-2024.json
+++ b/test/fixtures/SK-2024.json
@@ -94,8 +94,8 @@
     "start": "2024-08-31T22:00:00.000Z",
     "end": "2024-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
-    "type": "public",
-    "rule": "09-01",
+    "type": "observance",
+    "rule": "09-01 since 2024",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/SK-2025.json
+++ b/test/fixtures/SK-2025.json
@@ -94,8 +94,8 @@
     "start": "2025-08-31T22:00:00.000Z",
     "end": "2025-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
-    "type": "public",
-    "rule": "09-01",
+    "type": "observance",
+    "rule": "09-01 since 2024",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/SK-2026.json
+++ b/test/fixtures/SK-2026.json
@@ -94,8 +94,8 @@
     "start": "2026-08-31T22:00:00.000Z",
     "end": "2026-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
-    "type": "public",
-    "rule": "09-01",
+    "type": "observance",
+    "rule": "09-01 since 2024",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/SK-2027.json
+++ b/test/fixtures/SK-2027.json
@@ -94,8 +94,8 @@
     "start": "2027-08-31T22:00:00.000Z",
     "end": "2027-09-01T22:00:00.000Z",
     "name": "Deň Ústavy",
-    "type": "public",
-    "rule": "09-01",
+    "type": "observance",
+    "rule": "09-01 since 2024",
     "_weekday": "Wed"
   },
   {


### PR DESCRIPTION
As of 2024, 1st of September in Slovakia become to be an exception - it is still formally celebrated, but nobody has paid day off, schools are open too. 
Btw, was celebrated only since 1994.
[https://sk.wikipedia.org/wiki/De%C5%88_%C3%9Astavy_Slovenskej_republiky](Wikipedia)