### PR TITLE
correct spelling of Liechtenstein

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Countries: 198
 ├── KR: 대한민국
 ├── KY: Cayman Islands
 ├── LC: St. Lucia
-├── LI: Lichtenstein
+├── LI: Liechtenstein
 ├── LR: Liberia
 ├── LS: \'Muso oa Lesotho
 ├── LT: Lietuva

--- a/data/countries/LI.yaml
+++ b/data/countries/LI.yaml
@@ -3,8 +3,8 @@ holidays:
   # @source http://www.llv.li/files/apo/Feiertage-und-dienstfreie-Tage-LLV.pdf
   LI:
     names:
-      de: Lichtenstein
-      en: Lichtenstein
+      de: Liechtenstein
+      en: Liechtenstein
     dayoff: sunday
     langs:
       - de


### PR DESCRIPTION
Correct spelling of the country of Liechtenstein. Changed Lichtenstein -> Liechtenstein