### PR TITLE
ci: add node 24 to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 20, 22 ]
+        node: [ 20, 22, 24 ]
     name: Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes Node.js 24 in the testing matrix.