### PR TITLE
fix(BR): remove 'optional' type from Easter 60 holiday

### DIFF
--- a/data/countries/BR.yaml
+++ b/data/countries/BR.yaml
@@ -49,7 +49,6 @@ holidays:
         type: observance
       easter 60:
         _name: easter 60
-        type: optional
       06-12:
         name:
           pt: Dia dos Namorados


### PR DESCRIPTION
## Problem
The Corpus Christi holiday (easter 60) was explicitly marked as type: optional, which may not accurately represent its official status as a public/bank holiday in Brazil, or the explicit type declaration was redundant.
https://www.anbima.com.br/feriados/fer_nacionais/2026.asp

## Solution
Removed the explicit `type: optional` declaration from Corpus Christi, allowing the holiday to inherit the default type behavior or be properly categorized based on the _name reference.