### PR TITLE
fix(HK): correct "The day following Easter Monday" for 2026

### DIFF
--- a/data/countries/HK.yaml
+++ b/data/countries/HK.yaml
@@ -1,6 +1,7 @@
 holidays:
   HK:
     # sources:
+    #   - https://www.gov.hk/en/about/abouthk/holiday/2026.htm
     #   - https://www.gov.hk/en/about/abouthk/holiday/2025.htm
     #   - https://www.gov.hk/en/about/abouthk/holiday/2024.htm
     #   - https://www.gov.hk/en/about/abouthk/holiday/2023.htm
@@ -76,8 +77,13 @@ holidays:
         disable:
           # As the day following Ching Ming Festival and Easter Monday fall on the same day, the next following day that is not itself a general holiday will be observed as an additional general holiday.
           - "2021-04-05"
+          - "2026-04-06"
       # As the day following Ching Ming Festival and Easter Monday fall on the same day, the next following day that is not itself a general holiday will be observed as an additional general holiday.
       "2021-04-06":
+        name:
+          en: The day following Easter Monday
+          zh: 復活節星期一翌日
+      "2026-04-07":
         name:
           en: The day following Easter Monday
           zh: 復活節星期一翌日

--- a/test/fixtures/HK-2026.json
+++ b/test/fixtures/HK-2026.json
@@ -57,19 +57,19 @@
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-05T16:00:00.000Z",
     "end": "2026-04-06T16:00:00.000Z",
-    "name": "復活節星期一",
-    "type": "public",
-    "rule": "easter 1",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2026-04-06 00:00:00",
-    "start": "2026-04-05T16:00:00.000Z",
-    "end": "2026-04-06T16:00:00.000Z",
     "name": "清明節翌日",
     "type": "public",
     "rule": "substitutes chinese 5-01 solarterm if Sunday then next Monday",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-07 00:00:00",
+    "start": "2026-04-06T16:00:00.000Z",
+    "end": "2026-04-07T16:00:00.000Z",
+    "name": "復活節星期一翌日",
+    "type": "public",
+    "rule": "2026-04-07",
+    "_weekday": "Tue"
   },
   {
     "date": "2026-05-01 00:00:00",


### PR DESCRIPTION
The day following Ching Ming Festival and Easter Monday fall on the same day again in 2026.

Official Hong Kong general holidays for 2026
English: 
https://www.gov.hk/en/about/abouthk/holiday/2026.htm
Traditional Chinese:
https://www.gov.hk/tc/about/abouthk/holiday/2026.htm