### PR TITLE
ci: add workflow_dispatch trigger to run CI on any commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag, or commit SHA to checkout (optional)'
+        required: false
 
 env:
   CI: "true"
@@ -21,10 +26,11 @@ jobs:
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
       - name: Setup Node ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - run: npm install --ignore-scripts
       - run: npm run ci
-


### PR DESCRIPTION
This PR introduces manual triggering for the CI workflow via a "Run workflow" button (using the `workflow_dispatch` event) on the Actions > CI page.

<img width="329" alt="image" src="https://github.com/user-attachments/assets/651d5641-ce9c-45b0-abbb-5494b530c4b4" />

**Benefits:**

*   **For Contributors:** Allows running the CI pipeline on their forked repositories *before* submitting a pull request, enabling them to catch and fix errors early.
*   **For Maintainers:** Reduces the number of pull requests with failing CI, saving time and effort.



