### PR TITLE
Fix Saskatchewan Day date and add Terry Fox Day

### DIFF
--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -73,7 +73,7 @@ holidays:
         name:
           en: Canada Day
           fr: Fête du Canada
-      monday after 08-01:
+      1st monday in August:
         name:
           en: Civic Holiday
           fr: Premier lundi d’août
@@ -150,12 +150,16 @@ holidays:
             name:
               en: Louis Riel Day
               fr: Journée Louis Riel
+          1st monday in August:
+            name:
+              en: Terry Fox Day
+              fr: Journée Terry Fox
       NB:
         name: New Brunswick
         zones:
           - America/Moncton
         days:
-          monday after 08-01:
+          1st monday in August:
             name:
               en: New Brunswick Day
               fr: Jour de Nouveau Brunswick

--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -114,7 +114,7 @@ holidays:
           easter 1:
             _name: easter 1
             type: optional
-          monday after 08-01:
+          1st monday in August:
             name:
               en: Heritage Day
               fr: Fête du patrimoine
@@ -210,7 +210,7 @@ holidays:
             name:
               en: Heritage Day
               fr: Fête du Patrimoine
-          monday after 08-01:
+          1st monday in August:
             name:
               en: Natal Day
               fr: Jour de la Fondation
@@ -313,7 +313,7 @@ holidays:
         days:
           easter 1:
             _name: easter 1
-          3rd monday after 08-01:
+          3rd monday in August:
             name:
               en: Discovery Day
               fr: Jour de la Découverte

--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -298,7 +298,7 @@ holidays:
             name:
               en: Family Day
               fr: Fête de la famille
-          3rd monday after 08-01:
+          1st monday in August:
             name:
               en: Saskatchewan Day
       YT:

--- a/test/fixtures/CA-2015.json
+++ b/test/fixtures/CA-2015.json
@@ -95,7 +95,7 @@
     "end": "2015-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2016.json
+++ b/test/fixtures/CA-2016.json
@@ -95,7 +95,7 @@
     "end": "2016-08-02T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2017.json
+++ b/test/fixtures/CA-2017.json
@@ -95,7 +95,7 @@
     "end": "2017-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2018.json
+++ b/test/fixtures/CA-2018.json
@@ -95,7 +95,7 @@
     "end": "2018-08-07T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2019.json
+++ b/test/fixtures/CA-2019.json
@@ -95,7 +95,7 @@
     "end": "2019-08-06T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2020.json
+++ b/test/fixtures/CA-2020.json
@@ -95,7 +95,7 @@
     "end": "2020-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2021.json
+++ b/test/fixtures/CA-2021.json
@@ -95,7 +95,7 @@
     "end": "2021-08-03T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2022.json
+++ b/test/fixtures/CA-2022.json
@@ -95,7 +95,7 @@
     "end": "2022-08-02T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2023.json
+++ b/test/fixtures/CA-2023.json
@@ -95,7 +95,7 @@
     "end": "2023-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2024.json
+++ b/test/fixtures/CA-2024.json
@@ -95,7 +95,7 @@
     "end": "2024-08-06T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2025.json
+++ b/test/fixtures/CA-2025.json
@@ -95,7 +95,7 @@
     "end": "2025-08-05T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2026.json
+++ b/test/fixtures/CA-2026.json
@@ -95,7 +95,7 @@
     "end": "2026-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2027.json
+++ b/test/fixtures/CA-2027.json
@@ -95,7 +95,7 @@
     "end": "2027-08-03T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2028.json
+++ b/test/fixtures/CA-2028.json
@@ -95,7 +95,7 @@
     "end": "2028-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-2029.json
+++ b/test/fixtures/CA-2029.json
@@ -95,7 +95,7 @@
     "end": "2029-08-07T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-AB-2015.json
+++ b/test/fixtures/CA-AB-2015.json
@@ -111,6 +111,15 @@
     "date": "2015-08-03 00:00:00",
     "start": "2015-08-03T06:00:00.000Z",
     "end": "2015-08-04T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-03 00:00:00",
+    "start": "2015-08-03T06:00:00.000Z",
+    "end": "2015-08-04T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2016.json
+++ b/test/fixtures/CA-AB-2016.json
@@ -111,6 +111,15 @@
     "date": "2016-08-01 00:00:00",
     "start": "2016-08-01T06:00:00.000Z",
     "end": "2016-08-02T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-08-01 00:00:00",
+    "start": "2016-08-01T06:00:00.000Z",
+    "end": "2016-08-02T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2017.json
+++ b/test/fixtures/CA-AB-2017.json
@@ -111,6 +111,15 @@
     "date": "2017-08-07 00:00:00",
     "start": "2017-08-07T06:00:00.000Z",
     "end": "2017-08-08T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T06:00:00.000Z",
+    "end": "2017-08-08T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2018.json
+++ b/test/fixtures/CA-AB-2018.json
@@ -111,6 +111,15 @@
     "date": "2018-08-06 00:00:00",
     "start": "2018-08-06T06:00:00.000Z",
     "end": "2018-08-07T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T06:00:00.000Z",
+    "end": "2018-08-07T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2019.json
+++ b/test/fixtures/CA-AB-2019.json
@@ -111,6 +111,15 @@
     "date": "2019-08-05 00:00:00",
     "start": "2019-08-05T06:00:00.000Z",
     "end": "2019-08-06T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-08-05 00:00:00",
+    "start": "2019-08-05T06:00:00.000Z",
+    "end": "2019-08-06T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2020.json
+++ b/test/fixtures/CA-AB-2020.json
@@ -111,6 +111,15 @@
     "date": "2020-08-03 00:00:00",
     "start": "2020-08-03T06:00:00.000Z",
     "end": "2020-08-04T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-03 00:00:00",
+    "start": "2020-08-03T06:00:00.000Z",
+    "end": "2020-08-04T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2021.json
+++ b/test/fixtures/CA-AB-2021.json
@@ -111,6 +111,15 @@
     "date": "2021-08-02 00:00:00",
     "start": "2021-08-02T06:00:00.000Z",
     "end": "2021-08-03T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-02 00:00:00",
+    "start": "2021-08-02T06:00:00.000Z",
+    "end": "2021-08-03T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2022.json
+++ b/test/fixtures/CA-AB-2022.json
@@ -111,6 +111,15 @@
     "date": "2022-08-01 00:00:00",
     "start": "2022-08-01T06:00:00.000Z",
     "end": "2022-08-02T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-08-01 00:00:00",
+    "start": "2022-08-01T06:00:00.000Z",
+    "end": "2022-08-02T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2023.json
+++ b/test/fixtures/CA-AB-2023.json
@@ -111,6 +111,15 @@
     "date": "2023-08-07 00:00:00",
     "start": "2023-08-07T06:00:00.000Z",
     "end": "2023-08-08T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T06:00:00.000Z",
+    "end": "2023-08-08T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2024.json
+++ b/test/fixtures/CA-AB-2024.json
@@ -111,6 +111,15 @@
     "date": "2024-08-05 00:00:00",
     "start": "2024-08-05T06:00:00.000Z",
     "end": "2024-08-06T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-08-05 00:00:00",
+    "start": "2024-08-05T06:00:00.000Z",
+    "end": "2024-08-06T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2025.json
+++ b/test/fixtures/CA-AB-2025.json
@@ -111,6 +111,15 @@
     "date": "2025-08-04 00:00:00",
     "start": "2025-08-04T06:00:00.000Z",
     "end": "2025-08-05T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-08-04 00:00:00",
+    "start": "2025-08-04T06:00:00.000Z",
+    "end": "2025-08-05T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2026.json
+++ b/test/fixtures/CA-AB-2026.json
@@ -111,6 +111,15 @@
     "date": "2026-08-03 00:00:00",
     "start": "2026-08-03T06:00:00.000Z",
     "end": "2026-08-04T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-03 00:00:00",
+    "start": "2026-08-03T06:00:00.000Z",
+    "end": "2026-08-04T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2027.json
+++ b/test/fixtures/CA-AB-2027.json
@@ -111,6 +111,15 @@
     "date": "2027-08-02 00:00:00",
     "start": "2027-08-02T06:00:00.000Z",
     "end": "2027-08-03T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-02 00:00:00",
+    "start": "2027-08-02T06:00:00.000Z",
+    "end": "2027-08-03T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2028.json
+++ b/test/fixtures/CA-AB-2028.json
@@ -111,6 +111,15 @@
     "date": "2028-08-07 00:00:00",
     "start": "2028-08-07T06:00:00.000Z",
     "end": "2028-08-08T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-08-07 00:00:00",
+    "start": "2028-08-07T06:00:00.000Z",
+    "end": "2028-08-08T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-AB-2029.json
+++ b/test/fixtures/CA-AB-2029.json
@@ -111,6 +111,15 @@
     "date": "2029-08-06 00:00:00",
     "start": "2029-08-06T06:00:00.000Z",
     "end": "2029-08-07T06:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-08-06 00:00:00",
+    "start": "2029-08-06T06:00:00.000Z",
+    "end": "2029-08-07T06:00:00.000Z",
     "name": "Heritage Day",
     "type": "optional",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-BC-2015.json
+++ b/test/fixtures/CA-BC-2015.json
@@ -104,7 +104,7 @@
     "end": "2015-08-04T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2016.json
+++ b/test/fixtures/CA-BC-2016.json
@@ -104,7 +104,7 @@
     "end": "2016-08-02T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2017.json
+++ b/test/fixtures/CA-BC-2017.json
@@ -104,7 +104,7 @@
     "end": "2017-08-08T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2018.json
+++ b/test/fixtures/CA-BC-2018.json
@@ -104,7 +104,7 @@
     "end": "2018-08-07T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2019.json
+++ b/test/fixtures/CA-BC-2019.json
@@ -104,7 +104,7 @@
     "end": "2019-08-06T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2020.json
+++ b/test/fixtures/CA-BC-2020.json
@@ -104,7 +104,7 @@
     "end": "2020-08-04T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2021.json
+++ b/test/fixtures/CA-BC-2021.json
@@ -104,7 +104,7 @@
     "end": "2021-08-03T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2022.json
+++ b/test/fixtures/CA-BC-2022.json
@@ -104,7 +104,7 @@
     "end": "2022-08-02T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2023.json
+++ b/test/fixtures/CA-BC-2023.json
@@ -104,7 +104,7 @@
     "end": "2023-08-08T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2024.json
+++ b/test/fixtures/CA-BC-2024.json
@@ -104,7 +104,7 @@
     "end": "2024-08-06T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2025.json
+++ b/test/fixtures/CA-BC-2025.json
@@ -104,7 +104,7 @@
     "end": "2025-08-05T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2026.json
+++ b/test/fixtures/CA-BC-2026.json
@@ -104,7 +104,7 @@
     "end": "2026-08-04T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2027.json
+++ b/test/fixtures/CA-BC-2027.json
@@ -104,7 +104,7 @@
     "end": "2027-08-03T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2028.json
+++ b/test/fixtures/CA-BC-2028.json
@@ -104,7 +104,7 @@
     "end": "2028-08-08T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-BC-2029.json
+++ b/test/fixtures/CA-BC-2029.json
@@ -104,7 +104,7 @@
     "end": "2029-08-07T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2015.json
+++ b/test/fixtures/CA-MB-2015.json
@@ -102,9 +102,9 @@
     "date": "2015-08-03 00:00:00",
     "start": "2015-08-03T05:00:00.000Z",
     "end": "2015-08-04T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2016.json
+++ b/test/fixtures/CA-MB-2016.json
@@ -102,9 +102,9 @@
     "date": "2016-08-01 00:00:00",
     "start": "2016-08-01T05:00:00.000Z",
     "end": "2016-08-02T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2017.json
+++ b/test/fixtures/CA-MB-2017.json
@@ -102,9 +102,9 @@
     "date": "2017-08-07 00:00:00",
     "start": "2017-08-07T05:00:00.000Z",
     "end": "2017-08-08T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2018.json
+++ b/test/fixtures/CA-MB-2018.json
@@ -102,9 +102,9 @@
     "date": "2018-08-06 00:00:00",
     "start": "2018-08-06T05:00:00.000Z",
     "end": "2018-08-07T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2019.json
+++ b/test/fixtures/CA-MB-2019.json
@@ -102,9 +102,9 @@
     "date": "2019-08-05 00:00:00",
     "start": "2019-08-05T05:00:00.000Z",
     "end": "2019-08-06T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2020.json
+++ b/test/fixtures/CA-MB-2020.json
@@ -102,9 +102,9 @@
     "date": "2020-08-03 00:00:00",
     "start": "2020-08-03T05:00:00.000Z",
     "end": "2020-08-04T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2021.json
+++ b/test/fixtures/CA-MB-2021.json
@@ -102,9 +102,9 @@
     "date": "2021-08-02 00:00:00",
     "start": "2021-08-02T05:00:00.000Z",
     "end": "2021-08-03T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2022.json
+++ b/test/fixtures/CA-MB-2022.json
@@ -102,9 +102,9 @@
     "date": "2022-08-01 00:00:00",
     "start": "2022-08-01T05:00:00.000Z",
     "end": "2022-08-02T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2023.json
+++ b/test/fixtures/CA-MB-2023.json
@@ -102,9 +102,9 @@
     "date": "2023-08-07 00:00:00",
     "start": "2023-08-07T05:00:00.000Z",
     "end": "2023-08-08T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2024.json
+++ b/test/fixtures/CA-MB-2024.json
@@ -102,9 +102,9 @@
     "date": "2024-08-05 00:00:00",
     "start": "2024-08-05T05:00:00.000Z",
     "end": "2024-08-06T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2025.json
+++ b/test/fixtures/CA-MB-2025.json
@@ -102,9 +102,9 @@
     "date": "2025-08-04 00:00:00",
     "start": "2025-08-04T05:00:00.000Z",
     "end": "2025-08-05T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2026.json
+++ b/test/fixtures/CA-MB-2026.json
@@ -102,9 +102,9 @@
     "date": "2026-08-03 00:00:00",
     "start": "2026-08-03T05:00:00.000Z",
     "end": "2026-08-04T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2027.json
+++ b/test/fixtures/CA-MB-2027.json
@@ -102,9 +102,9 @@
     "date": "2027-08-02 00:00:00",
     "start": "2027-08-02T05:00:00.000Z",
     "end": "2027-08-03T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2028.json
+++ b/test/fixtures/CA-MB-2028.json
@@ -102,9 +102,9 @@
     "date": "2028-08-07 00:00:00",
     "start": "2028-08-07T05:00:00.000Z",
     "end": "2028-08-08T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-MB-2029.json
+++ b/test/fixtures/CA-MB-2029.json
@@ -102,9 +102,9 @@
     "date": "2029-08-06 00:00:00",
     "start": "2029-08-06T05:00:00.000Z",
     "end": "2029-08-07T05:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "Terry Fox Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2015.json
+++ b/test/fixtures/CA-NB-2015.json
@@ -95,7 +95,7 @@
     "end": "2015-08-04T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2016.json
+++ b/test/fixtures/CA-NB-2016.json
@@ -95,7 +95,7 @@
     "end": "2016-08-02T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2017.json
+++ b/test/fixtures/CA-NB-2017.json
@@ -95,7 +95,7 @@
     "end": "2017-08-08T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2018.json
+++ b/test/fixtures/CA-NB-2018.json
@@ -104,7 +104,7 @@
     "end": "2018-08-07T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2019.json
+++ b/test/fixtures/CA-NB-2019.json
@@ -104,7 +104,7 @@
     "end": "2019-08-06T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2020.json
+++ b/test/fixtures/CA-NB-2020.json
@@ -104,7 +104,7 @@
     "end": "2020-08-04T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2021.json
+++ b/test/fixtures/CA-NB-2021.json
@@ -104,7 +104,7 @@
     "end": "2021-08-03T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2022.json
+++ b/test/fixtures/CA-NB-2022.json
@@ -104,7 +104,7 @@
     "end": "2022-08-02T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2023.json
+++ b/test/fixtures/CA-NB-2023.json
@@ -104,7 +104,7 @@
     "end": "2023-08-08T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2024.json
+++ b/test/fixtures/CA-NB-2024.json
@@ -104,7 +104,7 @@
     "end": "2024-08-06T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2025.json
+++ b/test/fixtures/CA-NB-2025.json
@@ -104,7 +104,7 @@
     "end": "2025-08-05T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2026.json
+++ b/test/fixtures/CA-NB-2026.json
@@ -104,7 +104,7 @@
     "end": "2026-08-04T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2027.json
+++ b/test/fixtures/CA-NB-2027.json
@@ -104,7 +104,7 @@
     "end": "2027-08-03T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2028.json
+++ b/test/fixtures/CA-NB-2028.json
@@ -104,7 +104,7 @@
     "end": "2028-08-08T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NB-2029.json
+++ b/test/fixtures/CA-NB-2029.json
@@ -104,7 +104,7 @@
     "end": "2029-08-07T03:00:00.000Z",
     "name": "New Brunswick Day",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2015.json
+++ b/test/fixtures/CA-NL-2015.json
@@ -122,7 +122,7 @@
     "end": "2015-08-04T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2016.json
+++ b/test/fixtures/CA-NL-2016.json
@@ -122,7 +122,7 @@
     "end": "2016-08-02T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2017.json
+++ b/test/fixtures/CA-NL-2017.json
@@ -122,7 +122,7 @@
     "end": "2017-08-08T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2018.json
+++ b/test/fixtures/CA-NL-2018.json
@@ -122,7 +122,7 @@
     "end": "2018-08-07T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2019.json
+++ b/test/fixtures/CA-NL-2019.json
@@ -122,7 +122,7 @@
     "end": "2019-08-06T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2020.json
+++ b/test/fixtures/CA-NL-2020.json
@@ -122,7 +122,7 @@
     "end": "2020-08-04T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2021.json
+++ b/test/fixtures/CA-NL-2021.json
@@ -122,7 +122,7 @@
     "end": "2021-08-03T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2022.json
+++ b/test/fixtures/CA-NL-2022.json
@@ -122,7 +122,7 @@
     "end": "2022-08-02T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2023.json
+++ b/test/fixtures/CA-NL-2023.json
@@ -122,7 +122,7 @@
     "end": "2023-08-08T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2024.json
+++ b/test/fixtures/CA-NL-2024.json
@@ -122,7 +122,7 @@
     "end": "2024-08-06T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2025.json
+++ b/test/fixtures/CA-NL-2025.json
@@ -122,7 +122,7 @@
     "end": "2025-08-05T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2026.json
+++ b/test/fixtures/CA-NL-2026.json
@@ -122,7 +122,7 @@
     "end": "2026-08-04T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2027.json
+++ b/test/fixtures/CA-NL-2027.json
@@ -122,7 +122,7 @@
     "end": "2027-08-03T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2028.json
+++ b/test/fixtures/CA-NL-2028.json
@@ -122,7 +122,7 @@
     "end": "2028-08-08T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NL-2029.json
+++ b/test/fixtures/CA-NL-2029.json
@@ -122,7 +122,7 @@
     "end": "2029-08-07T02:30:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NS-2015.json
+++ b/test/fixtures/CA-NS-2015.json
@@ -102,6 +102,15 @@
     "date": "2015-08-03 00:00:00",
     "start": "2015-08-03T03:00:00.000Z",
     "end": "2015-08-04T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-08-03 00:00:00",
+    "start": "2015-08-03T03:00:00.000Z",
+    "end": "2015-08-04T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2016.json
+++ b/test/fixtures/CA-NS-2016.json
@@ -102,6 +102,15 @@
     "date": "2016-08-01 00:00:00",
     "start": "2016-08-01T03:00:00.000Z",
     "end": "2016-08-02T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-08-01 00:00:00",
+    "start": "2016-08-01T03:00:00.000Z",
+    "end": "2016-08-02T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2017.json
+++ b/test/fixtures/CA-NS-2017.json
@@ -102,6 +102,15 @@
     "date": "2017-08-07 00:00:00",
     "start": "2017-08-07T03:00:00.000Z",
     "end": "2017-08-08T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T03:00:00.000Z",
+    "end": "2017-08-08T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2018.json
+++ b/test/fixtures/CA-NS-2018.json
@@ -102,6 +102,15 @@
     "date": "2018-08-06 00:00:00",
     "start": "2018-08-06T03:00:00.000Z",
     "end": "2018-08-07T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T03:00:00.000Z",
+    "end": "2018-08-07T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2019.json
+++ b/test/fixtures/CA-NS-2019.json
@@ -102,6 +102,15 @@
     "date": "2019-08-05 00:00:00",
     "start": "2019-08-05T03:00:00.000Z",
     "end": "2019-08-06T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-08-05 00:00:00",
+    "start": "2019-08-05T03:00:00.000Z",
+    "end": "2019-08-06T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2020.json
+++ b/test/fixtures/CA-NS-2020.json
@@ -102,6 +102,15 @@
     "date": "2020-08-03 00:00:00",
     "start": "2020-08-03T03:00:00.000Z",
     "end": "2020-08-04T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-08-03 00:00:00",
+    "start": "2020-08-03T03:00:00.000Z",
+    "end": "2020-08-04T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2021.json
+++ b/test/fixtures/CA-NS-2021.json
@@ -102,6 +102,15 @@
     "date": "2021-08-02 00:00:00",
     "start": "2021-08-02T03:00:00.000Z",
     "end": "2021-08-03T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-02 00:00:00",
+    "start": "2021-08-02T03:00:00.000Z",
+    "end": "2021-08-03T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2022.json
+++ b/test/fixtures/CA-NS-2022.json
@@ -102,6 +102,15 @@
     "date": "2022-08-01 00:00:00",
     "start": "2022-08-01T03:00:00.000Z",
     "end": "2022-08-02T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-08-01 00:00:00",
+    "start": "2022-08-01T03:00:00.000Z",
+    "end": "2022-08-02T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2023.json
+++ b/test/fixtures/CA-NS-2023.json
@@ -102,6 +102,15 @@
     "date": "2023-08-07 00:00:00",
     "start": "2023-08-07T03:00:00.000Z",
     "end": "2023-08-08T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T03:00:00.000Z",
+    "end": "2023-08-08T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2024.json
+++ b/test/fixtures/CA-NS-2024.json
@@ -102,6 +102,15 @@
     "date": "2024-08-05 00:00:00",
     "start": "2024-08-05T03:00:00.000Z",
     "end": "2024-08-06T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-08-05 00:00:00",
+    "start": "2024-08-05T03:00:00.000Z",
+    "end": "2024-08-06T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2025.json
+++ b/test/fixtures/CA-NS-2025.json
@@ -102,6 +102,15 @@
     "date": "2025-08-04 00:00:00",
     "start": "2025-08-04T03:00:00.000Z",
     "end": "2025-08-05T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-08-04 00:00:00",
+    "start": "2025-08-04T03:00:00.000Z",
+    "end": "2025-08-05T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2026.json
+++ b/test/fixtures/CA-NS-2026.json
@@ -102,6 +102,15 @@
     "date": "2026-08-03 00:00:00",
     "start": "2026-08-03T03:00:00.000Z",
     "end": "2026-08-04T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-08-03 00:00:00",
+    "start": "2026-08-03T03:00:00.000Z",
+    "end": "2026-08-04T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2027.json
+++ b/test/fixtures/CA-NS-2027.json
@@ -102,6 +102,15 @@
     "date": "2027-08-02 00:00:00",
     "start": "2027-08-02T03:00:00.000Z",
     "end": "2027-08-03T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-02 00:00:00",
+    "start": "2027-08-02T03:00:00.000Z",
+    "end": "2027-08-03T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2028.json
+++ b/test/fixtures/CA-NS-2028.json
@@ -102,6 +102,15 @@
     "date": "2028-08-07 00:00:00",
     "start": "2028-08-07T03:00:00.000Z",
     "end": "2028-08-08T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-08-07 00:00:00",
+    "start": "2028-08-07T03:00:00.000Z",
+    "end": "2028-08-08T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NS-2029.json
+++ b/test/fixtures/CA-NS-2029.json
@@ -102,6 +102,15 @@
     "date": "2029-08-06 00:00:00",
     "start": "2029-08-06T03:00:00.000Z",
     "end": "2029-08-07T03:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-08-06 00:00:00",
+    "start": "2029-08-06T03:00:00.000Z",
+    "end": "2029-08-07T03:00:00.000Z",
     "name": "Natal Day",
     "type": "public",
     "rule": "monday after 08-01",

--- a/test/fixtures/CA-NT-2015.json
+++ b/test/fixtures/CA-NT-2015.json
@@ -104,7 +104,7 @@
     "end": "2015-08-04T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2016.json
+++ b/test/fixtures/CA-NT-2016.json
@@ -104,7 +104,7 @@
     "end": "2016-08-02T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2017.json
+++ b/test/fixtures/CA-NT-2017.json
@@ -104,7 +104,7 @@
     "end": "2017-08-08T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2018.json
+++ b/test/fixtures/CA-NT-2018.json
@@ -104,7 +104,7 @@
     "end": "2018-08-07T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2019.json
+++ b/test/fixtures/CA-NT-2019.json
@@ -104,7 +104,7 @@
     "end": "2019-08-06T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2020.json
+++ b/test/fixtures/CA-NT-2020.json
@@ -104,7 +104,7 @@
     "end": "2020-08-04T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2021.json
+++ b/test/fixtures/CA-NT-2021.json
@@ -104,7 +104,7 @@
     "end": "2021-08-03T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2022.json
+++ b/test/fixtures/CA-NT-2022.json
@@ -104,7 +104,7 @@
     "end": "2022-08-02T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2023.json
+++ b/test/fixtures/CA-NT-2023.json
@@ -104,7 +104,7 @@
     "end": "2023-08-08T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2024.json
+++ b/test/fixtures/CA-NT-2024.json
@@ -104,7 +104,7 @@
     "end": "2024-08-06T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2025.json
+++ b/test/fixtures/CA-NT-2025.json
@@ -104,7 +104,7 @@
     "end": "2025-08-05T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2026.json
+++ b/test/fixtures/CA-NT-2026.json
@@ -104,7 +104,7 @@
     "end": "2026-08-04T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2027.json
+++ b/test/fixtures/CA-NT-2027.json
@@ -104,7 +104,7 @@
     "end": "2027-08-03T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2028.json
+++ b/test/fixtures/CA-NT-2028.json
@@ -104,7 +104,7 @@
     "end": "2028-08-08T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NT-2029.json
+++ b/test/fixtures/CA-NT-2029.json
@@ -104,7 +104,7 @@
     "end": "2029-08-07T06:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2015.json
+++ b/test/fixtures/CA-NU-2015.json
@@ -104,7 +104,7 @@
     "end": "2015-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2016.json
+++ b/test/fixtures/CA-NU-2016.json
@@ -104,7 +104,7 @@
     "end": "2016-08-02T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2017.json
+++ b/test/fixtures/CA-NU-2017.json
@@ -104,7 +104,7 @@
     "end": "2017-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2018.json
+++ b/test/fixtures/CA-NU-2018.json
@@ -104,7 +104,7 @@
     "end": "2018-08-07T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2019.json
+++ b/test/fixtures/CA-NU-2019.json
@@ -104,7 +104,7 @@
     "end": "2019-08-06T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2020.json
+++ b/test/fixtures/CA-NU-2020.json
@@ -104,7 +104,7 @@
     "end": "2020-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2021.json
+++ b/test/fixtures/CA-NU-2021.json
@@ -104,7 +104,7 @@
     "end": "2021-08-03T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2022.json
+++ b/test/fixtures/CA-NU-2022.json
@@ -104,7 +104,7 @@
     "end": "2022-08-02T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2023.json
+++ b/test/fixtures/CA-NU-2023.json
@@ -104,7 +104,7 @@
     "end": "2023-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2024.json
+++ b/test/fixtures/CA-NU-2024.json
@@ -104,7 +104,7 @@
     "end": "2024-08-06T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2025.json
+++ b/test/fixtures/CA-NU-2025.json
@@ -104,7 +104,7 @@
     "end": "2025-08-05T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2026.json
+++ b/test/fixtures/CA-NU-2026.json
@@ -104,7 +104,7 @@
     "end": "2026-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2027.json
+++ b/test/fixtures/CA-NU-2027.json
@@ -104,7 +104,7 @@
     "end": "2027-08-03T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2028.json
+++ b/test/fixtures/CA-NU-2028.json
@@ -104,7 +104,7 @@
     "end": "2028-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-NU-2029.json
+++ b/test/fixtures/CA-NU-2029.json
@@ -104,7 +104,7 @@
     "end": "2029-08-07T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2015.json
+++ b/test/fixtures/CA-ON-2015.json
@@ -113,7 +113,7 @@
     "end": "2015-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2016.json
+++ b/test/fixtures/CA-ON-2016.json
@@ -113,7 +113,7 @@
     "end": "2016-08-02T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2017.json
+++ b/test/fixtures/CA-ON-2017.json
@@ -113,7 +113,7 @@
     "end": "2017-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2018.json
+++ b/test/fixtures/CA-ON-2018.json
@@ -113,7 +113,7 @@
     "end": "2018-08-07T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2019.json
+++ b/test/fixtures/CA-ON-2019.json
@@ -113,7 +113,7 @@
     "end": "2019-08-06T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2020.json
+++ b/test/fixtures/CA-ON-2020.json
@@ -113,7 +113,7 @@
     "end": "2020-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2021.json
+++ b/test/fixtures/CA-ON-2021.json
@@ -113,7 +113,7 @@
     "end": "2021-08-03T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2022.json
+++ b/test/fixtures/CA-ON-2022.json
@@ -113,7 +113,7 @@
     "end": "2022-08-02T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2023.json
+++ b/test/fixtures/CA-ON-2023.json
@@ -113,7 +113,7 @@
     "end": "2023-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2024.json
+++ b/test/fixtures/CA-ON-2024.json
@@ -113,7 +113,7 @@
     "end": "2024-08-06T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2025.json
+++ b/test/fixtures/CA-ON-2025.json
@@ -113,7 +113,7 @@
     "end": "2025-08-05T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2026.json
+++ b/test/fixtures/CA-ON-2026.json
@@ -113,7 +113,7 @@
     "end": "2026-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2027.json
+++ b/test/fixtures/CA-ON-2027.json
@@ -113,7 +113,7 @@
     "end": "2027-08-03T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2028.json
+++ b/test/fixtures/CA-ON-2028.json
@@ -113,7 +113,7 @@
     "end": "2028-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-ON-2029.json
+++ b/test/fixtures/CA-ON-2029.json
@@ -113,7 +113,7 @@
     "end": "2029-08-07T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2015.json
+++ b/test/fixtures/CA-PE-2015.json
@@ -113,7 +113,7 @@
     "end": "2015-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2016.json
+++ b/test/fixtures/CA-PE-2016.json
@@ -113,7 +113,7 @@
     "end": "2016-08-02T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2017.json
+++ b/test/fixtures/CA-PE-2017.json
@@ -113,7 +113,7 @@
     "end": "2017-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2018.json
+++ b/test/fixtures/CA-PE-2018.json
@@ -113,7 +113,7 @@
     "end": "2018-08-07T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2019.json
+++ b/test/fixtures/CA-PE-2019.json
@@ -113,7 +113,7 @@
     "end": "2019-08-06T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2020.json
+++ b/test/fixtures/CA-PE-2020.json
@@ -113,7 +113,7 @@
     "end": "2020-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2021.json
+++ b/test/fixtures/CA-PE-2021.json
@@ -113,7 +113,7 @@
     "end": "2021-08-03T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2022.json
+++ b/test/fixtures/CA-PE-2022.json
@@ -113,7 +113,7 @@
     "end": "2022-08-02T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2023.json
+++ b/test/fixtures/CA-PE-2023.json
@@ -113,7 +113,7 @@
     "end": "2023-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2024.json
+++ b/test/fixtures/CA-PE-2024.json
@@ -113,7 +113,7 @@
     "end": "2024-08-06T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2025.json
+++ b/test/fixtures/CA-PE-2025.json
@@ -113,7 +113,7 @@
     "end": "2025-08-05T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2026.json
+++ b/test/fixtures/CA-PE-2026.json
@@ -113,7 +113,7 @@
     "end": "2026-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2027.json
+++ b/test/fixtures/CA-PE-2027.json
@@ -113,7 +113,7 @@
     "end": "2027-08-03T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2028.json
+++ b/test/fixtures/CA-PE-2028.json
@@ -113,7 +113,7 @@
     "end": "2028-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-PE-2029.json
+++ b/test/fixtures/CA-PE-2029.json
@@ -113,7 +113,7 @@
     "end": "2029-08-07T04:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-QC-2015.json
+++ b/test/fixtures/CA-QC-2015.json
@@ -110,6 +110,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2015-08-03 00:00:00",
+    "start": "2015-08-03T04:00:00.000Z",
+    "end": "2015-08-04T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2015-09-07 00:00:00",
     "start": "2015-09-07T04:00:00.000Z",
     "end": "2015-09-08T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2016.json
+++ b/test/fixtures/CA-QC-2016.json
@@ -110,6 +110,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2016-08-01 00:00:00",
+    "start": "2016-08-01T04:00:00.000Z",
+    "end": "2016-08-02T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2016-09-05 00:00:00",
     "start": "2016-09-05T04:00:00.000Z",
     "end": "2016-09-06T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2017.json
+++ b/test/fixtures/CA-QC-2017.json
@@ -110,6 +110,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2017-08-07 00:00:00",
+    "start": "2017-08-07T04:00:00.000Z",
+    "end": "2017-08-08T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2017-09-04 00:00:00",
     "start": "2017-09-04T04:00:00.000Z",
     "end": "2017-09-05T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2018.json
+++ b/test/fixtures/CA-QC-2018.json
@@ -110,6 +110,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2018-08-06 00:00:00",
+    "start": "2018-08-06T04:00:00.000Z",
+    "end": "2018-08-07T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2018-09-03 00:00:00",
     "start": "2018-09-03T04:00:00.000Z",
     "end": "2018-09-04T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2019.json
+++ b/test/fixtures/CA-QC-2019.json
@@ -110,6 +110,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-08-05 00:00:00",
+    "start": "2019-08-05T04:00:00.000Z",
+    "end": "2019-08-06T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2019-09-02 00:00:00",
     "start": "2019-09-02T04:00:00.000Z",
     "end": "2019-09-03T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2020.json
+++ b/test/fixtures/CA-QC-2020.json
@@ -110,6 +110,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2020-08-03 00:00:00",
+    "start": "2020-08-03T04:00:00.000Z",
+    "end": "2020-08-04T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2020-09-07 00:00:00",
     "start": "2020-09-07T04:00:00.000Z",
     "end": "2020-09-08T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2021.json
+++ b/test/fixtures/CA-QC-2021.json
@@ -110,6 +110,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2021-08-02 00:00:00",
+    "start": "2021-08-02T04:00:00.000Z",
+    "end": "2021-08-03T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-09-06 00:00:00",
     "start": "2021-09-06T04:00:00.000Z",
     "end": "2021-09-07T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2022.json
+++ b/test/fixtures/CA-QC-2022.json
@@ -110,6 +110,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-08-01 00:00:00",
+    "start": "2022-08-01T04:00:00.000Z",
+    "end": "2022-08-02T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-09-05 00:00:00",
     "start": "2022-09-05T04:00:00.000Z",
     "end": "2022-09-06T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2023.json
+++ b/test/fixtures/CA-QC-2023.json
@@ -110,6 +110,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2023-08-07 00:00:00",
+    "start": "2023-08-07T04:00:00.000Z",
+    "end": "2023-08-08T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-09-04 00:00:00",
     "start": "2023-09-04T04:00:00.000Z",
     "end": "2023-09-05T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2024.json
+++ b/test/fixtures/CA-QC-2024.json
@@ -110,6 +110,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-08-05 00:00:00",
+    "start": "2024-08-05T04:00:00.000Z",
+    "end": "2024-08-06T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-09-02 00:00:00",
     "start": "2024-09-02T04:00:00.000Z",
     "end": "2024-09-03T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2025.json
+++ b/test/fixtures/CA-QC-2025.json
@@ -110,6 +110,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2025-08-04 00:00:00",
+    "start": "2025-08-04T04:00:00.000Z",
+    "end": "2025-08-05T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2025-09-01 00:00:00",
     "start": "2025-09-01T04:00:00.000Z",
     "end": "2025-09-02T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2026.json
+++ b/test/fixtures/CA-QC-2026.json
@@ -110,6 +110,15 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2026-08-03 00:00:00",
+    "start": "2026-08-03T04:00:00.000Z",
+    "end": "2026-08-04T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-09-07 00:00:00",
     "start": "2026-09-07T04:00:00.000Z",
     "end": "2026-09-08T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2027.json
+++ b/test/fixtures/CA-QC-2027.json
@@ -110,6 +110,15 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2027-08-02 00:00:00",
+    "start": "2027-08-02T04:00:00.000Z",
+    "end": "2027-08-03T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-09-06 00:00:00",
     "start": "2027-09-06T04:00:00.000Z",
     "end": "2027-09-07T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2028.json
+++ b/test/fixtures/CA-QC-2028.json
@@ -110,6 +110,15 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2028-08-07 00:00:00",
+    "start": "2028-08-07T04:00:00.000Z",
+    "end": "2028-08-08T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2028-09-04 00:00:00",
     "start": "2028-09-04T04:00:00.000Z",
     "end": "2028-09-05T04:00:00.000Z",

--- a/test/fixtures/CA-QC-2029.json
+++ b/test/fixtures/CA-QC-2029.json
@@ -110,6 +110,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2029-08-06 00:00:00",
+    "start": "2029-08-06T04:00:00.000Z",
+    "end": "2029-08-07T04:00:00.000Z",
+    "name": "Civic Holiday",
+    "type": "public",
+    "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2029-09-03 00:00:00",
     "start": "2029-09-03T04:00:00.000Z",
     "end": "2029-09-04T04:00:00.000Z",

--- a/test/fixtures/CA-SK-2015.json
+++ b/test/fixtures/CA-SK-2015.json
@@ -102,18 +102,9 @@
     "date": "2015-08-03 00:00:00",
     "start": "2015-08-03T06:00:00.000Z",
     "end": "2015-08-04T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2015-08-17 00:00:00",
-    "start": "2015-08-17T06:00:00.000Z",
-    "end": "2015-08-18T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2016.json
+++ b/test/fixtures/CA-SK-2016.json
@@ -102,18 +102,9 @@
     "date": "2016-08-01 00:00:00",
     "start": "2016-08-01T06:00:00.000Z",
     "end": "2016-08-02T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2016-08-15 00:00:00",
-    "start": "2016-08-15T06:00:00.000Z",
-    "end": "2016-08-16T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2017.json
+++ b/test/fixtures/CA-SK-2017.json
@@ -102,18 +102,9 @@
     "date": "2017-08-07 00:00:00",
     "start": "2017-08-07T06:00:00.000Z",
     "end": "2017-08-08T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2017-08-21 00:00:00",
-    "start": "2017-08-21T06:00:00.000Z",
-    "end": "2017-08-22T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2018.json
+++ b/test/fixtures/CA-SK-2018.json
@@ -102,18 +102,9 @@
     "date": "2018-08-06 00:00:00",
     "start": "2018-08-06T06:00:00.000Z",
     "end": "2018-08-07T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2018-08-20 00:00:00",
-    "start": "2018-08-20T06:00:00.000Z",
-    "end": "2018-08-21T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2019.json
+++ b/test/fixtures/CA-SK-2019.json
@@ -102,18 +102,9 @@
     "date": "2019-08-05 00:00:00",
     "start": "2019-08-05T06:00:00.000Z",
     "end": "2019-08-06T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2019-08-19 00:00:00",
-    "start": "2019-08-19T06:00:00.000Z",
-    "end": "2019-08-20T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2020.json
+++ b/test/fixtures/CA-SK-2020.json
@@ -102,18 +102,9 @@
     "date": "2020-08-03 00:00:00",
     "start": "2020-08-03T06:00:00.000Z",
     "end": "2020-08-04T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2020-08-17 00:00:00",
-    "start": "2020-08-17T06:00:00.000Z",
-    "end": "2020-08-18T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2021.json
+++ b/test/fixtures/CA-SK-2021.json
@@ -102,18 +102,9 @@
     "date": "2021-08-02 00:00:00",
     "start": "2021-08-02T06:00:00.000Z",
     "end": "2021-08-03T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2021-08-16 00:00:00",
-    "start": "2021-08-16T06:00:00.000Z",
-    "end": "2021-08-17T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2022.json
+++ b/test/fixtures/CA-SK-2022.json
@@ -102,18 +102,9 @@
     "date": "2022-08-01 00:00:00",
     "start": "2022-08-01T06:00:00.000Z",
     "end": "2022-08-02T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2022-08-15 00:00:00",
-    "start": "2022-08-15T06:00:00.000Z",
-    "end": "2022-08-16T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2023.json
+++ b/test/fixtures/CA-SK-2023.json
@@ -102,18 +102,9 @@
     "date": "2023-08-07 00:00:00",
     "start": "2023-08-07T06:00:00.000Z",
     "end": "2023-08-08T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2023-08-21 00:00:00",
-    "start": "2023-08-21T06:00:00.000Z",
-    "end": "2023-08-22T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2024.json
+++ b/test/fixtures/CA-SK-2024.json
@@ -102,18 +102,9 @@
     "date": "2024-08-05 00:00:00",
     "start": "2024-08-05T06:00:00.000Z",
     "end": "2024-08-06T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2024-08-19 00:00:00",
-    "start": "2024-08-19T06:00:00.000Z",
-    "end": "2024-08-20T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2025.json
+++ b/test/fixtures/CA-SK-2025.json
@@ -102,18 +102,9 @@
     "date": "2025-08-04 00:00:00",
     "start": "2025-08-04T06:00:00.000Z",
     "end": "2025-08-05T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2025-08-18 00:00:00",
-    "start": "2025-08-18T06:00:00.000Z",
-    "end": "2025-08-19T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2026.json
+++ b/test/fixtures/CA-SK-2026.json
@@ -102,18 +102,9 @@
     "date": "2026-08-03 00:00:00",
     "start": "2026-08-03T06:00:00.000Z",
     "end": "2026-08-04T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2026-08-17 00:00:00",
-    "start": "2026-08-17T06:00:00.000Z",
-    "end": "2026-08-18T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2027.json
+++ b/test/fixtures/CA-SK-2027.json
@@ -102,18 +102,9 @@
     "date": "2027-08-02 00:00:00",
     "start": "2027-08-02T06:00:00.000Z",
     "end": "2027-08-03T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2027-08-16 00:00:00",
-    "start": "2027-08-16T06:00:00.000Z",
-    "end": "2027-08-17T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2028.json
+++ b/test/fixtures/CA-SK-2028.json
@@ -102,18 +102,9 @@
     "date": "2028-08-07 00:00:00",
     "start": "2028-08-07T06:00:00.000Z",
     "end": "2028-08-08T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2028-08-21 00:00:00",
-    "start": "2028-08-21T06:00:00.000Z",
-    "end": "2028-08-22T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-SK-2029.json
+++ b/test/fixtures/CA-SK-2029.json
@@ -102,18 +102,9 @@
     "date": "2029-08-06 00:00:00",
     "start": "2029-08-06T06:00:00.000Z",
     "end": "2029-08-07T06:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "monday after 08-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2029-08-20 00:00:00",
-    "start": "2029-08-20T06:00:00.000Z",
-    "end": "2029-08-21T06:00:00.000Z",
     "name": "Saskatchewan Day",
     "type": "public",
-    "rule": "3rd monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2015.json
+++ b/test/fixtures/CA-YT-2015.json
@@ -104,7 +104,7 @@
     "end": "2015-08-04T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2016.json
+++ b/test/fixtures/CA-YT-2016.json
@@ -104,7 +104,7 @@
     "end": "2016-08-02T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2017.json
+++ b/test/fixtures/CA-YT-2017.json
@@ -113,7 +113,7 @@
     "end": "2017-08-08T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2018.json
+++ b/test/fixtures/CA-YT-2018.json
@@ -113,7 +113,7 @@
     "end": "2018-08-07T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2019.json
+++ b/test/fixtures/CA-YT-2019.json
@@ -113,7 +113,7 @@
     "end": "2019-08-06T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2020.json
+++ b/test/fixtures/CA-YT-2020.json
@@ -113,7 +113,7 @@
     "end": "2020-08-04T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2021.json
+++ b/test/fixtures/CA-YT-2021.json
@@ -113,7 +113,7 @@
     "end": "2021-08-03T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2022.json
+++ b/test/fixtures/CA-YT-2022.json
@@ -113,7 +113,7 @@
     "end": "2022-08-02T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2023.json
+++ b/test/fixtures/CA-YT-2023.json
@@ -113,7 +113,7 @@
     "end": "2023-08-08T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2024.json
+++ b/test/fixtures/CA-YT-2024.json
@@ -113,7 +113,7 @@
     "end": "2024-08-06T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2025.json
+++ b/test/fixtures/CA-YT-2025.json
@@ -113,7 +113,7 @@
     "end": "2025-08-05T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2026.json
+++ b/test/fixtures/CA-YT-2026.json
@@ -113,7 +113,7 @@
     "end": "2026-08-04T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2027.json
+++ b/test/fixtures/CA-YT-2027.json
@@ -113,7 +113,7 @@
     "end": "2027-08-03T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2028.json
+++ b/test/fixtures/CA-YT-2028.json
@@ -113,7 +113,7 @@
     "end": "2028-08-08T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/CA-YT-2029.json
+++ b/test/fixtures/CA-YT-2029.json
@@ -113,7 +113,7 @@
     "end": "2029-08-07T07:00:00.000Z",
     "name": "Civic Holiday",
     "type": "public",
-    "rule": "monday after 08-01",
+    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {


### PR DESCRIPTION
Saskatchewan Day is on the first Monday in August. This is also Terry Fox Day in Manitoba. See CBC source [here](https://www.cbc.ca/news/canada/saskatchewan/saskatchewan-day-how-do-we-celebrate-1.4773846)