### PR TITLE
feat(AR): Update Argentine holiday data comprehensively (1976-2025)

### DIFF
--- a/data/countries/AR.yaml
+++ b/data/countries/AR.yaml
@@ -25,94 +25,400 @@ holidays:
     days:
       01-01:
         _name: 01-01
-      substitutes 01-01 if tuesday then previous monday if thursday then next friday:
-        _name: Bridge Day
-        disable:
-          - 2015
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-26840-207258/texto
+      '2013-01-31':
+        name:
+          en: Bicentennial of the Assembly of the Year XIII
+          es: Bicentenario de la Asamblea General Constituyente de 1813
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-26837-207405/texto
+      '2013-02-20':
+        name:
+          en: Bicentennial of the Battle of Salta
+          es: Bicentenario de la Batalla de Salta
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-26721-191835/texto
+      '2012-02-27':
+        name:
+          en: Bicentennial of the Creation and First Oath of Allegiance to the Argentine Flag
+          es: Bicentenario de la creación y primera jura de la bandera argentina
+      # Abolished in 1976
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-21329-65453/texto
+      # Reintroduced in 2010
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-1584-2010-174389/texto
       easter -48:
         _name: easter -48
+        active:
+          - to: '1976-06-14'
+          - from: '2010-11-03'
       easter -47:
         _name: easter -47
+        active:
+          - to: '1976-06-14'
+          - from: '2010-11-03'
+      # Introduced in 2006
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-26085-114811/texto
       03-24:
         name:
           en: Day of Remembrance for Truth and Justice
-          es: Día de la Memoria por la Verdad y la Justicia
-      substitutes 03-24 if tuesday then previous monday if thursday then next friday:
-        _name: Bridge Day
-      "2020-03-30":
-        _name: Bridge Day
+          es: Día Nacional de la Memoria por la Verdad y la Justicia
+        active:
+          - from: '2006-03-21'
       easter -3:
         _name: easter -3
+        type: bank
       easter -2:
         _name: easter -2
+      # Introduced in 1983
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-22769-65454/texto
+      # Holiday moved to 06-10 in 1984
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-901-1984-65455
+      '1983-04-02':
+        name:
+          en: Day of the Malvinas, South Georgia and South Sandwich Islands
+          es: Día de las Islas Malvinas, Georgias del Sur y Sandwich del Sur
+      # Introduced in 2000
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-25370-65442/texto
+      04-02 if tuesday,wednesday then previous monday if thursday,friday then next monday:
+        name:
+          en: Day of the Veterans and the Fallen in the Malvinas War
+          es: Día del Veterano y de los Caídos en la guerra en Malvinas
+        active:
+          - from: '2000-12-22'
+            to: '2006-06-30'
+      # Holiday name changed in 2006.
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-26110-117507/texto
       04-02:
         name:
-          en: Day of the veterans and the fallen in Malvinas War
+          en: Day of the Veterans and the Fallen in the Malvinas War
           es: Día del Veterano y de los Caídos en la Guerra de Malvinas
-      substitutes 04-02 if tuesday then previous monday if thursday then next friday:
-        _name: Bridge Day
+        active:
+          - from: '2006-07-01'
+        disable:
+          - '2020-04-02'
+        enable:
+          # @source https://www.argentina.gob.ar/normativa/nacional/decreto-297-2020-335741/texto
+          - '2020-03-31'
       05-01:
         _name: 05-01
-      substitutes 05-01 if tuesday then previous monday if thursday then next friday:
-        _name: Bridge Day
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-615-2010-166825/texto
+      '2010-05-24':
+        name:
+          en: National Holiday for the Bicentennial of the May Revolution
+          es: Feriado Nacional por el Bicentenario de la Revolución de Mayo
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-42-2022-360018/texto
+      '2022-05-18':
+        name:
+          en: National Census 2022
+          es: Censo Nacional 2022
       05-25:
         name:
           en: Day of the First National Government
           es: Primer Gobierno Patrio
-      substitutes 05-25 if tuesday then previous monday if thursday then next friday:
-        _name: Bridge Day
+      # Holiday moved from 04-02 in 1984
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-901-1984-65455
+      06-10:
+        name:
+          en: Day of Affirmation of Argentine Rights over the Malvinas, Islands and Antarctic Sector
+          es: Día de la Afirmación de los Derechos Argentinos sobre las Malvinas, Islas y Sector Antártico
+        active:
+          - from: '1984-03-23'
+            to: '1988-05-17'
+      # Made movable in 1988
+      # @source https://biblioteca.afip.gob.ar/dcp/LEY_C_023555_1988_04_28
+      # Abolished in 2000
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-25370-65442/texto
+      06-10 if tuesday,wednesday then previous monday if thursday,friday then next monday:
+        name:
+          en: Day of Affirmation of Argentine Rights over the Malvinas, Islands and Antarctic Sector
+          es: Día de la Afirmación de los Derechos Argentinos sobre las Malvinas, Islas y Sector Antártico
+        active:
+          - from: '1988-05-18'
+            to: '2000-12-15'
+      # introduced in 2016
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-27258-262574/texto
+      06-17 if tuesday,wednesday then previous monday if thursday then next monday:
+        name:
+          en: Anniversary of the Passing to Immortality of General Martín Miguel de Güemes
+          es: Día Paso a la Inmortalidad del General Martín Miguel de Güemes
+        active:
+          - from: '2016-06-11'
+      # Introduced in 1938
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-12361-232587/texto
+      # Made fixed (non-movable) in 1991
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-24023-422/texto
+      # Became fixed again in 2010
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-1584-2010-174389/texto
       06-20:
         name:
           en: National Flag Day
           es: Día de la Bandera
-      substitutes 06-20 if tuesday then previous monday if thursday then next friday:
-        _name: Bridge Day
+        active:
+          - from: '1938-06-08'
+            to: '1988-05-23'
+          - from: '1991-12-18'
+            to: '1995-01-10'
+          - from: '2010-11-03'
+      # Made movable in 1988
+      # @source https://biblioteca.afip.gob.ar/dcp/LEY_C_023555_1988_04_28
+      06-20 if tuesday,wednesday then previous monday if thursday,friday then next monday:
+        name:
+          en: National Flag Day
+          es: Día de la Bandera
+        active:
+          - from: '1988-05-24'
+            to: '1991-12-17'
+      # Made movable again in 1995
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-24445-782/texto
+      3rd monday in June:
+        name:
+          en: National Flag Day
+          es: Día de la Bandera
+        active:
+          - from: '1995-01-11'
+            to: '2010-11-02'
       07-09:
         _name: Independence Day
-      substitutes 07-09 if tuesday then previous monday if thursday then next friday if saturday then previous friday:
-        _name: Bridge Day
-        disable:
-          - 2015
-          - 2022
+      # Introduced in 1938
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-12387-231841/texto
+      # Made fixed (non-movable) in 1994
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-24360-756/texto
+      08-17:
+        name:
+          en: Anniversary of the Passing to Immortality of General José de San Martín
+          es: Paso a la Inmortalidad del General José de San Martín
+        active:
+          - from: '1938-09-01'
+            to: '1988-05-23'
+          - from: '1994-09-30'
+            to: '1995-01-10'
+      # Made movable in 1988
+      # @source https://biblioteca.afip.gob.ar/dcp/LEY_C_023555_1988_04_28
+      # Moving rule changed in 2017
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-52-2017-271094/texto
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-27399-281835/texto
+      08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday:
+        name:
+          en: Anniversary of the Passing to Immortality of General José de San Martín
+          es: Paso a la Inmortalidad del General José de San Martín
+        active:
+          - from: '1988-05-24'
+            to: '1994-09-29'
+          - from: '2017-01-24'
+      # Made movable again in 1995
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-24445-782/texto
       3rd monday in August:
         name:
-          en: Anniversary of the death of General José de San Martín
-          es: Día del Libertador José de San Martín
+          en: Anniversary of the Passing to Immortality of General José de San Martín
+          es: Paso a la Inmortalidad del General José de San Martín
+        active:
+          - from: '1995-01-11'
+            to: '2017-01-23'
+        disable:
+          - '2011-08-15'
+        enable:
+          # @source https://www.argentina.gob.ar/normativa/nacional/decreto-521-2011-181754/texto
+          - '2011-08-22'
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-26763-201915/texto
+      '2012-09-24':
+        name:
+          en: Bicentennial of the Battle of Tucumán
+          es: Bicentenario de la Batalla de Tucumán
+      # Abolished in 1976
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-21329-65453/texto
+      # Reintroduced in 1982
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-22655-140416/texto
+      10-12:
+        name:
+          en: The Day of the Race
+          es: Día de la Raza
+        active:
+          - to: '1976-06-14'
+          - from: '1982-10-12'
+            to: '1988-05-23'
+      # Made movable in 1988
+      # @source https://biblioteca.afip.gob.ar/dcp/LEY_C_023555_1988_04_28
+      '10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #1':
+        name:
+          en: The Day of the Race
+          es: Día de la Raza
+        active:
+          - from: '1988-05-24'
+            to: '2008-10-02'
+        disable:
+          - '2001-10-15'
+          - '2002-10-12'
+        enable:
+          # @source https://www.argentina.gob.ar/normativa/nacional/ley-25442-67888/texto
+          - '2001-10-08'
+          # @source https://www.argentina.gob.ar/normativa/nacional/decreto-1932-2002-78207/texto
+          - '2002-10-14'
+      # Moving rule changed in 2008
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-26416-145231/texto
       10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday:
+        name:
+          en: The Day of the Race
+          es: Día de la Raza
+        active:
+          - from: '2008-10-03'
+            to: '2010-11-02'
+      # Holiday name changed and moving rule changed in 2010
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-1584-2010-174389/texto
+      2nd monday in October:
         name:
           en: Day of Respect for Cultural Diversity
           es: Día del Respeto a la Diversidad Cultural
-      substitutes 10-12 if monday,tuesday,wednesday then previous friday:
-        _name: Bridge Day
-        disable:
-          - 2015
-          - 2016
-          - 2020
-      11-20 if tuesday,wednesday then previous monday if friday then next monday:
-        # @source http://www.mininterior.gov.ar/tramitesyservicios/pdf/feriado-nacional-27-11-2015.pdf
+        active:
+          - from: '2010-11-03'
+            to: '2017-01-23'
+      # Moving rule changed in 2017
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-52-2017-271094/texto
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-27399-281835/texto
+      '10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2':
+        name:
+          en: Day of Respect for Cultural Diversity
+          es: Día del Respeto a la Diversidad Cultural
+        active:
+          - from: '2017-01-24'
+      # @source https://www.argentina.gob.ar/normativa/nacional/resoluci%C3%B3n-1159-2010-173748/texto
+      '2010-10-27':
+        name:
+          en: National Census 2010
+          es: Censo Nacional 2010
+      # Introduced in 2010
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-1584-2010-174389/texto
+      4th monday in November:
         name:
           en: Day of National Sovereignty
-          es: Día de la Soberanía nacional
-      substitutes 11-20 if saturday,sunday then next monday:
-        _name: Bridge Day
+          es: Día de la Soberanía Nacional
+        active:
+          - from: '2010-11-03'
+            to: '2017-01-23'
         disable:
-          - 2016
+          - '2015-11-23'
+        enable:
+          # @source https://www.argentina.gob.ar/normativa/nacional/decreto-2226-2015-253971
+          - '2015-11-27'
+      # Moving rule changed in 2017
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-52-2017-271094/texto
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-27399-281835/texto
+      11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday:
+        name:
+          en: Day of National Sovereignty
+          es: Día de la Soberanía Nacional
+        active:
+          - from: '2017-01-24'
+      # Introduced in 1995
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-24445-782/texto
       12-08:
         _name: 12-08
-      substitutes 12-08 if tuesday then previous monday if thursday then next friday:
-        _name: Bridge Day
+        active:
+          - from: '1995-01-11'
       "12-24 12:00":
         _name: 12-24
         type: optional
-      substitutes 12-24 if tuesday then previous monday:
-        _name: Bridge Day
       12-25:
         _name: 12-25
-      substitutes 12-25 if tuesday then previous monday if thursday then next friday:
-        _name: Bridge Day
       "12-31 12:00":
         _name: 12-31
         type: optional
+      # Bridge holidays for tourism purpose (2011-2013)
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-1585-2010-174391/texto
+      '2011-03-25':
+        _name: Bridge Day
+      '2011-12-09':
+        _name: Bridge Day
+      '2012-04-30':
+        _name: Bridge Day
+      '2012-12-24':
+        _name: Bridge Day
+      '2013-04-01':
+        _name: Bridge Day
+      '2013-06-21':
+        _name: Bridge Day
+      # Bridge holidays for tourism purpose (2014-2016)
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-1768-2013-222021
+      '2014-05-02':
+        _name: Bridge Day
+      '2014-12-26':
+        _name: Bridge Day
+      '2015-03-23':
+        _name: Bridge Day
+      '2015-12-07':
+        _name: Bridge Day
+      '2016-07-08':
+        _name: Bridge Day
+      '2016-12-09':
+        _name: Bridge Day
+      # Non-working days for tourism purposes (2018-2019)
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-923-2017-287145/texto
+      '2018-04-30':
+        _name: Bridge Day
+        type: bank
+      '2018-12-24':
+        _name: Bridge Day
+        type: bank
+      '2018-12-31':
+        _name: Bridge Day
+        type: bank
+      '2019-07-08':
+        _name: Bridge Day
+        type: bank
+      '2019-08-19':
+        _name: Bridge Day
+        type: bank
+      '2019-10-14':
+        _name: Bridge Day
+        type: bank
+      # Bridge holidays for tourism purpose (2020)
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-717-2019-330204/texto
+      '2020-03-23':
+        _name: Bridge Day
+      '2020-07-10':
+        _name: Bridge Day
+      '2020-12-07':
+        _name: Bridge Day
+      # Bridge holidays for tourism purpose (2021)
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-947-2020-344620/texto
+      '2021-05-24':
+        _name: Bridge Day
+      '2021-10-08':
+        _name: Bridge Day
+      '2021-11-22':
+        _name: Bridge Day
+      # Bridge holidays for tourism purpose (2022)
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-789-2021-356678/texto
+      '2022-10-07':
+        _name: Bridge Day
+      '2022-11-21':
+        _name: Bridge Day
+      '2022-12-09':
+        _name: Bridge Day
+      # Bridge holidays for tourism purpose (2023)
+      # @source https://www.argentina.gob.ar/normativa/nacional/decreto-789-2021-356678/texto
+      '2023-05-26':
+        _name: Bridge Day
+      '2023-06-19':
+        _name: Bridge Day
+      '2023-10-13':
+        _name: Bridge Day
+      # Bridge holidays for tourism purpose (2024)
+      # @source https://www.boletinoficial.gob.ar/detalleAviso/primera/301434/20231229
+      '2024-04-01':
+        _name: Bridge Day
+      '2024-06-21':
+        _name: Bridge Day
+      '2024-10-11':
+        _name: Bridge Day
+      # Non-working days for tourism purpose (2025)
+      # @source https://www.boletinoficial.gob.ar/detalleAviso/primera/317188/20241121
+      '2025-05-02':
+        _name: Bridge Day
+        type: bank
+      '2025-08-15':
+        _name: Bridge Day
+        type: bank
+      '2025-11-21':
+        _name: Bridge Day
+        type: bank
 
     # states:
     # A:

--- a/test/fixtures/AR-2015.json
+++ b/test/fixtures/AR-2015.json
@@ -32,14 +32,14 @@
     "end": "2015-03-24T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 03-24 if tuesday then previous monday if thursday then next friday",
+    "rule": "2015-03-23",
     "_weekday": "Mon"
   },
   {
     "date": "2015-03-24 00:00:00",
     "start": "2015-03-24T03:00:00.000Z",
     "end": "2015-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Tue"
@@ -58,18 +58,9 @@
     "start": "2015-04-02T03:00:00.000Z",
     "end": "2015-04-03T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2015-04-03 00:00:00",
-    "start": "2015-04-03T03:00:00.000Z",
-    "end": "2015-04-04T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 04-02 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Fri"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -120,7 +111,7 @@
     "date": "2015-08-17 00:00:00",
     "start": "2015-08-17T03:00:00.000Z",
     "end": "2015-08-18T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
     "rule": "3rd monday in August",
     "_weekday": "Mon"
@@ -131,17 +122,17 @@
     "end": "2015-10-13T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "2nd monday in October",
     "_weekday": "Mon"
   },
   {
-    "date": "2015-11-23 00:00:00",
-    "start": "2015-11-23T03:00:00.000Z",
-    "end": "2015-11-24T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "date": "2015-11-27 00:00:00",
+    "start": "2015-11-27T03:00:00.000Z",
+    "end": "2015-11-28T03:00:00.000Z",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
-    "_weekday": "Mon"
+    "rule": "4th monday in November",
+    "_weekday": "Fri"
   },
   {
     "date": "2015-12-07 00:00:00",
@@ -149,7 +140,7 @@
     "end": "2015-12-08T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 12-08 if tuesday then previous monday if thursday then next friday",
+    "rule": "2015-12-07",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AR-2016.json
+++ b/test/fixtures/AR-2016.json
@@ -30,7 +30,7 @@
     "date": "2016-03-24 00:00:00",
     "start": "2016-03-24T03:00:00.000Z",
     "end": "2016-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Thu"
@@ -40,18 +40,9 @@
     "start": "2016-03-24T03:00:00.000Z",
     "end": "2016-03-25T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2016-03-25 00:00:00",
-    "start": "2016-03-25T03:00:00.000Z",
-    "end": "2016-03-26T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 03-24 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Fri"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -90,6 +81,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2016-06-17 00:00:00",
+    "start": "2016-06-17T03:00:00.000Z",
+    "end": "2016-06-18T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2016-06-20 00:00:00",
     "start": "2016-06-20T03:00:00.000Z",
     "end": "2016-06-21T03:00:00.000Z",
@@ -104,7 +104,7 @@
     "end": "2016-07-09T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 07-09 if tuesday then previous monday if thursday then next friday if saturday then previous friday",
+    "rule": "2016-07-08",
     "_weekday": "Fri"
   },
   {
@@ -120,7 +120,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-15T03:00:00.000Z",
     "end": "2016-08-16T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
     "rule": "3rd monday in August",
     "_weekday": "Mon"
@@ -131,17 +131,17 @@
     "end": "2016-10-11T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "2nd monday in October",
     "_weekday": "Mon"
   },
   {
-    "date": "2016-11-20 00:00:00",
-    "start": "2016-11-20T03:00:00.000Z",
-    "end": "2016-11-21T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "date": "2016-11-28 00:00:00",
+    "start": "2016-11-28T03:00:00.000Z",
+    "end": "2016-11-29T03:00:00.000Z",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
-    "_weekday": "Sun"
+    "rule": "4th monday in November",
+    "_weekday": "Mon"
   },
   {
     "date": "2016-12-08 00:00:00",
@@ -158,7 +158,7 @@
     "end": "2016-12-10T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 12-08 if tuesday then previous monday if thursday then next friday",
+    "rule": "2016-12-09",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/AR-2017.json
+++ b/test/fixtures/AR-2017.json
@@ -30,7 +30,7 @@
     "date": "2017-03-24 00:00:00",
     "start": "2017-03-24T03:00:00.000Z",
     "end": "2017-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Fri"
@@ -49,7 +49,7 @@
     "start": "2017-04-13T03:00:00.000Z",
     "end": "2017-04-14T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -81,22 +81,13 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2017-05-26 00:00:00",
-    "start": "2017-05-26T03:00:00.000Z",
-    "end": "2017-05-27T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
+    "date": "2017-06-17 00:00:00",
+    "start": "2017-06-17T03:00:00.000Z",
+    "end": "2017-06-18T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
     "type": "public",
-    "rule": "substitutes 05-25 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Fri"
-  },
-  {
-    "date": "2017-06-19 00:00:00",
-    "start": "2017-06-19T03:00:00.000Z",
-    "end": "2017-06-20T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 06-20 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Mon"
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Sat"
   },
   {
     "date": "2017-06-20 00:00:00",
@@ -120,9 +111,9 @@
     "date": "2017-08-21 00:00:00",
     "start": "2017-08-21T03:00:00.000Z",
     "end": "2017-08-22T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -131,16 +122,16 @@
     "end": "2017-10-17T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
     "_weekday": "Mon"
   },
   {
     "date": "2017-11-20 00:00:00",
     "start": "2017-11-20T03:00:00.000Z",
     "end": "2017-11-21T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AR-2018.json
+++ b/test/fixtures/AR-2018.json
@@ -30,7 +30,7 @@
     "date": "2018-03-24 00:00:00",
     "start": "2018-03-24T03:00:00.000Z",
     "end": "2018-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Sat"
@@ -40,7 +40,7 @@
     "start": "2018-03-29T03:00:00.000Z",
     "end": "2018-03-30T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -67,8 +67,8 @@
     "start": "2018-04-30T03:00:00.000Z",
     "end": "2018-05-01T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 05-01 if tuesday then previous monday if thursday then next friday",
+    "type": "bank",
+    "rule": "2018-04-30",
     "_weekday": "Mon"
   },
   {
@@ -88,6 +88,15 @@
     "type": "public",
     "rule": "05-25",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2018-06-17 00:00:00",
+    "start": "2018-06-17T03:00:00.000Z",
+    "end": "2018-06-18T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Sun"
   },
   {
     "date": "2018-06-20 00:00:00",
@@ -111,9 +120,9 @@
     "date": "2018-08-20 00:00:00",
     "start": "2018-08-20T03:00:00.000Z",
     "end": "2018-08-21T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -122,16 +131,16 @@
     "end": "2018-10-16T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
     "_weekday": "Mon"
   },
   {
     "date": "2018-11-19 00:00:00",
     "start": "2018-11-19T03:00:00.000Z",
     "end": "2018-11-20T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -148,8 +157,8 @@
     "start": "2018-12-24T03:00:00.000Z",
     "end": "2018-12-25T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 12-25 if tuesday then previous monday if thursday then next friday",
+    "type": "bank",
+    "rule": "2018-12-24",
     "_weekday": "Mon"
   },
   {
@@ -175,8 +184,8 @@
     "start": "2018-12-31T03:00:00.000Z",
     "end": "2019-01-01T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 01-01 if tuesday then previous monday if thursday then next friday",
+    "type": "bank",
+    "rule": "2018-12-31",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AR-2019.json
+++ b/test/fixtures/AR-2019.json
@@ -30,19 +30,10 @@
     "date": "2019-03-24 00:00:00",
     "start": "2019-03-24T03:00:00.000Z",
     "end": "2019-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2019-04-01 00:00:00",
-    "start": "2019-04-01T03:00:00.000Z",
-    "end": "2019-04-02T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 04-02 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Mon"
   },
   {
     "date": "2019-04-02 00:00:00",
@@ -58,7 +49,7 @@
     "start": "2019-04-18T03:00:00.000Z",
     "end": "2019-04-19T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -90,6 +81,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2019-06-17 00:00:00",
+    "start": "2019-06-17T03:00:00.000Z",
+    "end": "2019-06-18T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2019-06-20 00:00:00",
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
@@ -99,21 +99,12 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2019-06-21 00:00:00",
-    "start": "2019-06-21T03:00:00.000Z",
-    "end": "2019-06-22T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 06-20 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2019-07-08 00:00:00",
     "start": "2019-07-08T03:00:00.000Z",
     "end": "2019-07-09T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 07-09 if tuesday then previous monday if thursday then next friday if saturday then previous friday",
+    "type": "bank",
+    "rule": "2019-07-08",
     "_weekday": "Mon"
   },
   {
@@ -126,30 +117,48 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2019-08-17 00:00:00",
+    "start": "2019-08-17T03:00:00.000Z",
+    "end": "2019-08-18T03:00:00.000Z",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
+    "type": "public",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2019-08-19 00:00:00",
     "start": "2019-08-19T03:00:00.000Z",
     "end": "2019-08-20T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
-    "type": "public",
-    "rule": "3rd monday in August",
+    "name": "Feriado Puente Turístico",
+    "type": "bank",
+    "rule": "2019-08-19",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2019-10-12 00:00:00",
+    "start": "2019-10-12T03:00:00.000Z",
+    "end": "2019-10-13T03:00:00.000Z",
+    "name": "Día del Respeto a la Diversidad Cultural",
+    "type": "public",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
+    "_weekday": "Sat"
   },
   {
     "date": "2019-10-14 00:00:00",
     "start": "2019-10-14T03:00:00.000Z",
     "end": "2019-10-15T03:00:00.000Z",
-    "name": "Día del Respeto a la Diversidad Cultural",
-    "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "name": "Feriado Puente Turístico",
+    "type": "bank",
+    "rule": "2019-10-14",
     "_weekday": "Mon"
   },
   {
     "date": "2019-11-18 00:00:00",
     "start": "2019-11-18T03:00:00.000Z",
     "end": "2019-11-19T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -160,15 +169,6 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2019-12-23 00:00:00",
-    "start": "2019-12-23T03:00:00.000Z",
-    "end": "2019-12-24T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 12-24 if tuesday then previous monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2019-12-24 12:00:00",

--- a/test/fixtures/AR-2020.json
+++ b/test/fixtures/AR-2020.json
@@ -32,51 +32,33 @@
     "end": "2020-03-24T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 03-24 if tuesday then previous monday if thursday then next friday",
+    "rule": "2020-03-23",
     "_weekday": "Mon"
   },
   {
     "date": "2020-03-24 00:00:00",
     "start": "2020-03-24T03:00:00.000Z",
     "end": "2020-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Tue"
   },
   {
-    "date": "2020-03-30 00:00:00",
-    "start": "2020-03-30T03:00:00.000Z",
-    "end": "2020-03-31T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "2020-03-30",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2020-04-02 00:00:00",
-    "start": "2020-04-02T03:00:00.000Z",
-    "end": "2020-04-03T03:00:00.000Z",
+    "date": "2020-03-31 00:00:00",
+    "start": "2020-03-31T03:00:00.000Z",
+    "end": "2020-04-01T03:00:00.000Z",
     "name": "Día del Veterano y de los Caídos en la Guerra de Malvinas",
     "type": "public",
     "rule": "04-02",
-    "_weekday": "Thu"
-  },
-  {
-    "date": "2020-04-03 00:00:00",
-    "start": "2020-04-03T03:00:00.000Z",
-    "end": "2020-04-04T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 04-02 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Fri"
+    "_weekday": "Tue"
   },
   {
     "date": "2020-04-09 00:00:00",
     "start": "2020-04-09T03:00:00.000Z",
     "end": "2020-04-10T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -108,6 +90,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-06-15 00:00:00",
+    "start": "2020-06-15T03:00:00.000Z",
+    "end": "2020-06-16T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2020-06-20 00:00:00",
     "start": "2020-06-20T03:00:00.000Z",
     "end": "2020-06-21T03:00:00.000Z",
@@ -131,16 +122,16 @@
     "end": "2020-07-11T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 07-09 if tuesday then previous monday if thursday then next friday if saturday then previous friday",
+    "rule": "2020-07-10",
     "_weekday": "Fri"
   },
   {
     "date": "2020-08-17 00:00:00",
     "start": "2020-08-17T03:00:00.000Z",
     "end": "2020-08-18T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -149,16 +140,16 @@
     "end": "2020-10-13T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
     "_weekday": "Mon"
   },
   {
     "date": "2020-11-23 00:00:00",
     "start": "2020-11-23T03:00:00.000Z",
     "end": "2020-11-24T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -167,7 +158,7 @@
     "end": "2020-12-08T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 12-08 if tuesday then previous monday if thursday then next friday",
+    "rule": "2020-12-07",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AR-2021.json
+++ b/test/fixtures/AR-2021.json
@@ -30,7 +30,7 @@
     "date": "2021-03-24 00:00:00",
     "start": "2021-03-24T03:00:00.000Z",
     "end": "2021-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Wed"
@@ -40,7 +40,7 @@
     "start": "2021-04-01T03:00:00.000Z",
     "end": "2021-04-02T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -77,7 +77,7 @@
     "end": "2021-05-25T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 05-25 if tuesday then previous monday if thursday then next friday",
+    "rule": "2021-05-24",
     "_weekday": "Mon"
   },
   {
@@ -99,6 +99,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T03:00:00.000Z",
+    "end": "2021-06-22T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-07-09 00:00:00",
     "start": "2021-07-09T03:00:00.000Z",
     "end": "2021-07-10T03:00:00.000Z",
@@ -111,9 +120,9 @@
     "date": "2021-08-16 00:00:00",
     "start": "2021-08-16T03:00:00.000Z",
     "end": "2021-08-17T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -122,7 +131,7 @@
     "end": "2021-10-09T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 10-12 if monday,tuesday,wednesday then previous friday",
+    "rule": "2021-10-08",
     "_weekday": "Fri"
   },
   {
@@ -131,16 +140,16 @@
     "end": "2021-10-12T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
     "_weekday": "Mon"
   },
   {
     "date": "2021-11-20 00:00:00",
     "start": "2021-11-20T03:00:00.000Z",
     "end": "2021-11-21T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Sat"
   },
   {
@@ -149,7 +158,7 @@
     "end": "2021-11-23T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 11-20 if saturday,sunday then next monday",
+    "rule": "2021-11-22",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AR-2022.json
+++ b/test/fixtures/AR-2022.json
@@ -30,19 +30,10 @@
     "date": "2022-03-24 00:00:00",
     "start": "2022-03-24T03:00:00.000Z",
     "end": "2022-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2022-03-25 00:00:00",
-    "start": "2022-03-25T03:00:00.000Z",
-    "end": "2022-03-26T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 03-24 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Fri"
   },
   {
     "date": "2022-04-02 00:00:00",
@@ -58,7 +49,7 @@
     "start": "2022-04-14T03:00:00.000Z",
     "end": "2022-04-15T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -81,6 +72,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2022-05-18 00:00:00",
+    "start": "2022-05-18T03:00:00.000Z",
+    "end": "2022-05-19T03:00:00.000Z",
+    "name": "Censo Nacional 2022",
+    "type": "public",
+    "rule": "2022-05-18",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2022-05-25 00:00:00",
     "start": "2022-05-25T03:00:00.000Z",
     "end": "2022-05-26T03:00:00.000Z",
@@ -88,6 +88,15 @@
     "type": "public",
     "rule": "05-25",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2022-06-17 00:00:00",
+    "start": "2022-06-17T03:00:00.000Z",
+    "end": "2022-06-18T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Fri"
   },
   {
     "date": "2022-06-20 00:00:00",
@@ -111,9 +120,9 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-15T03:00:00.000Z",
     "end": "2022-08-16T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -122,7 +131,7 @@
     "end": "2022-10-08T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 10-12 if monday,tuesday,wednesday then previous friday",
+    "rule": "2022-10-07",
     "_weekday": "Fri"
   },
   {
@@ -131,16 +140,16 @@
     "end": "2022-10-11T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
     "_weekday": "Mon"
   },
   {
     "date": "2022-11-20 00:00:00",
     "start": "2022-11-20T03:00:00.000Z",
     "end": "2022-11-21T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -149,7 +158,7 @@
     "end": "2022-11-22T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 11-20 if saturday,sunday then next monday",
+    "rule": "2022-11-21",
     "_weekday": "Mon"
   },
   {
@@ -167,7 +176,7 @@
     "end": "2022-12-10T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 12-08 if tuesday then previous monday if thursday then next friday",
+    "rule": "2022-12-09",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/AR-2023.json
+++ b/test/fixtures/AR-2023.json
@@ -30,7 +30,7 @@
     "date": "2023-03-24 00:00:00",
     "start": "2023-03-24T03:00:00.000Z",
     "end": "2023-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Fri"
@@ -49,7 +49,7 @@
     "start": "2023-04-06T03:00:00.000Z",
     "end": "2023-04-07T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -86,8 +86,17 @@
     "end": "2023-05-27T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 05-25 if tuesday then previous monday if thursday then next friday",
+    "rule": "2023-05-26",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2023-06-17 00:00:00",
+    "start": "2023-06-17T03:00:00.000Z",
+    "end": "2023-06-18T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Sat"
   },
   {
     "date": "2023-06-19 00:00:00",
@@ -95,7 +104,7 @@
     "end": "2023-06-20T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 06-20 if tuesday then previous monday if thursday then next friday",
+    "rule": "2023-06-19",
     "_weekday": "Mon"
   },
   {
@@ -120,10 +129,19 @@
     "date": "2023-08-21 00:00:00",
     "start": "2023-08-21T03:00:00.000Z",
     "end": "2023-08-22T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2023-10-13 00:00:00",
+    "start": "2023-10-13T03:00:00.000Z",
+    "end": "2023-10-14T03:00:00.000Z",
+    "name": "Feriado Puente Turístico",
+    "type": "public",
+    "rule": "2023-10-13",
+    "_weekday": "Fri"
   },
   {
     "date": "2023-10-16 00:00:00",
@@ -131,16 +149,16 @@
     "end": "2023-10-17T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
     "_weekday": "Mon"
   },
   {
     "date": "2023-11-20 00:00:00",
     "start": "2023-11-20T03:00:00.000Z",
     "end": "2023-11-21T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AR-2024.json
+++ b/test/fixtures/AR-2024.json
@@ -30,7 +30,7 @@
     "date": "2024-03-24 00:00:00",
     "start": "2024-03-24T03:00:00.000Z",
     "end": "2024-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Sun"
@@ -40,7 +40,7 @@
     "start": "2024-03-28T03:00:00.000Z",
     "end": "2024-03-29T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -59,7 +59,7 @@
     "end": "2024-04-02T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 04-02 if tuesday then previous monday if thursday then next friday",
+    "rule": "2024-04-01",
     "_weekday": "Mon"
   },
   {
@@ -90,6 +90,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2024-06-17 00:00:00",
+    "start": "2024-06-17T03:00:00.000Z",
+    "end": "2024-06-18T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-06-20 00:00:00",
     "start": "2024-06-20T03:00:00.000Z",
     "end": "2024-06-21T03:00:00.000Z",
@@ -104,17 +113,8 @@
     "end": "2024-06-22T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
     "type": "public",
-    "rule": "substitutes 06-20 if tuesday then previous monday if thursday then next friday",
+    "rule": "2024-06-21",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2024-07-08 00:00:00",
-    "start": "2024-07-08T03:00:00.000Z",
-    "end": "2024-07-09T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 07-09 if tuesday then previous monday if thursday then next friday if saturday then previous friday",
-    "_weekday": "Mon"
   },
   {
     "date": "2024-07-09 00:00:00",
@@ -126,30 +126,39 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2024-08-19 00:00:00",
-    "start": "2024-08-19T03:00:00.000Z",
-    "end": "2024-08-20T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "date": "2024-08-17 00:00:00",
+    "start": "2024-08-17T03:00:00.000Z",
+    "end": "2024-08-18T03:00:00.000Z",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
-    "_weekday": "Mon"
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
+    "_weekday": "Sat"
   },
   {
-    "date": "2024-10-14 00:00:00",
-    "start": "2024-10-14T03:00:00.000Z",
-    "end": "2024-10-15T03:00:00.000Z",
+    "date": "2024-10-11 00:00:00",
+    "start": "2024-10-11T03:00:00.000Z",
+    "end": "2024-10-12T03:00:00.000Z",
+    "name": "Feriado Puente Turístico",
+    "type": "public",
+    "rule": "2024-10-11",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-10-12 00:00:00",
+    "start": "2024-10-12T03:00:00.000Z",
+    "end": "2024-10-13T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
-    "_weekday": "Mon"
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
+    "_weekday": "Sat"
   },
   {
     "date": "2024-11-18 00:00:00",
     "start": "2024-11-18T03:00:00.000Z",
     "end": "2024-11-19T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -160,15 +169,6 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2024-12-23 00:00:00",
-    "start": "2024-12-23T03:00:00.000Z",
-    "end": "2024-12-24T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 12-24 if tuesday then previous monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2024-12-24 12:00:00",

--- a/test/fixtures/AR-2025.json
+++ b/test/fixtures/AR-2025.json
@@ -30,7 +30,7 @@
     "date": "2025-03-24 00:00:00",
     "start": "2025-03-24T03:00:00.000Z",
     "end": "2025-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Mon"
@@ -49,7 +49,7 @@
     "start": "2025-04-17T03:00:00.000Z",
     "end": "2025-04-18T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -76,8 +76,8 @@
     "start": "2025-05-02T03:00:00.000Z",
     "end": "2025-05-03T03:00:00.000Z",
     "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 05-01 if tuesday then previous monday if thursday then next friday",
+    "type": "bank",
+    "rule": "2025-05-02",
     "_weekday": "Fri"
   },
   {
@@ -88,6 +88,15 @@
     "type": "public",
     "rule": "05-25",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2025-06-16 00:00:00",
+    "start": "2025-06-16T03:00:00.000Z",
+    "end": "2025-06-17T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2025-06-20 00:00:00",
@@ -108,31 +117,49 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2025-08-18 00:00:00",
-    "start": "2025-08-18T03:00:00.000Z",
-    "end": "2025-08-19T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
-    "type": "public",
-    "rule": "3rd monday in August",
-    "_weekday": "Mon"
+    "date": "2025-08-15 00:00:00",
+    "start": "2025-08-15T03:00:00.000Z",
+    "end": "2025-08-16T03:00:00.000Z",
+    "name": "Feriado Puente Turístico",
+    "type": "bank",
+    "rule": "2025-08-15",
+    "_weekday": "Fri"
   },
   {
-    "date": "2025-10-13 00:00:00",
-    "start": "2025-10-13T03:00:00.000Z",
-    "end": "2025-10-14T03:00:00.000Z",
+    "date": "2025-08-17 00:00:00",
+    "start": "2025-08-17T03:00:00.000Z",
+    "end": "2025-08-18T03:00:00.000Z",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
+    "type": "public",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-12 00:00:00",
+    "start": "2025-10-12T03:00:00.000Z",
+    "end": "2025-10-13T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
-    "_weekday": "Mon"
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
+    "_weekday": "Sun"
   },
   {
-    "date": "2025-11-20 00:00:00",
-    "start": "2025-11-20T03:00:00.000Z",
-    "end": "2025-11-21T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "date": "2025-11-21 00:00:00",
+    "start": "2025-11-21T03:00:00.000Z",
+    "end": "2025-11-22T03:00:00.000Z",
+    "name": "Feriado Puente Turístico",
+    "type": "bank",
+    "rule": "2025-11-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-11-24 00:00:00",
+    "start": "2025-11-24T03:00:00.000Z",
+    "end": "2025-11-25T03:00:00.000Z",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
-    "_weekday": "Thu"
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2025-12-08 00:00:00",
@@ -160,15 +187,6 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T03:00:00.000Z",
-    "end": "2025-12-27T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 12-25 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Fri"
   },
   {
     "date": "2025-12-31 12:00:00",

--- a/test/fixtures/AR-2026.json
+++ b/test/fixtures/AR-2026.json
@@ -9,15 +9,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2026-01-02 00:00:00",
-    "start": "2026-01-02T03:00:00.000Z",
-    "end": "2026-01-03T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 01-01 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2026-02-16 00:00:00",
     "start": "2026-02-16T03:00:00.000Z",
     "end": "2026-02-17T03:00:00.000Z",
@@ -36,19 +27,10 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2026-03-23 00:00:00",
-    "start": "2026-03-23T03:00:00.000Z",
-    "end": "2026-03-24T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 03-24 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2026-03-24 00:00:00",
     "start": "2026-03-24T03:00:00.000Z",
     "end": "2026-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Tue"
@@ -67,18 +49,9 @@
     "start": "2026-04-02T03:00:00.000Z",
     "end": "2026-04-03T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2026-04-03 00:00:00",
-    "start": "2026-04-03T03:00:00.000Z",
-    "end": "2026-04-04T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 04-02 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Fri"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -108,6 +81,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2026-06-15 00:00:00",
+    "start": "2026-06-15T03:00:00.000Z",
+    "end": "2026-06-16T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-06-20 00:00:00",
     "start": "2026-06-20T03:00:00.000Z",
     "end": "2026-06-21T03:00:00.000Z",
@@ -126,31 +108,13 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2026-07-10 00:00:00",
-    "start": "2026-07-10T03:00:00.000Z",
-    "end": "2026-07-11T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 07-09 if tuesday then previous monday if thursday then next friday if saturday then previous friday",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2026-08-17 00:00:00",
     "start": "2026-08-17T03:00:00.000Z",
     "end": "2026-08-18T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2026-10-09 00:00:00",
-    "start": "2026-10-09T03:00:00.000Z",
-    "end": "2026-10-10T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 10-12 if monday,tuesday,wednesday then previous friday",
-    "_weekday": "Fri"
   },
   {
     "date": "2026-10-12 00:00:00",
@@ -158,25 +122,16 @@
     "end": "2026-10-13T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
     "_weekday": "Mon"
   },
   {
     "date": "2026-11-23 00:00:00",
     "start": "2026-11-23T03:00:00.000Z",
     "end": "2026-11-24T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2026-12-07 00:00:00",
-    "start": "2026-12-07T03:00:00.000Z",
-    "end": "2026-12-08T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 12-08 if tuesday then previous monday if thursday then next friday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AR-2027.json
+++ b/test/fixtures/AR-2027.json
@@ -30,7 +30,7 @@
     "date": "2027-03-24 00:00:00",
     "start": "2027-03-24T03:00:00.000Z",
     "end": "2027-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Wed"
@@ -40,7 +40,7 @@
     "start": "2027-03-25T03:00:00.000Z",
     "end": "2027-03-26T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -72,15 +72,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2027-05-24 00:00:00",
-    "start": "2027-05-24T03:00:00.000Z",
-    "end": "2027-05-25T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 05-25 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2027-05-25 00:00:00",
     "start": "2027-05-25T03:00:00.000Z",
     "end": "2027-05-26T03:00:00.000Z",
@@ -99,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T03:00:00.000Z",
+    "end": "2027-06-22T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-07-09 00:00:00",
     "start": "2027-07-09T03:00:00.000Z",
     "end": "2027-07-10T03:00:00.000Z",
@@ -111,19 +111,10 @@
     "date": "2027-08-16 00:00:00",
     "start": "2027-08-16T03:00:00.000Z",
     "end": "2027-08-17T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2027-10-08 00:00:00",
-    "start": "2027-10-08T03:00:00.000Z",
-    "end": "2027-10-09T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 10-12 if monday,tuesday,wednesday then previous friday",
-    "_weekday": "Fri"
   },
   {
     "date": "2027-10-11 00:00:00",
@@ -131,26 +122,17 @@
     "end": "2027-10-12T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
     "_weekday": "Mon"
   },
   {
     "date": "2027-11-20 00:00:00",
     "start": "2027-11-20T03:00:00.000Z",
     "end": "2027-11-21T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-11-22 00:00:00",
-    "start": "2027-11-22T03:00:00.000Z",
-    "end": "2027-11-23T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 11-20 if saturday,sunday then next monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2027-12-08 00:00:00",

--- a/test/fixtures/AR-2028.json
+++ b/test/fixtures/AR-2028.json
@@ -30,7 +30,7 @@
     "date": "2028-03-24 00:00:00",
     "start": "2028-03-24T03:00:00.000Z",
     "end": "2028-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Fri"
@@ -49,7 +49,7 @@
     "start": "2028-04-13T03:00:00.000Z",
     "end": "2028-04-14T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -81,22 +81,13 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2028-05-26 00:00:00",
-    "start": "2028-05-26T03:00:00.000Z",
-    "end": "2028-05-27T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
+    "date": "2028-06-17 00:00:00",
+    "start": "2028-06-17T03:00:00.000Z",
+    "end": "2028-06-18T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
     "type": "public",
-    "rule": "substitutes 05-25 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Fri"
-  },
-  {
-    "date": "2028-06-19 00:00:00",
-    "start": "2028-06-19T03:00:00.000Z",
-    "end": "2028-06-20T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 06-20 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Mon"
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Sat"
   },
   {
     "date": "2028-06-20 00:00:00",
@@ -120,9 +111,9 @@
     "date": "2028-08-21 00:00:00",
     "start": "2028-08-21T03:00:00.000Z",
     "end": "2028-08-22T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -131,16 +122,16 @@
     "end": "2028-10-17T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
     "_weekday": "Mon"
   },
   {
     "date": "2028-11-20 00:00:00",
     "start": "2028-11-20T03:00:00.000Z",
     "end": "2028-11-21T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AR-2029.json
+++ b/test/fixtures/AR-2029.json
@@ -30,7 +30,7 @@
     "date": "2029-03-24 00:00:00",
     "start": "2029-03-24T03:00:00.000Z",
     "end": "2029-03-25T03:00:00.000Z",
-    "name": "Día de la Memoria por la Verdad y la Justicia",
+    "name": "Día Nacional de la Memoria por la Verdad y la Justicia",
     "type": "public",
     "rule": "03-24",
     "_weekday": "Sat"
@@ -40,7 +40,7 @@
     "start": "2029-03-29T03:00:00.000Z",
     "end": "2029-03-30T03:00:00.000Z",
     "name": "Jueves Santo",
-    "type": "public",
+    "type": "bank",
     "rule": "easter -3",
     "_weekday": "Thu"
   },
@@ -63,15 +63,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2029-04-30 00:00:00",
-    "start": "2029-04-30T03:00:00.000Z",
-    "end": "2029-05-01T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 05-01 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2029-05-01 00:00:00",
     "start": "2029-05-01T03:00:00.000Z",
     "end": "2029-05-02T03:00:00.000Z",
@@ -88,6 +79,15 @@
     "type": "public",
     "rule": "05-25",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2029-06-17 00:00:00",
+    "start": "2029-06-17T03:00:00.000Z",
+    "end": "2029-06-18T03:00:00.000Z",
+    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "type": "public",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "_weekday": "Sun"
   },
   {
     "date": "2029-06-20 00:00:00",
@@ -111,9 +111,9 @@
     "date": "2029-08-20 00:00:00",
     "start": "2029-08-20T03:00:00.000Z",
     "end": "2029-08-21T03:00:00.000Z",
-    "name": "Día del Libertador José de San Martín",
+    "name": "Paso a la Inmortalidad del General José de San Martín",
     "type": "public",
-    "rule": "3rd monday in August",
+    "rule": "08-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -122,16 +122,16 @@
     "end": "2029-10-16T03:00:00.000Z",
     "name": "Día del Respeto a la Diversidad Cultural",
     "type": "public",
-    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday,saturday,sunday then next monday",
+    "rule": "10-12 if tuesday,wednesday then previous monday if thursday,friday then next monday #2",
     "_weekday": "Mon"
   },
   {
     "date": "2029-11-19 00:00:00",
     "start": "2029-11-19T03:00:00.000Z",
     "end": "2029-11-20T03:00:00.000Z",
-    "name": "Día de la Soberanía nacional",
+    "name": "Día de la Soberanía Nacional",
     "type": "public",
-    "rule": "11-20 if tuesday,wednesday then previous monday if friday then next monday",
+    "rule": "11-20 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -142,15 +142,6 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2029-12-24 00:00:00",
-    "start": "2029-12-24T03:00:00.000Z",
-    "end": "2029-12-25T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 12-25 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-12-24 12:00:00",
@@ -169,15 +160,6 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-31 00:00:00",
-    "start": "2029-12-31T03:00:00.000Z",
-    "end": "2030-01-01T03:00:00.000Z",
-    "name": "Feriado Puente Turístico",
-    "type": "public",
-    "rule": "substitutes 01-01 if tuesday then previous monday if thursday then next friday",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-12-31 12:00:00",


### PR DESCRIPTION
## Overview

This pull request provides a comprehensive update to the holiday data for Argentina (AR), covering the period from 1976 to 2025.

## Changes

- **Improved Comprehensiveness and Accuracy**:
  - Added and updated holiday information for the years 1976 to 2025.
  - Thoroughly tracked the history of holiday name changes (e.g., "Day of Respect for Cultural Diversity") and changes in the rules governing movable holidays.
  - Incorporated numerous sources of information, including laws, decrees, presidential decrees, and resolutions, to ensure the accuracy, reliability, and traceability of each holiday.
  - Corrected existing holiday names to reflect more common and accurate terminology.
- **Support for Single-Year Holidays and One-Off Date Modifications**:
  - Accurately represented holidays that are valid for a single year only, as well as holidays that have had their dates modified for a single year due to specific laws or decrees.
  - Utilized the `enable` and `disable` keys to appropriately handle these exceptional cases.
- **Complete Coverage of Holidays and Non-Working Days for Tourism Purposes**:
  - Comprehensively added both holidays (feriados con fines turísticos) and non-working days (días no laborables con fines turísticos) for tourism purposes from 2011 to 2025.
  - Replaced the previous, less precise definition of "Bridge Day" with specific entries for each individual instance, as these dates are determined by decree on a year-by-year basis.
- **Type Specification for Specific Days**:
  - Specified `type: bank` for Maundy Thursday and non-working days for tourism purposes.
    - This reflects the practice of the Central Bank of Argentina (BCRA), which customarily treats these days as bank days off.

## Notes

I was unable to address holidays prior to 1976 due to the lack of readily available primary sources; it appears that digitization of laws from that period is incomplete.
