### PR TITLE
Update names.yaml: replaced `sv: Kristi himmelfärds dag` with `sv: Kristi himmelfärdsdag`

### DIFF
--- a/data/names.yaml
+++ b/data/names.yaml
@@ -712,7 +712,7 @@ names:
       no: Kristi himmelfartsdag
       pap: Dia di Asuncion
       ro: Ziua Eroilor
-      sv: Kristi himmelfärds dag
+      sv: Kristi himmelfärdsdag
       vi: Lễ Thăng Thiên
   easter 49: # Pentecost / Whit Sunday
     name:


### PR DESCRIPTION
The correct spelling is "[Kristi himmelsfärdsdag](https://sv.wikipedia.org/wiki/Kristi_himmelsf%C3%A4rdsdag)" as two words. Although it can sometimes be written as three words "Kristi himmelsfärds dag," the most common and formally accepted form is the single compound word. This follows the general rule for Swedish calendar day names, where compound words are often written together, especially when referring to specific named holidays.

- Source: [Förordning (1989:253) om allmänna helgdagar](https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-1989253-om-allmanna-helgdagar_sfs-1989-253/)
