### PR TITLE
Remove Easter and Pentecost Sundays from DE-HE

### DIFF
--- a/data/countries/DE.yaml
+++ b/data/countries/DE.yaml
@@ -204,13 +204,9 @@ holidays:
             active:
               - from: 2018-01-01
       HE:
-        # @source http://www.rv.hessenrecht.hessen.de/cgi-bin/lexsoft/capi/hessen.cgi/export_pdf?docid=169523,1&hideVersionDate=1&shortTitleFileName=1&showVersionInfo=1&displayConfig=0&exportLawlist=1&customFooter=Hessische%20Gesetze%20und%20Verwaltungsvorschriften%20in%20Zusammenarbeit%20mit%20Wolters%20Kluwer%20Deutschland%20GmbH&at=1&pid=UAN_nv_3470
+        # @source https://www.rv.hessenrecht.hessen.de/bshe/document/jlr-FeiertGHE1952rahmen
         name: Hessen
         days:
-          easter:
-            _name: easter
-          easter 49:
-            _name: easter 49
           easter 60:
             _name: easter 60
       HH:

--- a/test/fixtures/DE-HE-2015.json
+++ b/test/fixtures/DE-HE-2015.json
@@ -76,7 +76,7 @@
     "start": "2015-04-04T22:00:00.000Z",
     "end": "2015-04-05T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2015-05-23T22:00:00.000Z",
     "end": "2015-05-24T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2016.json
+++ b/test/fixtures/DE-HE-2016.json
@@ -76,7 +76,7 @@
     "start": "2016-03-26T23:00:00.000Z",
     "end": "2016-03-27T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2016-05-14T22:00:00.000Z",
     "end": "2016-05-15T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2017.json
+++ b/test/fixtures/DE-HE-2017.json
@@ -76,7 +76,7 @@
     "start": "2017-04-15T22:00:00.000Z",
     "end": "2017-04-16T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2017-06-03T22:00:00.000Z",
     "end": "2017-06-04T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2018.json
+++ b/test/fixtures/DE-HE-2018.json
@@ -76,7 +76,7 @@
     "start": "2018-03-31T22:00:00.000Z",
     "end": "2018-04-01T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2018-05-19T22:00:00.000Z",
     "end": "2018-05-20T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2019.json
+++ b/test/fixtures/DE-HE-2019.json
@@ -76,7 +76,7 @@
     "start": "2019-04-20T22:00:00.000Z",
     "end": "2019-04-21T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2019-06-08T22:00:00.000Z",
     "end": "2019-06-09T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2020.json
+++ b/test/fixtures/DE-HE-2020.json
@@ -76,7 +76,7 @@
     "start": "2020-04-11T22:00:00.000Z",
     "end": "2020-04-12T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2020-05-30T22:00:00.000Z",
     "end": "2020-05-31T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2021.json
+++ b/test/fixtures/DE-HE-2021.json
@@ -76,7 +76,7 @@
     "start": "2021-04-03T22:00:00.000Z",
     "end": "2021-04-04T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2021-05-22T22:00:00.000Z",
     "end": "2021-05-23T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2022.json
+++ b/test/fixtures/DE-HE-2022.json
@@ -76,7 +76,7 @@
     "start": "2022-04-16T22:00:00.000Z",
     "end": "2022-04-17T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2022-06-04T22:00:00.000Z",
     "end": "2022-06-05T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2023.json
+++ b/test/fixtures/DE-HE-2023.json
@@ -76,7 +76,7 @@
     "start": "2023-04-08T22:00:00.000Z",
     "end": "2023-04-09T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2023-05-27T22:00:00.000Z",
     "end": "2023-05-28T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2024.json
+++ b/test/fixtures/DE-HE-2024.json
@@ -76,7 +76,7 @@
     "start": "2024-03-30T23:00:00.000Z",
     "end": "2024-03-31T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2024-05-18T22:00:00.000Z",
     "end": "2024-05-19T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2025.json
+++ b/test/fixtures/DE-HE-2025.json
@@ -76,7 +76,7 @@
     "start": "2025-04-19T22:00:00.000Z",
     "end": "2025-04-20T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2025-06-07T22:00:00.000Z",
     "end": "2025-06-08T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2026.json
+++ b/test/fixtures/DE-HE-2026.json
@@ -76,7 +76,7 @@
     "start": "2026-04-04T22:00:00.000Z",
     "end": "2026-04-05T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2026-05-23T22:00:00.000Z",
     "end": "2026-05-24T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2027.json
+++ b/test/fixtures/DE-HE-2027.json
@@ -76,7 +76,7 @@
     "start": "2027-03-27T23:00:00.000Z",
     "end": "2027-03-28T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2027-05-15T22:00:00.000Z",
     "end": "2027-05-16T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2028.json
+++ b/test/fixtures/DE-HE-2028.json
@@ -76,7 +76,7 @@
     "start": "2028-04-15T22:00:00.000Z",
     "end": "2028-04-16T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2028-06-03T22:00:00.000Z",
     "end": "2028-06-04T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-HE-2029.json
+++ b/test/fixtures/DE-HE-2029.json
@@ -76,7 +76,7 @@
     "start": "2029-03-31T22:00:00.000Z",
     "end": "2029-04-01T22:00:00.000Z",
     "name": "Ostersonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -121,7 +121,7 @@
     "start": "2029-05-19T22:00:00.000Z",
     "end": "2029-05-20T22:00:00.000Z",
     "name": "Pfingstsonntag",
-    "type": "public",
+    "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
   },


### PR DESCRIPTION
According to the Law in Hessen, neither the Easter nor the Pentecost Sundays are public holidays in Germany-Hessen. See the reference here:

https://www.rv.hessenrecht.hessen.de/bshe/document/jlr-FeiertGHE1952rahmen

Here also as a quote:

--------------
(1) Gesetzliche Feiertage sind die Sonntage sowie
1.  der Neujahrstag,
2.  der Karfreitag,
3.  der Ostermontag,
4.  der 1. Mai,
5.  der Himmelfahrtstag,
6.  der Pfingstmontag,
7.  der Fronleichnamstag,
8.  der Tag der Deutschen Einheit,
9.  der 1. und 2. Weihnachtstag.

(2) Der zweitletzte Sonntag nach Trinitatis ist Gedenktag für die Opfer des Nationalsozialismus und die Toten beider Weltkriege (Volkstrauertag).

(3) Der letzte Sonntag nach Trinitatis ist Totensonntag. 

-------------