### PR TITLE
Add National Indigenous Peoples Day for Yukon Province Canada

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,16 +10,20 @@ If you like to add or change data please take a look at [holidays.yaml specifica
 
 1. Fork the project
 2. Create a branch for your changes
-3. Build the project:
+3. Install dependencies:
+   ```
+   npm install
+   ```
+4. Build the project:
    ```
    npm run build
    ```
-4. Modify the yaml file for the country your changes apply in `./data/countries/<code>.yaml` for holiday data and/or `./data/names.yaml` for translations as appropriate
-5. Generate the Json file from the yaml files with
+5. Modify the yaml file for the country your changes apply in `./data/countries/<code>.yaml` for holiday data and/or `./data/names.yaml` for translations as appropriate
+6. Generate the Json file from the yaml files with
    ```
    npm run yaml
    ```
-6. Run the samples file with the country containing your changes, e.g. here for "at.w" (Austria, Vienna)
+7. Run the samples file with the country containing your changes, e.g. here for "at.w" (Austria, Vienna)
    ```
    node test/sample.js "at.w" 2016
    ```
@@ -27,11 +31,11 @@ If you like to add or change data please take a look at [holidays.yaml specifica
    ```
    node test/sample.js "at.w" 2016 --lang en
    ```
-7. Run the tests with
+8. Run the tests with
    ```
    npm test
    ```
-8. If a new country was added there might be failing tests in Step 7.
+9. If a new country was added there might be failing tests in Step 7.
    Generate these with:
    ```
    npx mocha test/all.mocha.js --writetests
@@ -39,8 +43,8 @@ If you like to add or change data please take a look at [holidays.yaml specifica
    npx mocha test/all.mocha.js --writetests --countries AD
    ```
    Now check any changes with `git diff test/fixtures`. Make sure that your changes did not affect other countries.
-9. Push your branch to GitHub and submit a pull request
-10. Monitor the pull request to make sure the Travis build succeeds.
+10. Push your branch to GitHub and submit a pull request
+11. Monitor the pull request to make sure the Travis build succeeds.
    If it fails simply make the necessary changes to your branch and push it.
 Travis will re-test the changes.
 

--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -216,7 +216,7 @@ holidays:
           - America/Yellowknife
           - America/Inuvik
         days:
-          06-21:
+          06-21 since 2001:
             name:
               en: National Indigenous Peoples Day
               fr: Journée nationale des Autochthones
@@ -313,3 +313,7 @@ holidays:
             name:
               en: Discovery Day
               fr: Jour de la Découverte
+          06-21 since 2017:
+            name:
+              en: National Indigenous Peoples Day
+              fr: Journée nationale des Autochthones

--- a/test/fixtures/CA-NT-2015.json
+++ b/test/fixtures/CA-NT-2015.json
@@ -86,7 +86,7 @@
     "end": "2015-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/CA-NT-2016.json
+++ b/test/fixtures/CA-NT-2016.json
@@ -86,7 +86,7 @@
     "end": "2016-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/CA-NT-2017.json
+++ b/test/fixtures/CA-NT-2017.json
@@ -86,7 +86,7 @@
     "end": "2017-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/CA-NT-2018.json
+++ b/test/fixtures/CA-NT-2018.json
@@ -86,7 +86,7 @@
     "end": "2018-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/CA-NT-2019.json
+++ b/test/fixtures/CA-NT-2019.json
@@ -86,7 +86,7 @@
     "end": "2019-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/CA-NT-2020.json
+++ b/test/fixtures/CA-NT-2020.json
@@ -86,7 +86,7 @@
     "end": "2020-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/CA-NT-2021.json
+++ b/test/fixtures/CA-NT-2021.json
@@ -86,7 +86,7 @@
     "end": "2021-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2022.json
+++ b/test/fixtures/CA-NT-2022.json
@@ -86,7 +86,7 @@
     "end": "2022-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/CA-NT-2023.json
+++ b/test/fixtures/CA-NT-2023.json
@@ -86,7 +86,7 @@
     "end": "2023-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/CA-NT-2024.json
+++ b/test/fixtures/CA-NT-2024.json
@@ -86,7 +86,7 @@
     "end": "2024-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/CA-NT-2025.json
+++ b/test/fixtures/CA-NT-2025.json
@@ -86,7 +86,7 @@
     "end": "2025-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Sat"
   },
   {

--- a/test/fixtures/CA-NT-2026.json
+++ b/test/fixtures/CA-NT-2026.json
@@ -86,7 +86,7 @@
     "end": "2026-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/CA-NT-2027.json
+++ b/test/fixtures/CA-NT-2027.json
@@ -86,7 +86,7 @@
     "end": "2027-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2028.json
+++ b/test/fixtures/CA-NT-2028.json
@@ -86,7 +86,7 @@
     "end": "2028-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/CA-NT-2029.json
+++ b/test/fixtures/CA-NT-2029.json
@@ -86,7 +86,7 @@
     "end": "2029-06-22T06:00:00.000Z",
     "name": "National Indigenous Peoples Day",
     "type": "public",
-    "rule": "06-21",
+    "rule": "06-21 since 2001",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/CA-YT-2017.json
+++ b/test/fixtures/CA-YT-2017.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2017-06-21 00:00:00",
+    "start": "2017-06-21T07:00:00.000Z",
+    "end": "2017-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2017-07-01 00:00:00",
     "start": "2017-07-01T07:00:00.000Z",
     "end": "2017-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2018.json
+++ b/test/fixtures/CA-YT-2018.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2018-06-21 00:00:00",
+    "start": "2018-06-21T07:00:00.000Z",
+    "end": "2018-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2018-07-01 00:00:00",
     "start": "2018-07-01T07:00:00.000Z",
     "end": "2018-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2019.json
+++ b/test/fixtures/CA-YT-2019.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2019-06-21 00:00:00",
+    "start": "2019-06-21T07:00:00.000Z",
+    "end": "2019-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2019-07-01 00:00:00",
     "start": "2019-07-01T07:00:00.000Z",
     "end": "2019-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2020.json
+++ b/test/fixtures/CA-YT-2020.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2020-06-21 00:00:00",
+    "start": "2020-06-21T07:00:00.000Z",
+    "end": "2020-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2020-07-01 00:00:00",
     "start": "2020-07-01T07:00:00.000Z",
     "end": "2020-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2021.json
+++ b/test/fixtures/CA-YT-2021.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-06-21 00:00:00",
+    "start": "2021-06-21T07:00:00.000Z",
+    "end": "2021-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-07-01 00:00:00",
     "start": "2021-07-01T07:00:00.000Z",
     "end": "2021-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2022.json
+++ b/test/fixtures/CA-YT-2022.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2022-06-21 00:00:00",
+    "start": "2022-06-21T07:00:00.000Z",
+    "end": "2022-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2022-07-01 00:00:00",
     "start": "2022-07-01T07:00:00.000Z",
     "end": "2022-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2023.json
+++ b/test/fixtures/CA-YT-2023.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2023-06-21 00:00:00",
+    "start": "2023-06-21T07:00:00.000Z",
+    "end": "2023-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2023-07-01 00:00:00",
     "start": "2023-07-01T07:00:00.000Z",
     "end": "2023-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2024.json
+++ b/test/fixtures/CA-YT-2024.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2024-06-21 00:00:00",
+    "start": "2024-06-21T07:00:00.000Z",
+    "end": "2024-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2024-07-01 00:00:00",
     "start": "2024-07-01T07:00:00.000Z",
     "end": "2024-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2025.json
+++ b/test/fixtures/CA-YT-2025.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2025-06-21 00:00:00",
+    "start": "2025-06-21T07:00:00.000Z",
+    "end": "2025-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2025-07-01 00:00:00",
     "start": "2025-07-01T07:00:00.000Z",
     "end": "2025-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2026.json
+++ b/test/fixtures/CA-YT-2026.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2026-06-21 00:00:00",
+    "start": "2026-06-21T07:00:00.000Z",
+    "end": "2026-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2026-07-01 00:00:00",
     "start": "2026-07-01T07:00:00.000Z",
     "end": "2026-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2027.json
+++ b/test/fixtures/CA-YT-2027.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2027-06-21 00:00:00",
+    "start": "2027-06-21T07:00:00.000Z",
+    "end": "2027-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-07-01 00:00:00",
     "start": "2027-07-01T07:00:00.000Z",
     "end": "2027-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2028.json
+++ b/test/fixtures/CA-YT-2028.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2028-06-21 00:00:00",
+    "start": "2028-06-21T07:00:00.000Z",
+    "end": "2028-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2028-07-01 00:00:00",
     "start": "2028-07-01T07:00:00.000Z",
     "end": "2028-07-02T07:00:00.000Z",

--- a/test/fixtures/CA-YT-2029.json
+++ b/test/fixtures/CA-YT-2029.json
@@ -90,6 +90,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2029-06-21 00:00:00",
+    "start": "2029-06-21T07:00:00.000Z",
+    "end": "2029-06-22T07:00:00.000Z",
+    "name": "National Indigenous Peoples Day",
+    "type": "public",
+    "rule": "06-21 since 2017",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2029-07-01 00:00:00",
     "start": "2029-07-01T07:00:00.000Z",
     "end": "2029-07-02T07:00:00.000Z",


### PR DESCRIPTION
External sources:
https://en.wikipedia.org/wiki/National_Indigenous_Peoples_Day
https://www.thecanadianencyclopedia.ca/en/article/national-aboriginal-day

Issue:
#549

Changes:
- Add start year 2001 to NT province for NIPD
- Copy that exact same configuration to YT province, since in 2017
- Write test fixtures
- Add a step to CONTRIBUTING.md to run `npm install` before running `npm run build`