### PR TITLE
Improved Vatican holidays.

### DIFF
--- a/data/countries/VA.yaml
+++ b/data/countries/VA.yaml
@@ -25,16 +25,26 @@ holidays:
           it: Anniversario della istituzione dello Stato della Città del Vaticano
       03-19:
         _name: 03-19
+      easter -3:
+        _name: easter -3
+      easter -2:
+        _name: easter -2
+      easter -1:
+        _name: easter -1
+      easter:
+        _name: easter
       easter 1:
         _name: easter 1
+      easter 2:
+        name:
+          en: In Albis Tuesday
+          it: Martedì in Albis
       easter 39:
         _name: easter 39
-        active:
-          - to: 2009
+      easter 49:
+        _name: easter 49
       easter 60:
         _name: easter 60
-        active:
-          - to: 2009
       05-01:
         _name: 05-01
         name:
@@ -42,22 +52,34 @@ holidays:
           it: San Giuseppe lavoratore
       06-29:
         _name: 06-29
+      08-14:
+        name:
+          en: Summer holiday
+          it: Summer holiday
       08-15:
         _name: 08-15
         name:
           it: Assunzione di Maria in Cielo
-      09-08:
+      08-16:
         name:
-          en: Nativity of Mary
-          it: Festa della natività della madonna
+          en: Summer holiday
+          it: Summer holiday
       11-01:
         _name: 11-01
+      11-02:
+        _name: 11-02
       12-08:
         _name: 12-08
       12-25:
         _name: 12-25
       12-26:
         _name: 12-26
+      12-27:
+        name:
+          en: St. John
+          it: San Giovanni
+      12-31:
+        _name: 12-31
       # Pope John Paul II
       10-16:
         name:

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -607,7 +607,7 @@ names:
       fr: Samedi saint
       ge: დიდი შაბათი
       hu: Nagyszombat
-      it: Sabado santo
+      it: Sabato santo
       lb: Karsamschdeg
       nl: Dag voor Pasen
       no: Påskeaften


### PR DESCRIPTION
There is no analytic public source available, still the Vatican Pharmacy calendars confirm all my edits:
* https://www.farmaciavaticana.va/images/pdf/calendario_2023.pdf
* https://www.farmaciavaticana.va/media/attachments/2024/01/02/calendario_2024.pdf
* https://www.farmaciavaticana.va/media/attachments/2025/01/02/calendario-2025.pdf

A source in Italian is the article 27 of official rule for the Vatican employees: https://www.vatican.va/roman_curia/labour_office/docs/documents/ulsa_b18_7_it.html

The 2025 calendar misses the feasts tied to Pope Leo XIV.

Some discussions on: https://github.com/vacanza/holidays/issues/2184