### PR TITLE
Add rome holiday 06 29 Saint Peter's and Paul

### DIFF
--- a/data/countries/IT.yaml
+++ b/data/countries/IT.yaml
@@ -228,17 +228,24 @@ holidays:
       #       name: Macerata
       #     PU:
       #       name: Pesaro and Urbino
-      # '62':
-      #   name: Lazio
-      #   regions:
+      '62':
+        name: Lazio
+        regions:
       #     FR:
       #       name: Frosinone
       #     LT:
       #       name: Latina
       #     RI:
       #       name: Rieti
-      #     RM:
-      #       name: Rome
+          RM:
+            names:
+              it: Roma
+              en: Rome
+            days:
+              06-29:
+                name:
+                  it: Santi Pietro e Paolo
+                  en: Saints Peter and Paul
       #     VT:
       #       name: Viterbo
       # '65':

--- a/test/fixtures/IT-62-2015.json
+++ b/test/fixtures/IT-62-2015.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2014-12-31T23:00:00.000Z",
+    "end": "2015-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-06 00:00:00",
+    "start": "2015-01-05T23:00:00.000Z",
+    "end": "2015-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-04-05 00:00:00",
+    "start": "2015-04-04T22:00:00.000Z",
+    "end": "2015-04-05T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-04-06 00:00:00",
+    "start": "2015-04-05T22:00:00.000Z",
+    "end": "2015-04-06T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T22:00:00.000Z",
+    "end": "2015-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-04-30T22:00:00.000Z",
+    "end": "2015-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T22:00:00.000Z",
+    "end": "2015-05-10T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-02 00:00:00",
+    "start": "2015-06-01T22:00:00.000Z",
+    "end": "2015-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-08-15 00:00:00",
+    "start": "2015-08-14T22:00:00.000Z",
+    "end": "2015-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-10-31T23:00:00.000Z",
+    "end": "2015-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-08 00:00:00",
+    "start": "2015-12-07T23:00:00.000Z",
+    "end": "2015-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-24T23:00:00.000Z",
+    "end": "2015-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-12-26 00:00:00",
+    "start": "2015-12-25T23:00:00.000Z",
+    "end": "2015-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/IT-62-2016.json
+++ b/test/fixtures/IT-62-2016.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2015-12-31T23:00:00.000Z",
+    "end": "2016-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-06 00:00:00",
+    "start": "2016-01-05T23:00:00.000Z",
+    "end": "2016-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-27 00:00:00",
+    "start": "2016-03-26T23:00:00.000Z",
+    "end": "2016-03-27T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-03-28 00:00:00",
+    "start": "2016-03-27T22:00:00.000Z",
+    "end": "2016-03-28T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-04-25 00:00:00",
+    "start": "2016-04-24T22:00:00.000Z",
+    "end": "2016-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-04-30T22:00:00.000Z",
+    "end": "2016-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T22:00:00.000Z",
+    "end": "2016-05-08T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-06-02 00:00:00",
+    "start": "2016-06-01T22:00:00.000Z",
+    "end": "2016-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-08-15 00:00:00",
+    "start": "2016-08-14T22:00:00.000Z",
+    "end": "2016-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-10-31T23:00:00.000Z",
+    "end": "2016-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-12-08 00:00:00",
+    "start": "2016-12-07T23:00:00.000Z",
+    "end": "2016-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-24T23:00:00.000Z",
+    "end": "2016-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-25T23:00:00.000Z",
+    "end": "2016-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/IT-62-2017.json
+++ b/test/fixtures/IT-62-2017.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2016-12-31T23:00:00.000Z",
+    "end": "2017-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-06 00:00:00",
+    "start": "2017-01-05T23:00:00.000Z",
+    "end": "2017-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-04-16 00:00:00",
+    "start": "2017-04-15T22:00:00.000Z",
+    "end": "2017-04-16T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-04-17 00:00:00",
+    "start": "2017-04-16T22:00:00.000Z",
+    "end": "2017-04-17T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-04-25 00:00:00",
+    "start": "2017-04-24T22:00:00.000Z",
+    "end": "2017-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-04-30T22:00:00.000Z",
+    "end": "2017-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T22:00:00.000Z",
+    "end": "2017-05-14T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-06-02 00:00:00",
+    "start": "2017-06-01T22:00:00.000Z",
+    "end": "2017-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-08-15 00:00:00",
+    "start": "2017-08-14T22:00:00.000Z",
+    "end": "2017-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-10-31T23:00:00.000Z",
+    "end": "2017-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-12-08 00:00:00",
+    "start": "2017-12-07T23:00:00.000Z",
+    "end": "2017-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-24T23:00:00.000Z",
+    "end": "2017-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-12-26 00:00:00",
+    "start": "2017-12-25T23:00:00.000Z",
+    "end": "2017-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/IT-62-2018.json
+++ b/test/fixtures/IT-62-2018.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2017-12-31T23:00:00.000Z",
+    "end": "2018-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-06 00:00:00",
+    "start": "2018-01-05T23:00:00.000Z",
+    "end": "2018-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-04-01 00:00:00",
+    "start": "2018-03-31T22:00:00.000Z",
+    "end": "2018-04-01T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-04-02 00:00:00",
+    "start": "2018-04-01T22:00:00.000Z",
+    "end": "2018-04-02T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-04-25 00:00:00",
+    "start": "2018-04-24T22:00:00.000Z",
+    "end": "2018-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-04-30T22:00:00.000Z",
+    "end": "2018-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T22:00:00.000Z",
+    "end": "2018-05-13T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-06-02 00:00:00",
+    "start": "2018-06-01T22:00:00.000Z",
+    "end": "2018-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-08-15 00:00:00",
+    "start": "2018-08-14T22:00:00.000Z",
+    "end": "2018-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-10-31T23:00:00.000Z",
+    "end": "2018-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-12-08 00:00:00",
+    "start": "2018-12-07T23:00:00.000Z",
+    "end": "2018-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-24T23:00:00.000Z",
+    "end": "2018-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-12-26 00:00:00",
+    "start": "2018-12-25T23:00:00.000Z",
+    "end": "2018-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/IT-62-2019.json
+++ b/test/fixtures/IT-62-2019.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2018-12-31T23:00:00.000Z",
+    "end": "2019-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-06 00:00:00",
+    "start": "2019-01-05T23:00:00.000Z",
+    "end": "2019-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-04-21 00:00:00",
+    "start": "2019-04-20T22:00:00.000Z",
+    "end": "2019-04-21T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-04-22 00:00:00",
+    "start": "2019-04-21T22:00:00.000Z",
+    "end": "2019-04-22T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-04-25 00:00:00",
+    "start": "2019-04-24T22:00:00.000Z",
+    "end": "2019-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-04-30T22:00:00.000Z",
+    "end": "2019-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T22:00:00.000Z",
+    "end": "2019-05-12T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-06-02 00:00:00",
+    "start": "2019-06-01T22:00:00.000Z",
+    "end": "2019-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-08-15 00:00:00",
+    "start": "2019-08-14T22:00:00.000Z",
+    "end": "2019-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-10-31T23:00:00.000Z",
+    "end": "2019-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-12-08 00:00:00",
+    "start": "2019-12-07T23:00:00.000Z",
+    "end": "2019-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-24T23:00:00.000Z",
+    "end": "2019-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-12-26 00:00:00",
+    "start": "2019-12-25T23:00:00.000Z",
+    "end": "2019-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/IT-62-2020.json
+++ b/test/fixtures/IT-62-2020.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2019-12-31T23:00:00.000Z",
+    "end": "2020-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-06 00:00:00",
+    "start": "2020-01-05T23:00:00.000Z",
+    "end": "2020-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-11T22:00:00.000Z",
+    "end": "2020-04-12T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-04-13 00:00:00",
+    "start": "2020-04-12T22:00:00.000Z",
+    "end": "2020-04-13T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T22:00:00.000Z",
+    "end": "2020-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-04-30T22:00:00.000Z",
+    "end": "2020-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T22:00:00.000Z",
+    "end": "2020-05-10T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-02 00:00:00",
+    "start": "2020-06-01T22:00:00.000Z",
+    "end": "2020-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-08-15 00:00:00",
+    "start": "2020-08-14T22:00:00.000Z",
+    "end": "2020-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-10-31T23:00:00.000Z",
+    "end": "2020-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-08 00:00:00",
+    "start": "2020-12-07T23:00:00.000Z",
+    "end": "2020-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-24T23:00:00.000Z",
+    "end": "2020-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-12-26 00:00:00",
+    "start": "2020-12-25T23:00:00.000Z",
+    "end": "2020-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/IT-62-2021.json
+++ b/test/fixtures/IT-62-2021.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2020-12-31T23:00:00.000Z",
+    "end": "2021-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-06 00:00:00",
+    "start": "2021-01-05T23:00:00.000Z",
+    "end": "2021-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-04-04 00:00:00",
+    "start": "2021-04-03T22:00:00.000Z",
+    "end": "2021-04-04T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-04-05 00:00:00",
+    "start": "2021-04-04T22:00:00.000Z",
+    "end": "2021-04-05T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-04-25 00:00:00",
+    "start": "2021-04-24T22:00:00.000Z",
+    "end": "2021-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-04-30T22:00:00.000Z",
+    "end": "2021-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T22:00:00.000Z",
+    "end": "2021-05-09T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-02 00:00:00",
+    "start": "2021-06-01T22:00:00.000Z",
+    "end": "2021-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-08-15 00:00:00",
+    "start": "2021-08-14T22:00:00.000Z",
+    "end": "2021-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-10-31T23:00:00.000Z",
+    "end": "2021-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-12-08 00:00:00",
+    "start": "2021-12-07T23:00:00.000Z",
+    "end": "2021-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-24T23:00:00.000Z",
+    "end": "2021-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-12-26 00:00:00",
+    "start": "2021-12-25T23:00:00.000Z",
+    "end": "2021-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/IT-62-2022.json
+++ b/test/fixtures/IT-62-2022.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2021-12-31T23:00:00.000Z",
+    "end": "2022-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-06 00:00:00",
+    "start": "2022-01-05T23:00:00.000Z",
+    "end": "2022-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-17 00:00:00",
+    "start": "2022-04-16T22:00:00.000Z",
+    "end": "2022-04-17T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-04-18 00:00:00",
+    "start": "2022-04-17T22:00:00.000Z",
+    "end": "2022-04-18T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-04-25 00:00:00",
+    "start": "2022-04-24T22:00:00.000Z",
+    "end": "2022-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-04-30T22:00:00.000Z",
+    "end": "2022-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T22:00:00.000Z",
+    "end": "2022-05-08T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-06-02 00:00:00",
+    "start": "2022-06-01T22:00:00.000Z",
+    "end": "2022-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-08-15 00:00:00",
+    "start": "2022-08-14T22:00:00.000Z",
+    "end": "2022-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-10-31T23:00:00.000Z",
+    "end": "2022-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-12-08 00:00:00",
+    "start": "2022-12-07T23:00:00.000Z",
+    "end": "2022-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-24T23:00:00.000Z",
+    "end": "2022-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-25T23:00:00.000Z",
+    "end": "2022-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/IT-62-2023.json
+++ b/test/fixtures/IT-62-2023.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2022-12-31T23:00:00.000Z",
+    "end": "2023-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-06 00:00:00",
+    "start": "2023-01-05T23:00:00.000Z",
+    "end": "2023-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-09 00:00:00",
+    "start": "2023-04-08T22:00:00.000Z",
+    "end": "2023-04-09T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-04-10 00:00:00",
+    "start": "2023-04-09T22:00:00.000Z",
+    "end": "2023-04-10T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-04-25 00:00:00",
+    "start": "2023-04-24T22:00:00.000Z",
+    "end": "2023-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-04-30T22:00:00.000Z",
+    "end": "2023-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T22:00:00.000Z",
+    "end": "2023-05-14T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-06-02 00:00:00",
+    "start": "2023-06-01T22:00:00.000Z",
+    "end": "2023-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-08-15 00:00:00",
+    "start": "2023-08-14T22:00:00.000Z",
+    "end": "2023-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-10-31T23:00:00.000Z",
+    "end": "2023-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-12-08 00:00:00",
+    "start": "2023-12-07T23:00:00.000Z",
+    "end": "2023-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-24T23:00:00.000Z",
+    "end": "2023-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-12-26 00:00:00",
+    "start": "2023-12-25T23:00:00.000Z",
+    "end": "2023-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/IT-62-2024.json
+++ b/test/fixtures/IT-62-2024.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2023-12-31T23:00:00.000Z",
+    "end": "2024-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-06 00:00:00",
+    "start": "2024-01-05T23:00:00.000Z",
+    "end": "2024-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-31 00:00:00",
+    "start": "2024-03-30T23:00:00.000Z",
+    "end": "2024-03-31T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-04-01 00:00:00",
+    "start": "2024-03-31T22:00:00.000Z",
+    "end": "2024-04-01T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-04-25 00:00:00",
+    "start": "2024-04-24T22:00:00.000Z",
+    "end": "2024-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-04-30T22:00:00.000Z",
+    "end": "2024-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T22:00:00.000Z",
+    "end": "2024-05-12T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-06-02 00:00:00",
+    "start": "2024-06-01T22:00:00.000Z",
+    "end": "2024-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-08-15 00:00:00",
+    "start": "2024-08-14T22:00:00.000Z",
+    "end": "2024-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-10-31T23:00:00.000Z",
+    "end": "2024-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-12-08 00:00:00",
+    "start": "2024-12-07T23:00:00.000Z",
+    "end": "2024-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-24T23:00:00.000Z",
+    "end": "2024-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-12-26 00:00:00",
+    "start": "2024-12-25T23:00:00.000Z",
+    "end": "2024-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/IT-62-2025.json
+++ b/test/fixtures/IT-62-2025.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2024-12-31T23:00:00.000Z",
+    "end": "2025-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-06 00:00:00",
+    "start": "2025-01-05T23:00:00.000Z",
+    "end": "2025-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-04-20 00:00:00",
+    "start": "2025-04-19T22:00:00.000Z",
+    "end": "2025-04-20T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-21 00:00:00",
+    "start": "2025-04-20T22:00:00.000Z",
+    "end": "2025-04-21T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-04-25 00:00:00",
+    "start": "2025-04-24T22:00:00.000Z",
+    "end": "2025-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-04-30T22:00:00.000Z",
+    "end": "2025-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T22:00:00.000Z",
+    "end": "2025-05-11T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-06-02 00:00:00",
+    "start": "2025-06-01T22:00:00.000Z",
+    "end": "2025-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-08-15 00:00:00",
+    "start": "2025-08-14T22:00:00.000Z",
+    "end": "2025-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-10-31T23:00:00.000Z",
+    "end": "2025-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-12-08 00:00:00",
+    "start": "2025-12-07T23:00:00.000Z",
+    "end": "2025-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-24T23:00:00.000Z",
+    "end": "2025-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-12-26 00:00:00",
+    "start": "2025-12-25T23:00:00.000Z",
+    "end": "2025-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/IT-62-2026.json
+++ b/test/fixtures/IT-62-2026.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2025-12-31T23:00:00.000Z",
+    "end": "2026-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-06 00:00:00",
+    "start": "2026-01-05T23:00:00.000Z",
+    "end": "2026-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-04-05 00:00:00",
+    "start": "2026-04-04T22:00:00.000Z",
+    "end": "2026-04-05T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-04-06 00:00:00",
+    "start": "2026-04-05T22:00:00.000Z",
+    "end": "2026-04-06T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-25 00:00:00",
+    "start": "2026-04-24T22:00:00.000Z",
+    "end": "2026-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-04-30T22:00:00.000Z",
+    "end": "2026-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-10 00:00:00",
+    "start": "2026-05-09T22:00:00.000Z",
+    "end": "2026-05-10T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-02 00:00:00",
+    "start": "2026-06-01T22:00:00.000Z",
+    "end": "2026-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-08-15 00:00:00",
+    "start": "2026-08-14T22:00:00.000Z",
+    "end": "2026-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-10-31T23:00:00.000Z",
+    "end": "2026-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-12-08 00:00:00",
+    "start": "2026-12-07T23:00:00.000Z",
+    "end": "2026-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-24T23:00:00.000Z",
+    "end": "2026-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-12-26 00:00:00",
+    "start": "2026-12-25T23:00:00.000Z",
+    "end": "2026-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/IT-62-2027.json
+++ b/test/fixtures/IT-62-2027.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2026-12-31T23:00:00.000Z",
+    "end": "2027-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-06 00:00:00",
+    "start": "2027-01-05T23:00:00.000Z",
+    "end": "2027-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-03-28 00:00:00",
+    "start": "2027-03-27T23:00:00.000Z",
+    "end": "2027-03-28T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-03-29 00:00:00",
+    "start": "2027-03-28T22:00:00.000Z",
+    "end": "2027-03-29T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-04-25 00:00:00",
+    "start": "2027-04-24T22:00:00.000Z",
+    "end": "2027-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-04-30T22:00:00.000Z",
+    "end": "2027-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-09 00:00:00",
+    "start": "2027-05-08T22:00:00.000Z",
+    "end": "2027-05-09T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-02 00:00:00",
+    "start": "2027-06-01T22:00:00.000Z",
+    "end": "2027-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-08-15 00:00:00",
+    "start": "2027-08-14T22:00:00.000Z",
+    "end": "2027-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-10-31T23:00:00.000Z",
+    "end": "2027-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-12-08 00:00:00",
+    "start": "2027-12-07T23:00:00.000Z",
+    "end": "2027-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-24T23:00:00.000Z",
+    "end": "2027-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-26 00:00:00",
+    "start": "2027-12-25T23:00:00.000Z",
+    "end": "2027-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/IT-62-2028.json
+++ b/test/fixtures/IT-62-2028.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2028-01-01 00:00:00",
+    "start": "2027-12-31T23:00:00.000Z",
+    "end": "2028-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-01-06 00:00:00",
+    "start": "2028-01-05T23:00:00.000Z",
+    "end": "2028-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-04-16 00:00:00",
+    "start": "2028-04-15T22:00:00.000Z",
+    "end": "2028-04-16T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-04-17 00:00:00",
+    "start": "2028-04-16T22:00:00.000Z",
+    "end": "2028-04-17T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-04-25 00:00:00",
+    "start": "2028-04-24T22:00:00.000Z",
+    "end": "2028-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-05-01 00:00:00",
+    "start": "2028-04-30T22:00:00.000Z",
+    "end": "2028-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-05-14 00:00:00",
+    "start": "2028-05-13T22:00:00.000Z",
+    "end": "2028-05-14T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-06-02 00:00:00",
+    "start": "2028-06-01T22:00:00.000Z",
+    "end": "2028-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2028-08-15 00:00:00",
+    "start": "2028-08-14T22:00:00.000Z",
+    "end": "2028-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-11-01 00:00:00",
+    "start": "2028-10-31T23:00:00.000Z",
+    "end": "2028-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-12-08 00:00:00",
+    "start": "2028-12-07T23:00:00.000Z",
+    "end": "2028-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2028-12-25 00:00:00",
+    "start": "2028-12-24T23:00:00.000Z",
+    "end": "2028-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-12-26 00:00:00",
+    "start": "2028-12-25T23:00:00.000Z",
+    "end": "2028-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/IT-62-2029.json
+++ b/test/fixtures/IT-62-2029.json
@@ -1,0 +1,119 @@
+[
+  {
+    "date": "2029-01-01 00:00:00",
+    "start": "2028-12-31T23:00:00.000Z",
+    "end": "2029-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-01-06 00:00:00",
+    "start": "2029-01-05T23:00:00.000Z",
+    "end": "2029-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-04-01 00:00:00",
+    "start": "2029-03-31T22:00:00.000Z",
+    "end": "2029-04-01T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-04-02 00:00:00",
+    "start": "2029-04-01T22:00:00.000Z",
+    "end": "2029-04-02T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-04-25 00:00:00",
+    "start": "2029-04-24T22:00:00.000Z",
+    "end": "2029-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2029-05-01 00:00:00",
+    "start": "2029-04-30T22:00:00.000Z",
+    "end": "2029-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-05-13 00:00:00",
+    "start": "2029-05-12T22:00:00.000Z",
+    "end": "2029-05-13T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-06-02 00:00:00",
+    "start": "2029-06-01T22:00:00.000Z",
+    "end": "2029-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-08-15 00:00:00",
+    "start": "2029-08-14T22:00:00.000Z",
+    "end": "2029-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2029-11-01 00:00:00",
+    "start": "2029-10-31T23:00:00.000Z",
+    "end": "2029-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-12-08 00:00:00",
+    "start": "2029-12-07T23:00:00.000Z",
+    "end": "2029-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-12-25 00:00:00",
+    "start": "2029-12-24T23:00:00.000Z",
+    "end": "2029-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-12-26 00:00:00",
+    "start": "2029-12-25T23:00:00.000Z",
+    "end": "2029-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/IT-62-RM-2015.json
+++ b/test/fixtures/IT-62-RM-2015.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2014-12-31T23:00:00.000Z",
+    "end": "2015-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-01-06 00:00:00",
+    "start": "2015-01-05T23:00:00.000Z",
+    "end": "2015-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-04-05 00:00:00",
+    "start": "2015-04-04T22:00:00.000Z",
+    "end": "2015-04-05T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-04-06 00:00:00",
+    "start": "2015-04-05T22:00:00.000Z",
+    "end": "2015-04-06T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-25 00:00:00",
+    "start": "2015-04-24T22:00:00.000Z",
+    "end": "2015-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-04-30T22:00:00.000Z",
+    "end": "2015-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-09T22:00:00.000Z",
+    "end": "2015-05-10T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-02 00:00:00",
+    "start": "2015-06-01T22:00:00.000Z",
+    "end": "2015-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-06-29 00:00:00",
+    "start": "2015-06-28T22:00:00.000Z",
+    "end": "2015-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-15 00:00:00",
+    "start": "2015-08-14T22:00:00.000Z",
+    "end": "2015-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-11-01 00:00:00",
+    "start": "2015-10-31T23:00:00.000Z",
+    "end": "2015-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-08 00:00:00",
+    "start": "2015-12-07T23:00:00.000Z",
+    "end": "2015-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-24T23:00:00.000Z",
+    "end": "2015-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-12-26 00:00:00",
+    "start": "2015-12-25T23:00:00.000Z",
+    "end": "2015-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/IT-62-RM-2016.json
+++ b/test/fixtures/IT-62-RM-2016.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2015-12-31T23:00:00.000Z",
+    "end": "2016-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-01-06 00:00:00",
+    "start": "2016-01-05T23:00:00.000Z",
+    "end": "2016-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-27 00:00:00",
+    "start": "2016-03-26T23:00:00.000Z",
+    "end": "2016-03-27T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-03-28 00:00:00",
+    "start": "2016-03-27T22:00:00.000Z",
+    "end": "2016-03-28T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-04-25 00:00:00",
+    "start": "2016-04-24T22:00:00.000Z",
+    "end": "2016-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-04-30T22:00:00.000Z",
+    "end": "2016-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-07T22:00:00.000Z",
+    "end": "2016-05-08T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-06-02 00:00:00",
+    "start": "2016-06-01T22:00:00.000Z",
+    "end": "2016-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-06-29 00:00:00",
+    "start": "2016-06-28T22:00:00.000Z",
+    "end": "2016-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-08-15 00:00:00",
+    "start": "2016-08-14T22:00:00.000Z",
+    "end": "2016-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-11-01 00:00:00",
+    "start": "2016-10-31T23:00:00.000Z",
+    "end": "2016-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-12-08 00:00:00",
+    "start": "2016-12-07T23:00:00.000Z",
+    "end": "2016-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-24T23:00:00.000Z",
+    "end": "2016-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-26 00:00:00",
+    "start": "2016-12-25T23:00:00.000Z",
+    "end": "2016-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/IT-62-RM-2017.json
+++ b/test/fixtures/IT-62-RM-2017.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2016-12-31T23:00:00.000Z",
+    "end": "2017-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-01-06 00:00:00",
+    "start": "2017-01-05T23:00:00.000Z",
+    "end": "2017-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-04-16 00:00:00",
+    "start": "2017-04-15T22:00:00.000Z",
+    "end": "2017-04-16T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-04-17 00:00:00",
+    "start": "2017-04-16T22:00:00.000Z",
+    "end": "2017-04-17T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-04-25 00:00:00",
+    "start": "2017-04-24T22:00:00.000Z",
+    "end": "2017-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-04-30T22:00:00.000Z",
+    "end": "2017-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-13T22:00:00.000Z",
+    "end": "2017-05-14T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-06-02 00:00:00",
+    "start": "2017-06-01T22:00:00.000Z",
+    "end": "2017-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-06-29 00:00:00",
+    "start": "2017-06-28T22:00:00.000Z",
+    "end": "2017-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-08-15 00:00:00",
+    "start": "2017-08-14T22:00:00.000Z",
+    "end": "2017-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-11-01 00:00:00",
+    "start": "2017-10-31T23:00:00.000Z",
+    "end": "2017-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-12-08 00:00:00",
+    "start": "2017-12-07T23:00:00.000Z",
+    "end": "2017-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-24T23:00:00.000Z",
+    "end": "2017-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-12-26 00:00:00",
+    "start": "2017-12-25T23:00:00.000Z",
+    "end": "2017-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/IT-62-RM-2018.json
+++ b/test/fixtures/IT-62-RM-2018.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2017-12-31T23:00:00.000Z",
+    "end": "2018-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-01-06 00:00:00",
+    "start": "2018-01-05T23:00:00.000Z",
+    "end": "2018-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-04-01 00:00:00",
+    "start": "2018-03-31T22:00:00.000Z",
+    "end": "2018-04-01T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-04-02 00:00:00",
+    "start": "2018-04-01T22:00:00.000Z",
+    "end": "2018-04-02T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-04-25 00:00:00",
+    "start": "2018-04-24T22:00:00.000Z",
+    "end": "2018-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-04-30T22:00:00.000Z",
+    "end": "2018-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-12T22:00:00.000Z",
+    "end": "2018-05-13T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-06-02 00:00:00",
+    "start": "2018-06-01T22:00:00.000Z",
+    "end": "2018-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-06-29 00:00:00",
+    "start": "2018-06-28T22:00:00.000Z",
+    "end": "2018-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-08-15 00:00:00",
+    "start": "2018-08-14T22:00:00.000Z",
+    "end": "2018-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-11-01 00:00:00",
+    "start": "2018-10-31T23:00:00.000Z",
+    "end": "2018-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-12-08 00:00:00",
+    "start": "2018-12-07T23:00:00.000Z",
+    "end": "2018-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-24T23:00:00.000Z",
+    "end": "2018-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-12-26 00:00:00",
+    "start": "2018-12-25T23:00:00.000Z",
+    "end": "2018-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/IT-62-RM-2019.json
+++ b/test/fixtures/IT-62-RM-2019.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2018-12-31T23:00:00.000Z",
+    "end": "2019-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-01-06 00:00:00",
+    "start": "2019-01-05T23:00:00.000Z",
+    "end": "2019-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-04-21 00:00:00",
+    "start": "2019-04-20T22:00:00.000Z",
+    "end": "2019-04-21T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-04-22 00:00:00",
+    "start": "2019-04-21T22:00:00.000Z",
+    "end": "2019-04-22T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-04-25 00:00:00",
+    "start": "2019-04-24T22:00:00.000Z",
+    "end": "2019-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-04-30T22:00:00.000Z",
+    "end": "2019-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-11T22:00:00.000Z",
+    "end": "2019-05-12T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-06-02 00:00:00",
+    "start": "2019-06-01T22:00:00.000Z",
+    "end": "2019-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-06-29 00:00:00",
+    "start": "2019-06-28T22:00:00.000Z",
+    "end": "2019-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-08-15 00:00:00",
+    "start": "2019-08-14T22:00:00.000Z",
+    "end": "2019-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-11-01 00:00:00",
+    "start": "2019-10-31T23:00:00.000Z",
+    "end": "2019-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-12-08 00:00:00",
+    "start": "2019-12-07T23:00:00.000Z",
+    "end": "2019-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-24T23:00:00.000Z",
+    "end": "2019-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-12-26 00:00:00",
+    "start": "2019-12-25T23:00:00.000Z",
+    "end": "2019-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/IT-62-RM-2020.json
+++ b/test/fixtures/IT-62-RM-2020.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2019-12-31T23:00:00.000Z",
+    "end": "2020-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-01-06 00:00:00",
+    "start": "2020-01-05T23:00:00.000Z",
+    "end": "2020-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-11T22:00:00.000Z",
+    "end": "2020-04-12T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-04-13 00:00:00",
+    "start": "2020-04-12T22:00:00.000Z",
+    "end": "2020-04-13T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-25 00:00:00",
+    "start": "2020-04-24T22:00:00.000Z",
+    "end": "2020-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-04-30T22:00:00.000Z",
+    "end": "2020-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-09T22:00:00.000Z",
+    "end": "2020-05-10T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-02 00:00:00",
+    "start": "2020-06-01T22:00:00.000Z",
+    "end": "2020-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-06-29 00:00:00",
+    "start": "2020-06-28T22:00:00.000Z",
+    "end": "2020-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-15 00:00:00",
+    "start": "2020-08-14T22:00:00.000Z",
+    "end": "2020-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-11-01 00:00:00",
+    "start": "2020-10-31T23:00:00.000Z",
+    "end": "2020-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-08 00:00:00",
+    "start": "2020-12-07T23:00:00.000Z",
+    "end": "2020-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-24T23:00:00.000Z",
+    "end": "2020-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-12-26 00:00:00",
+    "start": "2020-12-25T23:00:00.000Z",
+    "end": "2020-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/IT-62-RM-2021.json
+++ b/test/fixtures/IT-62-RM-2021.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2020-12-31T23:00:00.000Z",
+    "end": "2021-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-01-06 00:00:00",
+    "start": "2021-01-05T23:00:00.000Z",
+    "end": "2021-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-04-04 00:00:00",
+    "start": "2021-04-03T22:00:00.000Z",
+    "end": "2021-04-04T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-04-05 00:00:00",
+    "start": "2021-04-04T22:00:00.000Z",
+    "end": "2021-04-05T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-04-25 00:00:00",
+    "start": "2021-04-24T22:00:00.000Z",
+    "end": "2021-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-04-30T22:00:00.000Z",
+    "end": "2021-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-08T22:00:00.000Z",
+    "end": "2021-05-09T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-02 00:00:00",
+    "start": "2021-06-01T22:00:00.000Z",
+    "end": "2021-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-06-29 00:00:00",
+    "start": "2021-06-28T22:00:00.000Z",
+    "end": "2021-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-08-15 00:00:00",
+    "start": "2021-08-14T22:00:00.000Z",
+    "end": "2021-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-11-01 00:00:00",
+    "start": "2021-10-31T23:00:00.000Z",
+    "end": "2021-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-12-08 00:00:00",
+    "start": "2021-12-07T23:00:00.000Z",
+    "end": "2021-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-24T23:00:00.000Z",
+    "end": "2021-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-12-26 00:00:00",
+    "start": "2021-12-25T23:00:00.000Z",
+    "end": "2021-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/IT-62-RM-2022.json
+++ b/test/fixtures/IT-62-RM-2022.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2021-12-31T23:00:00.000Z",
+    "end": "2022-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-01-06 00:00:00",
+    "start": "2022-01-05T23:00:00.000Z",
+    "end": "2022-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-17 00:00:00",
+    "start": "2022-04-16T22:00:00.000Z",
+    "end": "2022-04-17T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-04-18 00:00:00",
+    "start": "2022-04-17T22:00:00.000Z",
+    "end": "2022-04-18T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-04-25 00:00:00",
+    "start": "2022-04-24T22:00:00.000Z",
+    "end": "2022-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-04-30T22:00:00.000Z",
+    "end": "2022-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-07T22:00:00.000Z",
+    "end": "2022-05-08T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-06-02 00:00:00",
+    "start": "2022-06-01T22:00:00.000Z",
+    "end": "2022-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-06-29 00:00:00",
+    "start": "2022-06-28T22:00:00.000Z",
+    "end": "2022-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-08-15 00:00:00",
+    "start": "2022-08-14T22:00:00.000Z",
+    "end": "2022-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-11-01 00:00:00",
+    "start": "2022-10-31T23:00:00.000Z",
+    "end": "2022-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-12-08 00:00:00",
+    "start": "2022-12-07T23:00:00.000Z",
+    "end": "2022-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-24T23:00:00.000Z",
+    "end": "2022-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-26 00:00:00",
+    "start": "2022-12-25T23:00:00.000Z",
+    "end": "2022-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/IT-62-RM-2023.json
+++ b/test/fixtures/IT-62-RM-2023.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2022-12-31T23:00:00.000Z",
+    "end": "2023-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-01-06 00:00:00",
+    "start": "2023-01-05T23:00:00.000Z",
+    "end": "2023-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-09 00:00:00",
+    "start": "2023-04-08T22:00:00.000Z",
+    "end": "2023-04-09T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-04-10 00:00:00",
+    "start": "2023-04-09T22:00:00.000Z",
+    "end": "2023-04-10T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-04-25 00:00:00",
+    "start": "2023-04-24T22:00:00.000Z",
+    "end": "2023-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-04-30T22:00:00.000Z",
+    "end": "2023-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-13T22:00:00.000Z",
+    "end": "2023-05-14T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-06-02 00:00:00",
+    "start": "2023-06-01T22:00:00.000Z",
+    "end": "2023-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-06-29 00:00:00",
+    "start": "2023-06-28T22:00:00.000Z",
+    "end": "2023-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-08-15 00:00:00",
+    "start": "2023-08-14T22:00:00.000Z",
+    "end": "2023-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-11-01 00:00:00",
+    "start": "2023-10-31T23:00:00.000Z",
+    "end": "2023-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-12-08 00:00:00",
+    "start": "2023-12-07T23:00:00.000Z",
+    "end": "2023-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-24T23:00:00.000Z",
+    "end": "2023-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-12-26 00:00:00",
+    "start": "2023-12-25T23:00:00.000Z",
+    "end": "2023-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/IT-62-RM-2024.json
+++ b/test/fixtures/IT-62-RM-2024.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2023-12-31T23:00:00.000Z",
+    "end": "2024-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-01-06 00:00:00",
+    "start": "2024-01-05T23:00:00.000Z",
+    "end": "2024-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-03-31 00:00:00",
+    "start": "2024-03-30T23:00:00.000Z",
+    "end": "2024-03-31T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-04-01 00:00:00",
+    "start": "2024-03-31T22:00:00.000Z",
+    "end": "2024-04-01T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-04-25 00:00:00",
+    "start": "2024-04-24T22:00:00.000Z",
+    "end": "2024-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-04-30T22:00:00.000Z",
+    "end": "2024-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-11T22:00:00.000Z",
+    "end": "2024-05-12T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-06-02 00:00:00",
+    "start": "2024-06-01T22:00:00.000Z",
+    "end": "2024-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-06-29 00:00:00",
+    "start": "2024-06-28T22:00:00.000Z",
+    "end": "2024-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-08-15 00:00:00",
+    "start": "2024-08-14T22:00:00.000Z",
+    "end": "2024-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-11-01 00:00:00",
+    "start": "2024-10-31T23:00:00.000Z",
+    "end": "2024-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-12-08 00:00:00",
+    "start": "2024-12-07T23:00:00.000Z",
+    "end": "2024-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-24T23:00:00.000Z",
+    "end": "2024-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-12-26 00:00:00",
+    "start": "2024-12-25T23:00:00.000Z",
+    "end": "2024-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/IT-62-RM-2025.json
+++ b/test/fixtures/IT-62-RM-2025.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2024-12-31T23:00:00.000Z",
+    "end": "2025-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-01-06 00:00:00",
+    "start": "2025-01-05T23:00:00.000Z",
+    "end": "2025-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-04-20 00:00:00",
+    "start": "2025-04-19T22:00:00.000Z",
+    "end": "2025-04-20T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-21 00:00:00",
+    "start": "2025-04-20T22:00:00.000Z",
+    "end": "2025-04-21T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-04-25 00:00:00",
+    "start": "2025-04-24T22:00:00.000Z",
+    "end": "2025-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-04-30T22:00:00.000Z",
+    "end": "2025-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-10T22:00:00.000Z",
+    "end": "2025-05-11T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-06-02 00:00:00",
+    "start": "2025-06-01T22:00:00.000Z",
+    "end": "2025-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-06-29 00:00:00",
+    "start": "2025-06-28T22:00:00.000Z",
+    "end": "2025-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-08-15 00:00:00",
+    "start": "2025-08-14T22:00:00.000Z",
+    "end": "2025-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-11-01 00:00:00",
+    "start": "2025-10-31T23:00:00.000Z",
+    "end": "2025-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-12-08 00:00:00",
+    "start": "2025-12-07T23:00:00.000Z",
+    "end": "2025-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-24T23:00:00.000Z",
+    "end": "2025-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-12-26 00:00:00",
+    "start": "2025-12-25T23:00:00.000Z",
+    "end": "2025-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/IT-62-RM-2026.json
+++ b/test/fixtures/IT-62-RM-2026.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2025-12-31T23:00:00.000Z",
+    "end": "2026-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-01-06 00:00:00",
+    "start": "2026-01-05T23:00:00.000Z",
+    "end": "2026-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-04-05 00:00:00",
+    "start": "2026-04-04T22:00:00.000Z",
+    "end": "2026-04-05T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-04-06 00:00:00",
+    "start": "2026-04-05T22:00:00.000Z",
+    "end": "2026-04-06T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-25 00:00:00",
+    "start": "2026-04-24T22:00:00.000Z",
+    "end": "2026-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-04-30T22:00:00.000Z",
+    "end": "2026-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-10 00:00:00",
+    "start": "2026-05-09T22:00:00.000Z",
+    "end": "2026-05-10T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-02 00:00:00",
+    "start": "2026-06-01T22:00:00.000Z",
+    "end": "2026-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-06-29 00:00:00",
+    "start": "2026-06-28T22:00:00.000Z",
+    "end": "2026-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-15 00:00:00",
+    "start": "2026-08-14T22:00:00.000Z",
+    "end": "2026-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-11-01 00:00:00",
+    "start": "2026-10-31T23:00:00.000Z",
+    "end": "2026-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-12-08 00:00:00",
+    "start": "2026-12-07T23:00:00.000Z",
+    "end": "2026-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-24T23:00:00.000Z",
+    "end": "2026-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-12-26 00:00:00",
+    "start": "2026-12-25T23:00:00.000Z",
+    "end": "2026-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/IT-62-RM-2027.json
+++ b/test/fixtures/IT-62-RM-2027.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2026-12-31T23:00:00.000Z",
+    "end": "2027-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-01-06 00:00:00",
+    "start": "2027-01-05T23:00:00.000Z",
+    "end": "2027-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-03-28 00:00:00",
+    "start": "2027-03-27T23:00:00.000Z",
+    "end": "2027-03-28T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-03-29 00:00:00",
+    "start": "2027-03-28T22:00:00.000Z",
+    "end": "2027-03-29T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-04-25 00:00:00",
+    "start": "2027-04-24T22:00:00.000Z",
+    "end": "2027-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-04-30T22:00:00.000Z",
+    "end": "2027-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-09 00:00:00",
+    "start": "2027-05-08T22:00:00.000Z",
+    "end": "2027-05-09T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-06-02 00:00:00",
+    "start": "2027-06-01T22:00:00.000Z",
+    "end": "2027-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-06-29 00:00:00",
+    "start": "2027-06-28T22:00:00.000Z",
+    "end": "2027-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-08-15 00:00:00",
+    "start": "2027-08-14T22:00:00.000Z",
+    "end": "2027-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-11-01 00:00:00",
+    "start": "2027-10-31T23:00:00.000Z",
+    "end": "2027-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-12-08 00:00:00",
+    "start": "2027-12-07T23:00:00.000Z",
+    "end": "2027-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-24T23:00:00.000Z",
+    "end": "2027-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-26 00:00:00",
+    "start": "2027-12-25T23:00:00.000Z",
+    "end": "2027-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/IT-62-RM-2028.json
+++ b/test/fixtures/IT-62-RM-2028.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2028-01-01 00:00:00",
+    "start": "2027-12-31T23:00:00.000Z",
+    "end": "2028-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-01-06 00:00:00",
+    "start": "2028-01-05T23:00:00.000Z",
+    "end": "2028-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-04-16 00:00:00",
+    "start": "2028-04-15T22:00:00.000Z",
+    "end": "2028-04-16T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-04-17 00:00:00",
+    "start": "2028-04-16T22:00:00.000Z",
+    "end": "2028-04-17T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-04-25 00:00:00",
+    "start": "2028-04-24T22:00:00.000Z",
+    "end": "2028-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-05-01 00:00:00",
+    "start": "2028-04-30T22:00:00.000Z",
+    "end": "2028-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-05-14 00:00:00",
+    "start": "2028-05-13T22:00:00.000Z",
+    "end": "2028-05-14T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-06-02 00:00:00",
+    "start": "2028-06-01T22:00:00.000Z",
+    "end": "2028-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2028-06-29 00:00:00",
+    "start": "2028-06-28T22:00:00.000Z",
+    "end": "2028-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-08-15 00:00:00",
+    "start": "2028-08-14T22:00:00.000Z",
+    "end": "2028-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-11-01 00:00:00",
+    "start": "2028-10-31T23:00:00.000Z",
+    "end": "2028-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-12-08 00:00:00",
+    "start": "2028-12-07T23:00:00.000Z",
+    "end": "2028-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2028-12-25 00:00:00",
+    "start": "2028-12-24T23:00:00.000Z",
+    "end": "2028-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-12-26 00:00:00",
+    "start": "2028-12-25T23:00:00.000Z",
+    "end": "2028-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/IT-62-RM-2029.json
+++ b/test/fixtures/IT-62-RM-2029.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2029-01-01 00:00:00",
+    "start": "2028-12-31T23:00:00.000Z",
+    "end": "2029-01-01T23:00:00.000Z",
+    "name": "Capodanno",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-01-06 00:00:00",
+    "start": "2029-01-05T23:00:00.000Z",
+    "end": "2029-01-06T23:00:00.000Z",
+    "name": "Befana",
+    "type": "public",
+    "rule": "01-06",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-04-01 00:00:00",
+    "start": "2029-03-31T22:00:00.000Z",
+    "end": "2029-04-01T22:00:00.000Z",
+    "name": "Domenica di Pasqua",
+    "type": "public",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-04-02 00:00:00",
+    "start": "2029-04-01T22:00:00.000Z",
+    "end": "2029-04-02T22:00:00.000Z",
+    "name": "Lunedì dell’Angelo",
+    "type": "public",
+    "rule": "easter 1",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-04-25 00:00:00",
+    "start": "2029-04-24T22:00:00.000Z",
+    "end": "2029-04-25T22:00:00.000Z",
+    "name": "Anniversario della Liberazione",
+    "type": "public",
+    "rule": "04-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2029-05-01 00:00:00",
+    "start": "2029-04-30T22:00:00.000Z",
+    "end": "2029-05-01T22:00:00.000Z",
+    "name": "Festa del Lavoro",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-05-13 00:00:00",
+    "start": "2029-05-12T22:00:00.000Z",
+    "end": "2029-05-13T22:00:00.000Z",
+    "name": "Festa della mamma",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-06-02 00:00:00",
+    "start": "2029-06-01T22:00:00.000Z",
+    "end": "2029-06-02T22:00:00.000Z",
+    "name": "Festa della Repubblica",
+    "type": "public",
+    "rule": "06-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-06-29 00:00:00",
+    "start": "2029-06-28T22:00:00.000Z",
+    "end": "2029-06-29T22:00:00.000Z",
+    "name": "Santi Pietro e Paolo",
+    "type": "public",
+    "rule": "06-29",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-08-15 00:00:00",
+    "start": "2029-08-14T22:00:00.000Z",
+    "end": "2029-08-15T22:00:00.000Z",
+    "name": "Ferragosto",
+    "type": "public",
+    "rule": "08-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2029-11-01 00:00:00",
+    "start": "2029-10-31T23:00:00.000Z",
+    "end": "2029-11-01T23:00:00.000Z",
+    "name": "Ognissanti",
+    "type": "public",
+    "rule": "11-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-12-08 00:00:00",
+    "start": "2029-12-07T23:00:00.000Z",
+    "end": "2029-12-08T23:00:00.000Z",
+    "name": "Immacolata Concezione",
+    "type": "public",
+    "rule": "12-08",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-12-25 00:00:00",
+    "start": "2029-12-24T23:00:00.000Z",
+    "end": "2029-12-25T23:00:00.000Z",
+    "name": "Natale",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-12-26 00:00:00",
+    "start": "2029-12-25T23:00:00.000Z",
+    "end": "2029-12-26T23:00:00.000Z",
+    "name": "Santo Stefano",
+    "type": "public",
+    "rule": "12-26",
+    "_weekday": "Wed"
+  }
+]


### PR DESCRIPTION
Hi i've added and holiday exclusively for Rome it is Saint Peter's and Paul, it's a respected holiday between companies in Rome.
I've also generated fixtures for Rome and Italy since the tests were failing.

Here's the Wikipedia page for the holiday,
https://en.wikipedia.org/wiki/Feast_of_Saints_Peter_and_Paul