### PR TITLE
fix(HK): Fix Hong Kong holidays

### DIFF
--- a/data/countries/HK.yaml
+++ b/data/countries/HK.yaml
@@ -1,12 +1,16 @@
 holidays:
   HK:
     # sources:
+    #   - https://www.gov.hk/en/about/abouthk/holiday/2025.htm
+    #   - https://www.gov.hk/en/about/abouthk/holiday/2024.htm
+    #   - https://www.gov.hk/en/about/abouthk/holiday/2023.htm
     #   - https://www.gov.hk/en/about/abouthk/holiday/2022.htm
     #   - https://www.gov.hk/en/about/abouthk/holiday/2021.htm
     #   - https://www.gov.hk/en/about/abouthk/holiday/2020.htm
     #   - https://www.gov.hk/en/about/abouthk/holiday/2019.htm
     #   - https://www.gov.hk/en/about/abouthk/holiday/2018.htm
     #   - https://www.gov.hk/en/about/abouthk/holiday/2017.htm
+    #   - https://www.gov.hk/en/about/abouthk/holiday/2016.htm
     names:
       zh: 香港
       en: Hong Kong
@@ -17,76 +21,135 @@ holidays:
       - Asia/Hong_Kong
     dayoff: sunday
     days:
-      01-01 and if Sunday then next Monday:
-        substitute: true
-        _name: 01-01
+      01-01 not on Sunday:
         name:
+          en: The first day of January
           zh: 一月一日
-      chinese 01-0-01 and if Saturday then next Tuesday:
+      substitutes 01-01 if Sunday then next Monday:
         name:
-          en: Lunar New Year
+          en: The day following the first day of January
+          zh: 一月一日翌日
+      chinese 01-0-01 not on Sunday:
+        name:
+          en: Lunar New Year’s Day
           zh: 農曆年初一
-      chinese 01-0-02 and if Saturday then next Monday:
+      chinese 01-0-02 not on Sunday:
         name:
-          en: The second day of the Lunar New Year
+          en: The second day of Lunar New Year
           zh: 農曆年初二
-      chinese 01-0-03 and if Saturday then next Monday:
+      chinese 01-0-03 not on Sunday:
         name:
-          en: The third day of the Lunar New Year
+          en: The third day of Lunar New Year
           zh: 農曆年初三
-      chinese 5-01 solarterm and if Sunday then next Monday:
+      substitutes chinese 01-0-01 if Sunday then next Wednesday:
         name:
-          en: Qingming Festival
+          en: The fourth day of Lunar New Year
+          zh: 農曆年初四
+      substitutes chinese 01-0-02 if Sunday then next Tuesday:
+        name:
+          en: The fourth day of Lunar New Year
+          zh: 農曆年初四
+      substitutes chinese 01-0-03 if Sunday then next Monday:
+        name:
+          en: The fourth day of Lunar New Year
+          zh: 農曆年初四
+      chinese 5-01 solarterm not on Sunday:
+        name:
+          en: Ching Ming Festival
           zh: 清明節
+      substitutes chinese 5-01 solarterm if Sunday then next Monday:
+        name:
+          en: The day following Ching Ming Festival
+          zh: 清明節翌日
       easter -2:
-        _name: easter -2
+        name:
+          en: Good Friday
+          zh: 耶穌受難節
       easter -1:
-        _name: easter -1
-      easter:
-        _name: easter
+        name:
+          en: The day following Good Friday
+          zh: 耶穌受難節翌日
       easter 1:
-        _name: easter 1
+        name:
+          en: Easter Monday
+          zh: 復活節星期一
         disable:
           # As the day following Ching Ming Festival and Easter Monday fall on the same day, the next following day that is not itself a general holiday will be observed as an additional general holiday.
-          - "2021-04-05"
-        enable:
-          - "2021-04-06"
-      05-01 and if Sunday then next Monday:
-        substitute: true
-        _name: 05-01
-      chinese 04-0-08 and if Sunday then next Monday:
+          - '2021-04-05'
+      # As the day following Ching Ming Festival and Easter Monday fall on the same day, the next following day that is not itself a general holiday will be observed as an additional general holiday.
+      '2021-04-06':
+        name:
+          en: The day following Easter Monday
+          zh: 復活節星期一翌日
+      05-01 not on Sunday:
+        name:
+          en: Labour Day
+          zh: 勞動節
+      substitutes 05-01 if Sunday then next Monday:
+        name:
+          en: The day following Labour Day
+          zh: 勞動節翌日
+      chinese 04-0-08 not on Sunday:
         name:
           en: Birthday of the Buddha
           zh: 佛誕
-      chinese 05-0-05:
+      substitutes chinese 04-0-08 if Sunday then next Monday:
         name:
-          en: Dragon Boat Festival
-          zh: 端午节
-      07-01 and if Sunday then next Monday:
-        substitute: true
+          en: The day following Birthday of the Buddha
+          zh: 佛誕翌日
+      chinese 05-0-05 not on Sunday:
+        name:
+          en: Tuen Ng Festival
+          zh: 端午節
+      substitutes chinese 05-0-05 if Sunday then next Monday:
+        name:
+          en: The day following Tuen Ng Festival
+          zh: 端午節翌日
+      07-01 not on Sunday:
         name:
           en: Hong Kong Special Administrative Region Establishment Day
           zh: 香港特別行政區成立紀念日
-      chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday:
-        substitute: true
+      substitutes 07-01 if Sunday then next Monday:
+        name:
+          en: The day following Hong Kong Special Administrative Region Establishment Day
+          zh: 香港特別行政區成立紀念日翌日
+      chinese 08-0-16 not on Sunday:
         name:
           en: The day following the Chinese Mid-Autumn Festival
           zh: 中秋節翌日
-      10-01 and if Sunday then next Monday:
-        substitute: true
+      substitutes chinese 08-0-16 if Sunday then next Monday:
+        name:
+          en: The second day following the Chinese Mid-Autumn Festival
+          zh: 中秋節後第二日
+      10-01 not on Sunday:
         name:
           en: National Day
           zh: 國慶日
-      chinese 09-0-09 and if Sunday then next Monday:
-        substitute: true
+      substitutes 10-01 if Sunday then next Monday:
+        name:
+          en: The day following National Day
+          zh: 國慶日翌日
+      chinese 09-0-09 not on Sunday:
         name:
           en: Chung Yeung Festival
-          zh: 重阳节
-      12-25 and if Sunday then next Monday:
-        substitute: true
-        _name: 12-25
-      12-26 and if Sunday then next Monday if Monday then next Tuesday:
-        substitute: true
+          zh: 重陽節
+      substitutes chinese 09-0-09 if Sunday then next Monday:
+        name:
+          en: The day following Chung Yeung Festival
+          zh: 重陽節翌日
+      12-25 not on Sunday:
+        name:
+          en: Christmas Day
+          zh: 聖誕節
+      12-26 not on Sunday:
         name:
           en: The first weekday after Christmas Day
-          zh: 圣诞节后的第一个工作日
+          zh: 聖誕節後第一個周日
+      substitutes 12-25 if Sunday then next Tuesday: # i.e. 12-25 on Sunday
+        name:
+          en: The second weekday after Christmas Day
+          zh: 聖誕節後第二個周日
+      substitutes 12-26 if Sunday then next Monday: # i.e. 12-25 on Saturday, 12-26 on Sunday
+        name:
+          en: The first weekday after Christmas Day
+          zh: 聖誕節後第一個周日

--- a/test/fixtures/HK-2015.json
+++ b/test/fixtures/HK-2015.json
@@ -5,7 +5,7 @@
     "end": "2015-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2015-02-19T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -23,7 +23,7 @@
     "end": "2015-02-20T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -32,17 +32,8 @@
     "end": "2015-02-21T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2015-02-23 00:00:00",
-    "start": "2015-02-22T16:00:00.000Z",
-    "end": "2015-02-23T16:00:00.000Z",
-    "name": "農曆年初三",
-    "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
-    "_weekday": "Mon"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -63,24 +54,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-04T16:00:00.000Z",
-    "end": "2015-04-05T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-04T16:00:00.000Z",
-    "end": "2015-04-05T16:00:00.000Z",
-    "name": "清明節",
-    "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-05T16:00:00.000Z",
     "end": "2015-04-06T16:00:00.000Z",
@@ -93,18 +66,18 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-05T16:00:00.000Z",
     "end": "2015-04-06T16:00:00.000Z",
-    "name": "清明節",
+    "name": "清明節翌日",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "substitutes chinese 5-01 solarterm if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T16:00:00.000Z",
     "end": "2015-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -113,16 +86,16 @@
     "end": "2015-05-25T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2015-06-20 00:00:00",
     "start": "2015-06-19T16:00:00.000Z",
     "end": "2015-06-20T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -131,7 +104,7 @@
     "end": "2015-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -140,7 +113,7 @@
     "end": "2015-09-28T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -149,16 +122,16 @@
     "end": "2015-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Thu"
   },
   {
     "date": "2015-10-21 00:00:00",
     "start": "2015-10-20T16:00:00.000Z",
     "end": "2015-10-21T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -167,16 +140,16 @@
     "end": "2015-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Fri"
   },
   {
     "date": "2015-12-26 00:00:00",
     "start": "2015-12-25T16:00:00.000Z",
     "end": "2015-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/HK-2016.json
+++ b/test/fixtures/HK-2016.json
@@ -5,7 +5,7 @@
     "end": "2016-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2016-02-08T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -23,7 +23,7 @@
     "end": "2016-02-09T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -32,7 +32,7 @@
     "end": "2016-02-10T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -54,15 +54,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-26T16:00:00.000Z",
-    "end": "2016-03-27T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-27T16:00:00.000Z",
     "end": "2016-03-28T16:00:00.000Z",
@@ -77,26 +68,16 @@
     "end": "2016-04-04T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2016-05-01 00:00:00",
-    "start": "2016-04-30T16:00:00.000Z",
-    "end": "2016-05-01T16:00:00.000Z",
-    "name": "劳动节",
-    "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2016-05-02 00:00:00",
     "start": "2016-05-01T16:00:00.000Z",
     "end": "2016-05-02T16:00:00.000Z",
-    "name": "劳动节 (更换日)",
+    "name": "勞動節翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "substitutes 05-01 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -105,16 +86,16 @@
     "end": "2016-05-14T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Sat"
   },
   {
     "date": "2016-06-09 00:00:00",
     "start": "2016-06-08T16:00:00.000Z",
     "end": "2016-06-09T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -123,7 +104,7 @@
     "end": "2016-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -132,7 +113,7 @@
     "end": "2016-09-16T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -141,64 +122,34 @@
     "end": "2016-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2016-10-09 00:00:00",
-    "start": "2016-10-08T16:00:00.000Z",
-    "end": "2016-10-09T16:00:00.000Z",
-    "name": "重阳节",
-    "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2016-10-10 00:00:00",
     "start": "2016-10-09T16:00:00.000Z",
     "end": "2016-10-10T16:00:00.000Z",
-    "name": "重阳节 (更换日)",
+    "name": "重陽節翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2016-12-25 00:00:00",
-    "start": "2016-12-24T16:00:00.000Z",
-    "end": "2016-12-25T16:00:00.000Z",
-    "name": "聖誕節",
-    "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
-    "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-25T16:00:00.000Z",
-    "end": "2016-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
-    "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "substitutes chinese 09-0-09 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
     "date": "2016-12-26 00:00:00",
     "start": "2016-12-25T16:00:00.000Z",
     "end": "2016-12-26T16:00:00.000Z",
-    "name": "聖誕節 (更换日)",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "substitute": true,
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2016-12-27 00:00:00",
     "start": "2016-12-26T16:00:00.000Z",
     "end": "2016-12-27T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日 (更换日)",
+    "name": "聖誕節後第二個周日",
     "type": "public",
-    "substitute": true,
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "substitutes 12-25 if Sunday then next Tuesday",
     "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/HK-2017.json
+++ b/test/fixtures/HK-2017.json
@@ -1,21 +1,11 @@
 [
   {
-    "date": "2017-01-01 00:00:00",
-    "start": "2016-12-31T16:00:00.000Z",
-    "end": "2017-01-01T16:00:00.000Z",
-    "name": "一月一日",
-    "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-01-02 00:00:00",
     "start": "2017-01-01T16:00:00.000Z",
     "end": "2017-01-02T16:00:00.000Z",
-    "name": "一月一日 (更换日)",
+    "name": "一月一日翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "substitutes 01-01 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -24,17 +14,8 @@
     "end": "2017-01-28T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2017-01-29 00:00:00",
-    "start": "2017-01-28T16:00:00.000Z",
-    "end": "2017-01-29T16:00:00.000Z",
-    "name": "農曆年初二",
-    "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2017-01-30 00:00:00",
@@ -42,16 +23,16 @@
     "end": "2017-01-30T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2017-01-31 00:00:00",
     "start": "2017-01-30T16:00:00.000Z",
     "end": "2017-01-31T16:00:00.000Z",
-    "name": "農曆年初一",
+    "name": "農曆年初四",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "substitutes chinese 01-0-02 if Sunday then next Tuesday",
     "_weekday": "Tue"
   },
   {
@@ -60,7 +41,7 @@
     "end": "2017-04-04T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -82,15 +63,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-15T16:00:00.000Z",
-    "end": "2017-04-16T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T16:00:00.000Z",
     "end": "2017-04-17T16:00:00.000Z",
@@ -103,9 +75,9 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T16:00:00.000Z",
     "end": "2017-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -114,16 +86,16 @@
     "end": "2017-05-03T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Wed"
   },
   {
     "date": "2017-05-30 00:00:00",
     "start": "2017-05-29T16:00:00.000Z",
     "end": "2017-05-30T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -132,26 +104,16 @@
     "end": "2017-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2017-10-01 00:00:00",
-    "start": "2017-09-30T16:00:00.000Z",
-    "end": "2017-10-01T16:00:00.000Z",
-    "name": "國慶日",
-    "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2017-10-02 00:00:00",
     "start": "2017-10-01T16:00:00.000Z",
     "end": "2017-10-02T16:00:00.000Z",
-    "name": "國慶日 (更换日)",
+    "name": "國慶日翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "substitutes 10-01 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -160,16 +122,16 @@
     "end": "2017-10-05T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Thu"
   },
   {
     "date": "2017-10-28 00:00:00",
     "start": "2017-10-27T16:00:00.000Z",
     "end": "2017-10-28T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -178,16 +140,16 @@
     "end": "2017-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2017-12-26 00:00:00",
     "start": "2017-12-25T16:00:00.000Z",
     "end": "2017-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/HK-2018.json
+++ b/test/fixtures/HK-2018.json
@@ -5,7 +5,7 @@
     "end": "2018-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2018-02-16T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -23,25 +23,16 @@
     "end": "2018-02-17T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2018-02-18 00:00:00",
-    "start": "2018-02-17T16:00:00.000Z",
-    "end": "2018-02-18T16:00:00.000Z",
-    "name": "農曆年初三",
-    "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2018-02-19 00:00:00",
     "start": "2018-02-18T16:00:00.000Z",
     "end": "2018-02-19T16:00:00.000Z",
-    "name": "農曆年初二",
+    "name": "農曆年初四",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "substitutes chinese 01-0-03 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -63,15 +54,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-03-31T16:00:00.000Z",
-    "end": "2018-04-01T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-01T16:00:00.000Z",
     "end": "2018-04-02T16:00:00.000Z",
@@ -86,16 +68,16 @@
     "end": "2018-04-05T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Thu"
   },
   {
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T16:00:00.000Z",
     "end": "2018-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -104,35 +86,25 @@
     "end": "2018-05-22T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Tue"
   },
   {
     "date": "2018-06-18 00:00:00",
     "start": "2018-06-17T16:00:00.000Z",
     "end": "2018-06-18T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2018-07-01 00:00:00",
-    "start": "2018-06-30T16:00:00.000Z",
-    "end": "2018-07-01T16:00:00.000Z",
-    "name": "香港特別行政區成立紀念日",
-    "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2018-07-02 00:00:00",
     "start": "2018-07-01T16:00:00.000Z",
     "end": "2018-07-02T16:00:00.000Z",
-    "name": "香港特別行政區成立紀念日 (更换日)",
+    "name": "香港特別行政區成立紀念日翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "substitutes 07-01 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -141,7 +113,7 @@
     "end": "2018-09-25T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -150,16 +122,16 @@
     "end": "2018-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2018-10-17 00:00:00",
     "start": "2018-10-16T16:00:00.000Z",
     "end": "2018-10-17T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -168,16 +140,16 @@
     "end": "2018-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Tue"
   },
   {
     "date": "2018-12-26 00:00:00",
     "start": "2018-12-25T16:00:00.000Z",
     "end": "2018-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/HK-2019.json
+++ b/test/fixtures/HK-2019.json
@@ -5,7 +5,7 @@
     "end": "2019-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2019-02-05T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -23,7 +23,7 @@
     "end": "2019-02-06T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -32,7 +32,7 @@
     "end": "2019-02-07T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -41,7 +41,7 @@
     "end": "2019-04-05T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -63,15 +63,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-20T16:00:00.000Z",
-    "end": "2019-04-21T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-21T16:00:00.000Z",
     "end": "2019-04-22T16:00:00.000Z",
@@ -84,36 +75,27 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T16:00:00.000Z",
     "end": "2019-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-05-12 00:00:00",
-    "start": "2019-05-11T16:00:00.000Z",
-    "end": "2019-05-12T16:00:00.000Z",
-    "name": "佛誕",
-    "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2019-05-13 00:00:00",
     "start": "2019-05-12T16:00:00.000Z",
     "end": "2019-05-13T16:00:00.000Z",
-    "name": "佛誕",
+    "name": "佛誕翌日",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "substitutes chinese 04-0-08 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
     "date": "2019-06-07 00:00:00",
     "start": "2019-06-06T16:00:00.000Z",
     "end": "2019-06-07T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -122,7 +104,7 @@
     "end": "2019-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -131,7 +113,7 @@
     "end": "2019-09-14T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -140,16 +122,16 @@
     "end": "2019-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Tue"
   },
   {
     "date": "2019-10-07 00:00:00",
     "start": "2019-10-06T16:00:00.000Z",
     "end": "2019-10-07T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -158,16 +140,16 @@
     "end": "2019-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Wed"
   },
   {
     "date": "2019-12-26 00:00:00",
     "start": "2019-12-25T16:00:00.000Z",
     "end": "2019-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/HK-2020.json
+++ b/test/fixtures/HK-2020.json
@@ -5,7 +5,7 @@
     "end": "2020-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -14,17 +14,8 @@
     "end": "2020-01-25T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2020-01-26 00:00:00",
-    "start": "2020-01-25T16:00:00.000Z",
-    "end": "2020-01-26T16:00:00.000Z",
-    "name": "農曆年初二",
-    "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2020-01-27 00:00:00",
@@ -32,16 +23,16 @@
     "end": "2020-01-27T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2020-01-28 00:00:00",
     "start": "2020-01-27T16:00:00.000Z",
     "end": "2020-01-28T16:00:00.000Z",
-    "name": "農曆年初一",
+    "name": "農曆年初四",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "substitutes chinese 01-0-02 if Sunday then next Tuesday",
     "_weekday": "Tue"
   },
   {
@@ -50,7 +41,7 @@
     "end": "2020-04-04T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -72,15 +63,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-11T16:00:00.000Z",
-    "end": "2020-04-12T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-12T16:00:00.000Z",
     "end": "2020-04-13T16:00:00.000Z",
@@ -95,25 +77,25 @@
     "end": "2020-04-30T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Thu"
   },
   {
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T16:00:00.000Z",
     "end": "2020-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Fri"
   },
   {
     "date": "2020-06-25 00:00:00",
     "start": "2020-06-24T16:00:00.000Z",
     "end": "2020-06-25T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -122,7 +104,7 @@
     "end": "2020-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -131,7 +113,7 @@
     "end": "2020-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -140,26 +122,16 @@
     "end": "2020-10-02T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-10-25 00:00:00",
-    "start": "2020-10-24T16:00:00.000Z",
-    "end": "2020-10-25T16:00:00.000Z",
-    "name": "重阳节",
-    "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2020-10-26 00:00:00",
     "start": "2020-10-25T16:00:00.000Z",
     "end": "2020-10-26T16:00:00.000Z",
-    "name": "重阳节 (更换日)",
+    "name": "重陽節翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "substitutes chinese 09-0-09 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -168,16 +140,16 @@
     "end": "2020-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Fri"
   },
   {
     "date": "2020-12-26 00:00:00",
     "start": "2020-12-25T16:00:00.000Z",
     "end": "2020-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/HK-2021.json
+++ b/test/fixtures/HK-2021.json
@@ -5,7 +5,7 @@
     "end": "2021-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2021-02-12T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -23,25 +23,16 @@
     "end": "2021-02-13T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-02-14 00:00:00",
-    "start": "2021-02-13T16:00:00.000Z",
-    "end": "2021-02-14T16:00:00.000Z",
-    "name": "農曆年初三",
-    "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2021-02-15 00:00:00",
     "start": "2021-02-14T16:00:00.000Z",
     "end": "2021-02-15T16:00:00.000Z",
-    "name": "農曆年初二",
+    "name": "農曆年初四",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "substitutes chinese 01-0-03 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -63,48 +54,30 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-03T16:00:00.000Z",
-    "end": "2021-04-04T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-03T16:00:00.000Z",
-    "end": "2021-04-04T16:00:00.000Z",
-    "name": "清明節",
-    "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-04T16:00:00.000Z",
     "end": "2021-04-05T16:00:00.000Z",
-    "name": "清明節",
+    "name": "清明節翌日",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "substitutes chinese 5-01 solarterm if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
     "date": "2021-04-06 00:00:00",
     "start": "2021-04-05T16:00:00.000Z",
     "end": "2021-04-06T16:00:00.000Z",
-    "name": "復活節星期一",
+    "name": "復活節星期一翌日",
     "type": "public",
-    "rule": "easter 1",
+    "rule": "2021-04-06",
     "_weekday": "Tue"
   },
   {
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T16:00:00.000Z",
     "end": "2021-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -113,16 +86,16 @@
     "end": "2021-05-19T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Wed"
   },
   {
     "date": "2021-06-14 00:00:00",
     "start": "2021-06-13T16:00:00.000Z",
     "end": "2021-06-14T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -131,7 +104,7 @@
     "end": "2021-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -140,7 +113,7 @@
     "end": "2021-09-22T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -149,16 +122,16 @@
     "end": "2021-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Fri"
   },
   {
     "date": "2021-10-14 00:00:00",
     "start": "2021-10-13T16:00:00.000Z",
     "end": "2021-10-14T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -167,26 +140,16 @@
     "end": "2021-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-25T16:00:00.000Z",
-    "end": "2021-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
-    "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
-    "_weekday": "Sun"
   },
   {
     "date": "2021-12-27 00:00:00",
     "start": "2021-12-26T16:00:00.000Z",
     "end": "2021-12-27T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日 (更换日)",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "substitute": true,
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "substitutes 12-26 if Sunday then next Monday",
     "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/HK-2022.json
+++ b/test/fixtures/HK-2022.json
@@ -5,7 +5,7 @@
     "end": "2022-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2022-02-01T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -23,7 +23,7 @@
     "end": "2022-02-02T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -32,7 +32,7 @@
     "end": "2022-02-03T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -41,7 +41,7 @@
     "end": "2022-04-05T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -63,15 +63,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-16T16:00:00.000Z",
-    "end": "2022-04-17T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-17T16:00:00.000Z",
     "end": "2022-04-18T16:00:00.000Z",
@@ -81,49 +72,30 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-05-01 00:00:00",
-    "start": "2022-04-30T16:00:00.000Z",
-    "end": "2022-05-01T16:00:00.000Z",
-    "name": "劳动节",
-    "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-05-02 00:00:00",
     "start": "2022-05-01T16:00:00.000Z",
     "end": "2022-05-02T16:00:00.000Z",
-    "name": "劳动节 (更换日)",
+    "name": "勞動節翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "substitutes 05-01 if Sunday then next Monday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2022-05-08 00:00:00",
-    "start": "2022-05-07T16:00:00.000Z",
-    "end": "2022-05-08T16:00:00.000Z",
-    "name": "佛誕",
-    "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2022-05-09 00:00:00",
     "start": "2022-05-08T16:00:00.000Z",
     "end": "2022-05-09T16:00:00.000Z",
-    "name": "佛誕",
+    "name": "佛誕翌日",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "substitutes chinese 04-0-08 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
     "date": "2022-06-03 00:00:00",
     "start": "2022-06-02T16:00:00.000Z",
     "end": "2022-06-03T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -132,26 +104,16 @@
     "end": "2022-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2022-09-11 00:00:00",
-    "start": "2022-09-10T16:00:00.000Z",
-    "end": "2022-09-11T16:00:00.000Z",
-    "name": "中秋節翌日",
-    "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
-    "_weekday": "Sun"
   },
   {
     "date": "2022-09-12 00:00:00",
     "start": "2022-09-11T16:00:00.000Z",
     "end": "2022-09-12T16:00:00.000Z",
-    "name": "中秋節翌日 (更换日)",
+    "name": "中秋節後第二日",
     "type": "public",
-    "substitute": true,
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "substitutes chinese 08-0-16 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -160,54 +122,34 @@
     "end": "2022-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Sat"
   },
   {
     "date": "2022-10-04 00:00:00",
     "start": "2022-10-03T16:00:00.000Z",
     "end": "2022-10-04T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Tue"
   },
   {
-    "date": "2022-12-25 00:00:00",
-    "start": "2022-12-24T16:00:00.000Z",
-    "end": "2022-12-25T16:00:00.000Z",
-    "name": "聖誕節",
-    "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-12-26 00:00:00",
     "start": "2022-12-25T16:00:00.000Z",
     "end": "2022-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-25T16:00:00.000Z",
-    "end": "2022-12-26T16:00:00.000Z",
-    "name": "聖誕節 (更换日)",
-    "type": "public",
-    "substitute": true,
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2022-12-27 00:00:00",
     "start": "2022-12-26T16:00:00.000Z",
     "end": "2022-12-27T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日 (更换日)",
+    "name": "聖誕節後第二個周日",
     "type": "public",
-    "substitute": true,
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "substitutes 12-25 if Sunday then next Tuesday",
     "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/HK-2023.json
+++ b/test/fixtures/HK-2023.json
@@ -1,31 +1,12 @@
 [
   {
-    "date": "2023-01-01 00:00:00",
-    "start": "2022-12-31T16:00:00.000Z",
-    "end": "2023-01-01T16:00:00.000Z",
-    "name": "一月一日",
-    "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-01-02 00:00:00",
     "start": "2023-01-01T16:00:00.000Z",
     "end": "2023-01-02T16:00:00.000Z",
-    "name": "一月一日 (更换日)",
+    "name": "一月一日翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "substitutes 01-01 if Sunday then next Monday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-01-22 00:00:00",
-    "start": "2023-01-21T16:00:00.000Z",
-    "end": "2023-01-22T16:00:00.000Z",
-    "name": "農曆年初一",
-    "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
-    "_weekday": "Sun"
   },
   {
     "date": "2023-01-23 00:00:00",
@@ -33,7 +14,7 @@
     "end": "2023-01-23T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -42,8 +23,17 @@
     "end": "2023-01-24T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2023-01-25 00:00:00",
+    "start": "2023-01-24T16:00:00.000Z",
+    "end": "2023-01-25T16:00:00.000Z",
+    "name": "農曆年初四",
+    "type": "public",
+    "rule": "substitutes chinese 01-0-01 if Sunday then next Wednesday",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-05 00:00:00",
@@ -51,7 +41,7 @@
     "end": "2023-04-05T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -73,15 +63,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-08T16:00:00.000Z",
-    "end": "2023-04-09T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-09T16:00:00.000Z",
     "end": "2023-04-10T16:00:00.000Z",
@@ -94,9 +75,9 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T16:00:00.000Z",
     "end": "2023-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -105,16 +86,16 @@
     "end": "2023-05-26T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Fri"
   },
   {
     "date": "2023-06-22 00:00:00",
     "start": "2023-06-21T16:00:00.000Z",
     "end": "2023-06-22T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -123,7 +104,7 @@
     "end": "2023-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -132,35 +113,25 @@
     "end": "2023-09-30T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2023-10-01 00:00:00",
-    "start": "2023-09-30T16:00:00.000Z",
-    "end": "2023-10-01T16:00:00.000Z",
-    "name": "國慶日",
-    "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2023-10-02 00:00:00",
     "start": "2023-10-01T16:00:00.000Z",
     "end": "2023-10-02T16:00:00.000Z",
-    "name": "國慶日 (更换日)",
+    "name": "國慶日翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "substitutes 10-01 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
     "date": "2023-10-23 00:00:00",
     "start": "2023-10-22T16:00:00.000Z",
     "end": "2023-10-23T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -169,16 +140,16 @@
     "end": "2023-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2023-12-26 00:00:00",
     "start": "2023-12-25T16:00:00.000Z",
     "end": "2023-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/HK-2024.json
+++ b/test/fixtures/HK-2024.json
@@ -5,7 +5,7 @@
     "end": "2024-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -14,17 +14,8 @@
     "end": "2024-02-10T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2024-02-11 00:00:00",
-    "start": "2024-02-10T16:00:00.000Z",
-    "end": "2024-02-11T16:00:00.000Z",
-    "name": "農曆年初二",
-    "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2024-02-12 00:00:00",
@@ -32,16 +23,16 @@
     "end": "2024-02-12T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2024-02-13 00:00:00",
     "start": "2024-02-12T16:00:00.000Z",
     "end": "2024-02-13T16:00:00.000Z",
-    "name": "農曆年初一",
+    "name": "農曆年初四",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "substitutes chinese 01-0-02 if Sunday then next Tuesday",
     "_weekday": "Tue"
   },
   {
@@ -63,15 +54,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-30T16:00:00.000Z",
-    "end": "2024-03-31T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-04-01 00:00:00",
     "start": "2024-03-31T16:00:00.000Z",
     "end": "2024-04-01T16:00:00.000Z",
@@ -86,16 +68,16 @@
     "end": "2024-04-04T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Thu"
   },
   {
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T16:00:00.000Z",
     "end": "2024-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -104,16 +86,16 @@
     "end": "2024-05-15T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Wed"
   },
   {
     "date": "2024-06-10 00:00:00",
     "start": "2024-06-09T16:00:00.000Z",
     "end": "2024-06-10T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -122,7 +104,7 @@
     "end": "2024-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -131,7 +113,7 @@
     "end": "2024-09-18T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -140,16 +122,16 @@
     "end": "2024-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Tue"
   },
   {
     "date": "2024-10-11 00:00:00",
     "start": "2024-10-10T16:00:00.000Z",
     "end": "2024-10-11T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -158,16 +140,16 @@
     "end": "2024-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Wed"
   },
   {
     "date": "2024-12-26 00:00:00",
     "start": "2024-12-25T16:00:00.000Z",
     "end": "2024-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/HK-2025.json
+++ b/test/fixtures/HK-2025.json
@@ -5,7 +5,7 @@
     "end": "2025-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2025-01-29T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -23,7 +23,7 @@
     "end": "2025-01-30T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -32,7 +32,7 @@
     "end": "2025-01-31T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -41,7 +41,7 @@
     "end": "2025-04-04T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -63,15 +63,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-19T16:00:00.000Z",
-    "end": "2025-04-20T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T16:00:00.000Z",
     "end": "2025-04-21T16:00:00.000Z",
@@ -84,9 +75,9 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T16:00:00.000Z",
     "end": "2025-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -95,16 +86,16 @@
     "end": "2025-05-05T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2025-05-31 00:00:00",
     "start": "2025-05-30T16:00:00.000Z",
     "end": "2025-05-31T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -113,7 +104,7 @@
     "end": "2025-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -122,7 +113,7 @@
     "end": "2025-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -131,16 +122,16 @@
     "end": "2025-10-07T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Tue"
   },
   {
     "date": "2025-10-29 00:00:00",
     "start": "2025-10-28T16:00:00.000Z",
     "end": "2025-10-29T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -149,16 +140,16 @@
     "end": "2025-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Thu"
   },
   {
     "date": "2025-12-26 00:00:00",
     "start": "2025-12-25T16:00:00.000Z",
     "end": "2025-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/HK-2026.json
+++ b/test/fixtures/HK-2026.json
@@ -5,7 +5,7 @@
     "end": "2026-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2026-02-17T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -23,7 +23,7 @@
     "end": "2026-02-18T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -32,7 +32,7 @@
     "end": "2026-02-19T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -54,24 +54,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-04T16:00:00.000Z",
-    "end": "2026-04-05T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-04T16:00:00.000Z",
-    "end": "2026-04-05T16:00:00.000Z",
-    "name": "清明節",
-    "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-05T16:00:00.000Z",
     "end": "2026-04-06T16:00:00.000Z",
@@ -84,45 +66,36 @@
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-05T16:00:00.000Z",
     "end": "2026-04-06T16:00:00.000Z",
-    "name": "清明節",
+    "name": "清明節翌日",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "substitutes chinese 5-01 solarterm if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T16:00:00.000Z",
     "end": "2026-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-05-24 00:00:00",
-    "start": "2026-05-23T16:00:00.000Z",
-    "end": "2026-05-24T16:00:00.000Z",
-    "name": "佛誕",
-    "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2026-05-25 00:00:00",
     "start": "2026-05-24T16:00:00.000Z",
     "end": "2026-05-25T16:00:00.000Z",
-    "name": "佛誕",
+    "name": "佛誕翌日",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "substitutes chinese 04-0-08 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
     "date": "2026-06-19 00:00:00",
     "start": "2026-06-18T16:00:00.000Z",
     "end": "2026-06-19T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -131,7 +104,7 @@
     "end": "2026-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -140,7 +113,7 @@
     "end": "2026-09-26T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -149,26 +122,16 @@
     "end": "2026-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2026-10-18 00:00:00",
-    "start": "2026-10-17T16:00:00.000Z",
-    "end": "2026-10-18T16:00:00.000Z",
-    "name": "重阳节",
-    "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2026-10-19 00:00:00",
     "start": "2026-10-18T16:00:00.000Z",
     "end": "2026-10-19T16:00:00.000Z",
-    "name": "重阳节 (更换日)",
+    "name": "重陽節翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "substitutes chinese 09-0-09 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -177,16 +140,16 @@
     "end": "2026-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Fri"
   },
   {
     "date": "2026-12-26 00:00:00",
     "start": "2026-12-25T16:00:00.000Z",
     "end": "2026-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/HK-2027.json
+++ b/test/fixtures/HK-2027.json
@@ -5,7 +5,7 @@
     "end": "2027-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -14,17 +14,8 @@
     "end": "2027-02-06T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-02-07 00:00:00",
-    "start": "2027-02-06T16:00:00.000Z",
-    "end": "2027-02-07T16:00:00.000Z",
-    "name": "農曆年初二",
-    "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2027-02-08 00:00:00",
@@ -32,16 +23,16 @@
     "end": "2027-02-08T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2027-02-09 00:00:00",
     "start": "2027-02-08T16:00:00.000Z",
     "end": "2027-02-09T16:00:00.000Z",
-    "name": "農曆年初一",
+    "name": "農曆年初四",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "substitutes chinese 01-0-02 if Sunday then next Tuesday",
     "_weekday": "Tue"
   },
   {
@@ -63,15 +54,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-27T16:00:00.000Z",
-    "end": "2027-03-28T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-28T16:00:00.000Z",
     "end": "2027-03-29T16:00:00.000Z",
@@ -86,16 +68,16 @@
     "end": "2027-04-05T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T16:00:00.000Z",
     "end": "2027-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -104,16 +86,16 @@
     "end": "2027-05-13T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Thu"
   },
   {
     "date": "2027-06-09 00:00:00",
     "start": "2027-06-08T16:00:00.000Z",
     "end": "2027-06-09T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -122,7 +104,7 @@
     "end": "2027-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -131,7 +113,7 @@
     "end": "2027-09-16T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -140,16 +122,16 @@
     "end": "2027-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Fri"
   },
   {
     "date": "2027-10-08 00:00:00",
     "start": "2027-10-07T16:00:00.000Z",
     "end": "2027-10-08T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -158,26 +140,16 @@
     "end": "2027-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-25T16:00:00.000Z",
-    "end": "2027-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
-    "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
-    "_weekday": "Sun"
   },
   {
     "date": "2027-12-27 00:00:00",
     "start": "2027-12-26T16:00:00.000Z",
     "end": "2027-12-27T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日 (更换日)",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "substitute": true,
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "substitutes 12-26 if Sunday then next Monday",
     "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/HK-2028.json
+++ b/test/fixtures/HK-2028.json
@@ -5,7 +5,7 @@
     "end": "2028-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Sat"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2028-01-26T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -23,7 +23,7 @@
     "end": "2028-01-27T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -32,7 +32,7 @@
     "end": "2028-01-28T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Fri"
   },
   {
@@ -41,7 +41,7 @@
     "end": "2028-04-04T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -63,15 +63,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-15T16:00:00.000Z",
-    "end": "2028-04-16T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T16:00:00.000Z",
     "end": "2028-04-17T16:00:00.000Z",
@@ -84,9 +75,9 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T16:00:00.000Z",
     "end": "2028-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -95,17 +86,17 @@
     "end": "2028-05-02T16:00:00.000Z",
     "name": "佛誕",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "chinese 04-0-08 not on Sunday",
     "_weekday": "Tue"
   },
   {
-    "date": "2028-05-28 00:00:00",
-    "start": "2028-05-27T16:00:00.000Z",
-    "end": "2028-05-28T16:00:00.000Z",
-    "name": "端午节",
+    "date": "2028-05-29 00:00:00",
+    "start": "2028-05-28T16:00:00.000Z",
+    "end": "2028-05-29T16:00:00.000Z",
+    "name": "端午節翌日",
     "type": "public",
-    "rule": "chinese 05-0-05",
-    "_weekday": "Sun"
+    "rule": "substitutes chinese 05-0-05 if Sunday then next Monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2028-07-01 00:00:00",
@@ -113,26 +104,16 @@
     "end": "2028-07-01T16:00:00.000Z",
     "name": "香港特別行政區成立紀念日",
     "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "07-01 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2028-10-01 00:00:00",
-    "start": "2028-09-30T16:00:00.000Z",
-    "end": "2028-10-01T16:00:00.000Z",
-    "name": "國慶日",
-    "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2028-10-02 00:00:00",
     "start": "2028-10-01T16:00:00.000Z",
     "end": "2028-10-02T16:00:00.000Z",
-    "name": "國慶日 (更换日)",
+    "name": "國慶日翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "substitutes 10-01 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -141,16 +122,16 @@
     "end": "2028-10-04T16:00:00.000Z",
     "name": "中秋節翌日",
     "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "chinese 08-0-16 not on Sunday",
     "_weekday": "Wed"
   },
   {
     "date": "2028-10-26 00:00:00",
     "start": "2028-10-25T16:00:00.000Z",
     "end": "2028-10-26T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -159,16 +140,16 @@
     "end": "2028-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2028-12-26 00:00:00",
     "start": "2028-12-25T16:00:00.000Z",
     "end": "2028-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/HK-2029.json
+++ b/test/fixtures/HK-2029.json
@@ -5,7 +5,7 @@
     "end": "2029-01-01T16:00:00.000Z",
     "name": "一月一日",
     "type": "public",
-    "rule": "01-01 and if Sunday then next Monday",
+    "rule": "01-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2029-02-13T16:00:00.000Z",
     "name": "農曆年初一",
     "type": "public",
-    "rule": "chinese 01-0-01 and if Saturday then next Tuesday",
+    "rule": "chinese 01-0-01 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -23,7 +23,7 @@
     "end": "2029-02-14T16:00:00.000Z",
     "name": "農曆年初二",
     "type": "public",
-    "rule": "chinese 01-0-02 and if Saturday then next Monday",
+    "rule": "chinese 01-0-02 not on Sunday",
     "_weekday": "Wed"
   },
   {
@@ -32,7 +32,7 @@
     "end": "2029-02-15T16:00:00.000Z",
     "name": "農曆年初三",
     "type": "public",
-    "rule": "chinese 01-0-03 and if Saturday then next Monday",
+    "rule": "chinese 01-0-03 not on Sunday",
     "_weekday": "Thu"
   },
   {
@@ -54,15 +54,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-03-31T16:00:00.000Z",
-    "end": "2029-04-01T16:00:00.000Z",
-    "name": "复活节",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-01T16:00:00.000Z",
     "end": "2029-04-02T16:00:00.000Z",
@@ -77,81 +68,52 @@
     "end": "2029-04-04T16:00:00.000Z",
     "name": "清明節",
     "type": "public",
-    "rule": "chinese 5-01 solarterm and if Sunday then next Monday",
+    "rule": "chinese 5-01 solarterm not on Sunday",
     "_weekday": "Wed"
   },
   {
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T16:00:00.000Z",
     "end": "2029-05-01T16:00:00.000Z",
-    "name": "劳动节",
+    "name": "勞動節",
     "type": "public",
-    "rule": "05-01 and if Sunday then next Monday",
+    "rule": "05-01 not on Sunday",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-05-20 00:00:00",
-    "start": "2029-05-19T16:00:00.000Z",
-    "end": "2029-05-20T16:00:00.000Z",
-    "name": "佛誕",
-    "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2029-05-21 00:00:00",
     "start": "2029-05-20T16:00:00.000Z",
     "end": "2029-05-21T16:00:00.000Z",
-    "name": "佛誕",
+    "name": "佛誕翌日",
     "type": "public",
-    "rule": "chinese 04-0-08 and if Sunday then next Monday",
+    "rule": "substitutes chinese 04-0-08 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
     "date": "2029-06-16 00:00:00",
     "start": "2029-06-15T16:00:00.000Z",
     "end": "2029-06-16T16:00:00.000Z",
-    "name": "端午节",
+    "name": "端午節",
     "type": "public",
-    "rule": "chinese 05-0-05",
+    "rule": "chinese 05-0-05 not on Sunday",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2029-07-01 00:00:00",
-    "start": "2029-06-30T16:00:00.000Z",
-    "end": "2029-07-01T16:00:00.000Z",
-    "name": "香港特別行政區成立紀念日",
-    "type": "public",
-    "rule": "07-01 and if Sunday then next Monday",
-    "_weekday": "Sun"
   },
   {
     "date": "2029-07-02 00:00:00",
     "start": "2029-07-01T16:00:00.000Z",
     "end": "2029-07-02T16:00:00.000Z",
-    "name": "香港特別行政區成立紀念日 (更换日)",
+    "name": "香港特別行政區成立紀念日翌日",
     "type": "public",
-    "substitute": true,
-    "rule": "07-01 and if Sunday then next Monday",
+    "rule": "substitutes 07-01 if Sunday then next Monday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2029-09-23 00:00:00",
-    "start": "2029-09-22T16:00:00.000Z",
-    "end": "2029-09-23T16:00:00.000Z",
-    "name": "中秋節翌日",
-    "type": "public",
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
-    "_weekday": "Sun"
   },
   {
     "date": "2029-09-24 00:00:00",
     "start": "2029-09-23T16:00:00.000Z",
     "end": "2029-09-24T16:00:00.000Z",
-    "name": "中秋節翌日 (更换日)",
+    "name": "中秋節後第二日",
     "type": "public",
-    "substitute": true,
-    "rule": "chinese 08-0-16 and if Sunday then next Monday if is public holiday then next day omit Saturday, Sunday",
+    "rule": "substitutes chinese 08-0-16 if Sunday then next Monday",
     "_weekday": "Mon"
   },
   {
@@ -160,16 +122,16 @@
     "end": "2029-10-01T16:00:00.000Z",
     "name": "國慶日",
     "type": "public",
-    "rule": "10-01 and if Sunday then next Monday",
+    "rule": "10-01 not on Sunday",
     "_weekday": "Mon"
   },
   {
     "date": "2029-10-16 00:00:00",
     "start": "2029-10-15T16:00:00.000Z",
     "end": "2029-10-16T16:00:00.000Z",
-    "name": "重阳节",
+    "name": "重陽節",
     "type": "public",
-    "rule": "chinese 09-0-09 and if Sunday then next Monday",
+    "rule": "chinese 09-0-09 not on Sunday",
     "_weekday": "Tue"
   },
   {
@@ -178,16 +140,16 @@
     "end": "2029-12-25T16:00:00.000Z",
     "name": "聖誕節",
     "type": "public",
-    "rule": "12-25 and if Sunday then next Monday",
+    "rule": "12-25 not on Sunday",
     "_weekday": "Tue"
   },
   {
     "date": "2029-12-26 00:00:00",
     "start": "2029-12-25T16:00:00.000Z",
     "end": "2029-12-26T16:00:00.000Z",
-    "name": "圣诞节后的第一个工作日",
+    "name": "聖誕節後第一個周日",
     "type": "public",
-    "rule": "12-26 and if Sunday then next Monday if Monday then next Tuesday",
+    "rule": "12-26 not on Sunday",
     "_weekday": "Wed"
   }
 ]


### PR DESCRIPTION
1. Standardize on Traditional Chinese only (instead of mixing them with some of the Simplified Chinese). Not appending substitute day string also for this reason.
2. Fix holidays fall on Sunday.
3. Format follows official gov website (https://www.gov.hk/en/about/abouthk/holiday), according to data on 2016-2025.