### PR TITLE
fix(MX): correct Mexican holiday definitions, prevent duplicate occurrences.

### DIFF
--- a/data/countries/MX.yaml
+++ b/data/countries/MX.yaml
@@ -14,6 +14,9 @@ holidays:
   #
   # For convenience, here is the same 2019 bank information condensed and in English:
   # @source http://www.banxico.org.mx/financial-system/d/%7B78042524-F8E9-89EB-9A8E-FD40D0CBCF40%7D.pdf
+  #
+  # Three holidays that shifted to Monday observances in 2006 and 2007:
+  # @source https://www.gob.mx/cms/uploads/attachment/file/156203/1044_Ley_Federal_del_Trabajo.pdf
   MX:
     names:
       es: México
@@ -39,18 +42,24 @@ holidays:
         _name: 01-01
       02-05:
         _name: Constitution Day
+        active:
+          - to: 2006-01-17
       1st monday in February:
-        name:
-          en: Constitution Day (day off)
-          es: Día de la Constitución (día libre)
+        _name: Constitution Day
+        active:
+          - from: 2006-01-18
       03-21:
         name:
           en: Benito Juárez's birthday
           es: Natalicio de Benito Juárez
+        active:
+          - to: 2006-12-31
       3rd monday in March:
         name:
-          en: Benito Juárez's birthday (day off)
-          es: Natalicio de Benito Juárez (día libre)
+          en: Benito Juárez's birthday
+          es: Natalicio de Benito Juárez
+        active:
+          - from: 2007-01-01
       easter -3:
         _name: easter -3
         type: bank
@@ -69,10 +78,12 @@ holidays:
         type: bank
       11-20:
         _name: Revolution Day
+        active:
+          - to: 2006-01-17
       3rd monday in November:
-        name:
-          en: Revolution Day (day off)
-          es: Día de la Revolución (día libre)
+        _name: Revolution Day
+        active:
+          - from: 2006-01-18
       12-01 every 6 years since 1934:
         name:
           en: Change of Federal Government

--- a/test/fixtures/MX-2015.json
+++ b/test/fixtures/MX-2015.json
@@ -12,37 +12,19 @@
     "date": "2015-02-02 00:00:00",
     "start": "2015-02-02T06:00:00.000Z",
     "end": "2015-02-03T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
   },
   {
-    "date": "2015-02-05 00:00:00",
-    "start": "2015-02-05T06:00:00.000Z",
-    "end": "2015-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Thu"
-  },
-  {
     "date": "2015-03-16 00:00:00",
     "start": "2015-03-16T06:00:00.000Z",
     "end": "2015-03-17T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2015-03-21 00:00:00",
-    "start": "2015-03-21T06:00:00.000Z",
-    "end": "2015-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Sat"
   },
   {
     "date": "2015-04-02 00:00:00",
@@ -102,19 +84,10 @@
     "date": "2015-11-16 00:00:00",
     "start": "2015-11-16T06:00:00.000Z",
     "end": "2015-11-17T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2015-11-20 00:00:00",
-    "start": "2015-11-20T06:00:00.000Z",
-    "end": "2015-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Fri"
   },
   {
     "date": "2015-12-12 00:00:00",

--- a/test/fixtures/MX-2016.json
+++ b/test/fixtures/MX-2016.json
@@ -12,34 +12,16 @@
     "date": "2016-02-01 00:00:00",
     "start": "2016-02-01T06:00:00.000Z",
     "end": "2016-02-02T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2016-02-05 00:00:00",
-    "start": "2016-02-05T06:00:00.000Z",
-    "end": "2016-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Fri"
   },
   {
     "date": "2016-03-21 00:00:00",
     "start": "2016-03-21T06:00:00.000Z",
     "end": "2016-03-22T06:00:00.000Z",
     "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2016-03-21 00:00:00",
-    "start": "2016-03-21T06:00:00.000Z",
-    "end": "2016-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
@@ -99,19 +81,10 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2016-11-20 00:00:00",
-    "start": "2016-11-20T06:00:00.000Z",
-    "end": "2016-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-11-21 00:00:00",
     "start": "2016-11-21T06:00:00.000Z",
     "end": "2016-11-22T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"

--- a/test/fixtures/MX-2017.json
+++ b/test/fixtures/MX-2017.json
@@ -9,19 +9,10 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2017-02-05 00:00:00",
-    "start": "2017-02-05T06:00:00.000Z",
-    "end": "2017-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-02-06 00:00:00",
     "start": "2017-02-06T06:00:00.000Z",
     "end": "2017-02-07T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
@@ -30,19 +21,10 @@
     "date": "2017-03-20 00:00:00",
     "start": "2017-03-20T06:00:00.000Z",
     "end": "2017-03-21T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-03-21 00:00:00",
-    "start": "2017-03-21T06:00:00.000Z",
-    "end": "2017-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Tue"
   },
   {
     "date": "2017-04-13 00:00:00",
@@ -103,15 +85,6 @@
     "start": "2017-11-20T06:00:00.000Z",
     "end": "2017-11-21T06:00:00.000Z",
     "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2017-11-20 00:00:00",
-    "start": "2017-11-20T06:00:00.000Z",
-    "end": "2017-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"

--- a/test/fixtures/MX-2018.json
+++ b/test/fixtures/MX-2018.json
@@ -14,15 +14,6 @@
     "end": "2018-02-06T06:00:00.000Z",
     "name": "Día de la Constitución",
     "type": "public",
-    "rule": "02-05",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2018-02-05 00:00:00",
-    "start": "2018-02-05T06:00:00.000Z",
-    "end": "2018-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
-    "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
   },
@@ -30,19 +21,10 @@
     "date": "2018-03-19 00:00:00",
     "start": "2018-03-19T06:00:00.000Z",
     "end": "2018-03-20T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2018-03-21 00:00:00",
-    "start": "2018-03-21T06:00:00.000Z",
-    "end": "2018-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Wed"
   },
   {
     "date": "2018-03-29 00:00:00",
@@ -102,19 +84,10 @@
     "date": "2018-11-19 00:00:00",
     "start": "2018-11-19T06:00:00.000Z",
     "end": "2018-11-20T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2018-11-20 00:00:00",
-    "start": "2018-11-20T06:00:00.000Z",
-    "end": "2018-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Tue"
   },
   {
     "date": "2018-12-01 00:00:00",

--- a/test/fixtures/MX-2019.json
+++ b/test/fixtures/MX-2019.json
@@ -12,37 +12,19 @@
     "date": "2019-02-04 00:00:00",
     "start": "2019-02-04T06:00:00.000Z",
     "end": "2019-02-05T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
   },
   {
-    "date": "2019-02-05 00:00:00",
-    "start": "2019-02-05T06:00:00.000Z",
-    "end": "2019-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Tue"
-  },
-  {
     "date": "2019-03-18 00:00:00",
     "start": "2019-03-18T06:00:00.000Z",
     "end": "2019-03-19T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2019-03-21 00:00:00",
-    "start": "2019-03-21T06:00:00.000Z",
-    "end": "2019-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Thu"
   },
   {
     "date": "2019-04-18 00:00:00",
@@ -102,19 +84,10 @@
     "date": "2019-11-18 00:00:00",
     "start": "2019-11-18T06:00:00.000Z",
     "end": "2019-11-19T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2019-11-20 00:00:00",
-    "start": "2019-11-20T06:00:00.000Z",
-    "end": "2019-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Wed"
   },
   {
     "date": "2019-12-12 00:00:00",

--- a/test/fixtures/MX-2020.json
+++ b/test/fixtures/MX-2020.json
@@ -12,37 +12,19 @@
     "date": "2020-02-03 00:00:00",
     "start": "2020-02-03T06:00:00.000Z",
     "end": "2020-02-04T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
   },
   {
-    "date": "2020-02-05 00:00:00",
-    "start": "2020-02-05T06:00:00.000Z",
-    "end": "2020-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Wed"
-  },
-  {
     "date": "2020-03-16 00:00:00",
     "start": "2020-03-16T06:00:00.000Z",
     "end": "2020-03-17T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2020-03-21 00:00:00",
-    "start": "2020-03-21T06:00:00.000Z",
-    "end": "2020-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Sat"
   },
   {
     "date": "2020-04-09 00:00:00",
@@ -102,19 +84,10 @@
     "date": "2020-11-16 00:00:00",
     "start": "2020-11-16T06:00:00.000Z",
     "end": "2020-11-17T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2020-11-20 00:00:00",
-    "start": "2020-11-20T06:00:00.000Z",
-    "end": "2020-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Fri"
   },
   {
     "date": "2020-12-12 00:00:00",

--- a/test/fixtures/MX-2021.json
+++ b/test/fixtures/MX-2021.json
@@ -12,37 +12,19 @@
     "date": "2021-02-01 00:00:00",
     "start": "2021-02-01T06:00:00.000Z",
     "end": "2021-02-02T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
   },
   {
-    "date": "2021-02-05 00:00:00",
-    "start": "2021-02-05T06:00:00.000Z",
-    "end": "2021-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2021-03-15 00:00:00",
     "start": "2021-03-15T06:00:00.000Z",
     "end": "2021-03-16T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2021-03-21 00:00:00",
-    "start": "2021-03-21T06:00:00.000Z",
-    "end": "2021-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Sun"
   },
   {
     "date": "2021-04-01 00:00:00",
@@ -102,19 +84,10 @@
     "date": "2021-11-15 00:00:00",
     "start": "2021-11-15T06:00:00.000Z",
     "end": "2021-11-16T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2021-11-20 00:00:00",
-    "start": "2021-11-20T06:00:00.000Z",
-    "end": "2021-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Sat"
   },
   {
     "date": "2021-12-12 00:00:00",

--- a/test/fixtures/MX-2022.json
+++ b/test/fixtures/MX-2022.json
@@ -9,19 +9,10 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2022-02-05 00:00:00",
-    "start": "2022-02-05T06:00:00.000Z",
-    "end": "2022-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Sat"
-  },
-  {
     "date": "2022-02-07 00:00:00",
     "start": "2022-02-07T06:00:00.000Z",
     "end": "2022-02-08T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
@@ -31,15 +22,6 @@
     "start": "2022-03-21T06:00:00.000Z",
     "end": "2022-03-22T06:00:00.000Z",
     "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2022-03-21 00:00:00",
-    "start": "2022-03-21T06:00:00.000Z",
-    "end": "2022-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
@@ -99,19 +81,10 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2022-11-20 00:00:00",
-    "start": "2022-11-20T06:00:00.000Z",
-    "end": "2022-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-11-21 00:00:00",
     "start": "2022-11-21T06:00:00.000Z",
     "end": "2022-11-22T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"

--- a/test/fixtures/MX-2023.json
+++ b/test/fixtures/MX-2023.json
@@ -9,19 +9,10 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2023-02-05 00:00:00",
-    "start": "2023-02-05T06:00:00.000Z",
-    "end": "2023-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-02-06 00:00:00",
     "start": "2023-02-06T06:00:00.000Z",
     "end": "2023-02-07T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
@@ -30,19 +21,10 @@
     "date": "2023-03-20 00:00:00",
     "start": "2023-03-20T06:00:00.000Z",
     "end": "2023-03-21T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-03-21 00:00:00",
-    "start": "2023-03-21T06:00:00.000Z",
-    "end": "2023-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Tue"
   },
   {
     "date": "2023-04-06 00:00:00",
@@ -103,15 +85,6 @@
     "start": "2023-11-20T06:00:00.000Z",
     "end": "2023-11-21T06:00:00.000Z",
     "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2023-11-20 00:00:00",
-    "start": "2023-11-20T06:00:00.000Z",
-    "end": "2023-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"

--- a/test/fixtures/MX-2024.json
+++ b/test/fixtures/MX-2024.json
@@ -14,15 +14,6 @@
     "end": "2024-02-06T06:00:00.000Z",
     "name": "Día de la Constitución",
     "type": "public",
-    "rule": "02-05",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2024-02-05 00:00:00",
-    "start": "2024-02-05T06:00:00.000Z",
-    "end": "2024-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
-    "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
   },
@@ -30,19 +21,10 @@
     "date": "2024-03-18 00:00:00",
     "start": "2024-03-18T06:00:00.000Z",
     "end": "2024-03-19T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2024-03-21 00:00:00",
-    "start": "2024-03-21T06:00:00.000Z",
-    "end": "2024-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Thu"
   },
   {
     "date": "2024-03-28 00:00:00",
@@ -102,19 +84,10 @@
     "date": "2024-11-18 00:00:00",
     "start": "2024-11-18T06:00:00.000Z",
     "end": "2024-11-19T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2024-11-20 00:00:00",
-    "start": "2024-11-20T06:00:00.000Z",
-    "end": "2024-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Wed"
   },
   {
     "date": "2024-12-01 00:00:00",

--- a/test/fixtures/MX-2025.json
+++ b/test/fixtures/MX-2025.json
@@ -12,37 +12,19 @@
     "date": "2025-02-03 00:00:00",
     "start": "2025-02-03T06:00:00.000Z",
     "end": "2025-02-04T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
   },
   {
-    "date": "2025-02-05 00:00:00",
-    "start": "2025-02-05T06:00:00.000Z",
-    "end": "2025-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Wed"
-  },
-  {
     "date": "2025-03-17 00:00:00",
     "start": "2025-03-17T06:00:00.000Z",
     "end": "2025-03-18T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2025-03-21 00:00:00",
-    "start": "2025-03-21T06:00:00.000Z",
-    "end": "2025-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Fri"
   },
   {
     "date": "2025-04-17 00:00:00",
@@ -102,19 +84,10 @@
     "date": "2025-11-17 00:00:00",
     "start": "2025-11-17T06:00:00.000Z",
     "end": "2025-11-18T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2025-11-20 00:00:00",
-    "start": "2025-11-20T06:00:00.000Z",
-    "end": "2025-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Thu"
   },
   {
     "date": "2025-12-12 00:00:00",

--- a/test/fixtures/MX-2026.json
+++ b/test/fixtures/MX-2026.json
@@ -12,37 +12,19 @@
     "date": "2026-02-02 00:00:00",
     "start": "2026-02-02T06:00:00.000Z",
     "end": "2026-02-03T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
   },
   {
-    "date": "2026-02-05 00:00:00",
-    "start": "2026-02-05T06:00:00.000Z",
-    "end": "2026-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Thu"
-  },
-  {
     "date": "2026-03-16 00:00:00",
     "start": "2026-03-16T06:00:00.000Z",
     "end": "2026-03-17T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2026-03-21 00:00:00",
-    "start": "2026-03-21T06:00:00.000Z",
-    "end": "2026-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Sat"
   },
   {
     "date": "2026-04-02 00:00:00",
@@ -102,19 +84,10 @@
     "date": "2026-11-16 00:00:00",
     "start": "2026-11-16T06:00:00.000Z",
     "end": "2026-11-17T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2026-11-20 00:00:00",
-    "start": "2026-11-20T06:00:00.000Z",
-    "end": "2026-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Fri"
   },
   {
     "date": "2026-12-12 00:00:00",

--- a/test/fixtures/MX-2027.json
+++ b/test/fixtures/MX-2027.json
@@ -12,37 +12,19 @@
     "date": "2027-02-01 00:00:00",
     "start": "2027-02-01T06:00:00.000Z",
     "end": "2027-02-02T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
   },
   {
-    "date": "2027-02-05 00:00:00",
-    "start": "2027-02-05T06:00:00.000Z",
-    "end": "2027-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2027-03-15 00:00:00",
     "start": "2027-03-15T06:00:00.000Z",
     "end": "2027-03-16T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2027-03-21 00:00:00",
-    "start": "2027-03-21T06:00:00.000Z",
-    "end": "2027-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Sun"
   },
   {
     "date": "2027-03-25 00:00:00",
@@ -102,19 +84,10 @@
     "date": "2027-11-15 00:00:00",
     "start": "2027-11-15T06:00:00.000Z",
     "end": "2027-11-16T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2027-11-20 00:00:00",
-    "start": "2027-11-20T06:00:00.000Z",
-    "end": "2027-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Sat"
   },
   {
     "date": "2027-12-12 00:00:00",

--- a/test/fixtures/MX-2028.json
+++ b/test/fixtures/MX-2028.json
@@ -9,19 +9,10 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2028-02-05 00:00:00",
-    "start": "2028-02-05T06:00:00.000Z",
-    "end": "2028-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución",
-    "type": "public",
-    "rule": "02-05",
-    "_weekday": "Sat"
-  },
-  {
     "date": "2028-02-07 00:00:00",
     "start": "2028-02-07T06:00:00.000Z",
     "end": "2028-02-08T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
+    "name": "Día de la Constitución",
     "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
@@ -30,19 +21,10 @@
     "date": "2028-03-20 00:00:00",
     "start": "2028-03-20T06:00:00.000Z",
     "end": "2028-03-21T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-03-21 00:00:00",
-    "start": "2028-03-21T06:00:00.000Z",
-    "end": "2028-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Tue"
   },
   {
     "date": "2028-04-13 00:00:00",
@@ -103,15 +85,6 @@
     "start": "2028-11-20T06:00:00.000Z",
     "end": "2028-11-21T06:00:00.000Z",
     "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2028-11-20 00:00:00",
-    "start": "2028-11-20T06:00:00.000Z",
-    "end": "2028-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"

--- a/test/fixtures/MX-2029.json
+++ b/test/fixtures/MX-2029.json
@@ -14,15 +14,6 @@
     "end": "2029-02-06T06:00:00.000Z",
     "name": "Día de la Constitución",
     "type": "public",
-    "rule": "02-05",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2029-02-05 00:00:00",
-    "start": "2029-02-05T06:00:00.000Z",
-    "end": "2029-02-06T06:00:00.000Z",
-    "name": "Día de la Constitución (día libre)",
-    "type": "public",
     "rule": "1st monday in February",
     "_weekday": "Mon"
   },
@@ -30,19 +21,10 @@
     "date": "2029-03-19 00:00:00",
     "start": "2029-03-19T06:00:00.000Z",
     "end": "2029-03-20T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez (día libre)",
+    "name": "Natalicio de Benito Juárez",
     "type": "public",
     "rule": "3rd monday in March",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2029-03-21 00:00:00",
-    "start": "2029-03-21T06:00:00.000Z",
-    "end": "2029-03-22T06:00:00.000Z",
-    "name": "Natalicio de Benito Juárez",
-    "type": "public",
-    "rule": "03-21",
-    "_weekday": "Wed"
   },
   {
     "date": "2029-03-29 00:00:00",
@@ -102,19 +84,10 @@
     "date": "2029-11-19 00:00:00",
     "start": "2029-11-19T06:00:00.000Z",
     "end": "2029-11-20T06:00:00.000Z",
-    "name": "Día de la Revolución (día libre)",
+    "name": "Día de la Revolución",
     "type": "public",
     "rule": "3rd monday in November",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2029-11-20 00:00:00",
-    "start": "2029-11-20T06:00:00.000Z",
-    "end": "2029-11-21T06:00:00.000Z",
-    "name": "Día de la Revolución",
-    "type": "public",
-    "rule": "11-20",
-    "_weekday": "Tue"
   },
   {
     "date": "2029-12-12 00:00:00",


### PR DESCRIPTION
This pull request addresses inaccuracies in the definitions for three Mexican holidays: Constitution Day, Benito Juárez's Birthday, and Revolution Day. The original historical dates and the shifted observed dates (the Monday off) were both defined without year restrictions, leading to the potential for the same holiday to be counted *twice* in a single year.

This PR updates the definitions to accurately reflect when each date was valid, ensuring the library provides correct results for both historical and modern holiday calculations. Each definition now includes year information to specify its validity period.

According to the government document "[Ley Federal del Trabajo](https://www.gob.mx/cms/uploads/attachment/file/156203/1044_Ley_Federal_del_Trabajo.pdf)", the legal change shifting these holidays to Mondays occurred in 2006. However, the document specifically notes that, for the commemoration of Benito Juárez's birthday in 2006, the change would not take effect until 2007. Therefore, only Benito Juárez's birthday's Monday shift was delayed. Constitution Day and Revolution Day shifted in 2006.
