### PR TITLE
fix: Slovakia public holidays aligned with the 2025 legislation changes

### DIFF
--- a/data/countries/SK.yaml
+++ b/data/countries/SK.yaml
@@ -1,4 +1,5 @@
-# @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Slovakia
+# @source https://nbs.sk/o-narodnej-banke/sviatky-v-sr/
+# @attrib https://cs.wikipedia.org/wiki/St%C3%A1tn%C3%AD_sv%C3%A1tky_Slovenska
 holidays:
   SK:
     names:
@@ -16,23 +17,19 @@ holidays:
           sk: Deň vzniku Slovenskej republiky
       01-06:
         _name: 01-06
-        type: observance
       easter -2:
         _name: easter -2
       easter:
         _name: easter
       easter 1:
         _name: easter 1
-      05-01 since 2025:
+      05-01:
         _name: 05-01
-        type: observance
-      05-01 prior to 2025:
-        _name: 05-01
-      05-08 prior to 2025:
+      05-08 prior to 2026:
         name:
           sk: Deň víťazstva nad fašizmom
           en: Day of victory over fascism
-      05-08 since 2025:
+      05-08 since 2026:
         name:
           sk: Deň víťazstva nad fašizmom
           en: Day of victory over fascism
@@ -40,43 +37,30 @@ holidays:
       2nd sunday in May:
         _name: Mothers Day
         type: observance
-      07-05 prior to 2025:
+      07-05:
         name:
           sk: Sviatok svätého Cyrila a Metoda
           en: Saints Cyril and Methodius Day
-      07-05 since 2025:
-        name:
-          sk: Sviatok svätého Cyrila a Metoda
-          en: Saints Cyril and Methodius Day
-        type: observance
-      08-29 prior to 2025:
+      08-29:
         name:
           sk: Výročie Slovenského národného povstania
           en: Slovak National Uprising anniversary
-      08-29 since 2025:
-        name:
-          sk: Výročie Slovenského národného povstania
-          en: Slovak National Uprising anniversary
-        type: observance
       09-01 since 1994 and prior to 2024:
         _name: Constitution Day
       09-01 since 2024:
         _name: Constitution Day
         type: observance
-      09-15 prior to 2025:
+      09-15 prior to 2026:
         name:
           sk: Sviatok Panny Márie Sedembolestnej
           en: Day of Our Lady of the Seven Sorrows
-      09-15 since 2025:
+      09-15 since 2026:
         name:
           sk: Sviatok Panny Márie Sedembolestnej
           en: Day of Our Lady of the Seven Sorrows
         type: observance
-      11-01 prior to 2025:
+      11-01:
         _name: 11-01
-      11-01 since 2025:
-        _name: 11-01
-        type: observance
       11-17 prior to 2025:
         name:
           sk: Deň boja za slobodu a demokraciu

--- a/test/fixtures/SK-2015.json
+++ b/test/fixtures/SK-2015.json
@@ -13,7 +13,7 @@
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
   },
@@ -50,7 +50,7 @@
     "end": "2015-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
     "type": "public",
-    "rule": "05-01 prior to 2025",
+    "rule": "05-01",
     "_weekday": "Fri"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2015-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "public",
-    "rule": "05-08 prior to 2025",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Fri"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2015-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
     "type": "public",
-    "rule": "07-05 prior to 2025",
+    "rule": "07-05",
     "_weekday": "Sun"
   },
   {
@@ -86,7 +86,7 @@
     "end": "2015-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
     "type": "public",
-    "rule": "08-29 prior to 2025",
+    "rule": "08-29",
     "_weekday": "Sat"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2015-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "public",
-    "rule": "09-15 prior to 2025",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Tue"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2015-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
     "type": "public",
-    "rule": "11-01 prior to 2025",
+    "rule": "11-01",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/SK-2016.json
+++ b/test/fixtures/SK-2016.json
@@ -13,7 +13,7 @@
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
   },
@@ -50,7 +50,7 @@
     "end": "2016-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
     "type": "public",
-    "rule": "05-01 prior to 2025",
+    "rule": "05-01",
     "_weekday": "Sun"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2016-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "public",
-    "rule": "05-08 prior to 2025",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Sun"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2016-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
     "type": "public",
-    "rule": "07-05 prior to 2025",
+    "rule": "07-05",
     "_weekday": "Tue"
   },
   {
@@ -86,7 +86,7 @@
     "end": "2016-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
     "type": "public",
-    "rule": "08-29 prior to 2025",
+    "rule": "08-29",
     "_weekday": "Mon"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2016-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "public",
-    "rule": "09-15 prior to 2025",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Thu"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2016-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
     "type": "public",
-    "rule": "11-01 prior to 2025",
+    "rule": "11-01",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/SK-2017.json
+++ b/test/fixtures/SK-2017.json
@@ -13,7 +13,7 @@
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
   },
@@ -50,7 +50,7 @@
     "end": "2017-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
     "type": "public",
-    "rule": "05-01 prior to 2025",
+    "rule": "05-01",
     "_weekday": "Mon"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2017-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "public",
-    "rule": "05-08 prior to 2025",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Mon"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2017-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
     "type": "public",
-    "rule": "07-05 prior to 2025",
+    "rule": "07-05",
     "_weekday": "Wed"
   },
   {
@@ -86,7 +86,7 @@
     "end": "2017-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
     "type": "public",
-    "rule": "08-29 prior to 2025",
+    "rule": "08-29",
     "_weekday": "Tue"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2017-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "public",
-    "rule": "09-15 prior to 2025",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Fri"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2017-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
     "type": "public",
-    "rule": "11-01 prior to 2025",
+    "rule": "11-01",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/SK-2018.json
+++ b/test/fixtures/SK-2018.json
@@ -13,7 +13,7 @@
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
   },
@@ -50,7 +50,7 @@
     "end": "2018-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
     "type": "public",
-    "rule": "05-01 prior to 2025",
+    "rule": "05-01",
     "_weekday": "Tue"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2018-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "public",
-    "rule": "05-08 prior to 2025",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Tue"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2018-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
     "type": "public",
-    "rule": "07-05 prior to 2025",
+    "rule": "07-05",
     "_weekday": "Thu"
   },
   {
@@ -86,7 +86,7 @@
     "end": "2018-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
     "type": "public",
-    "rule": "08-29 prior to 2025",
+    "rule": "08-29",
     "_weekday": "Wed"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2018-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "public",
-    "rule": "09-15 prior to 2025",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Sat"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2018-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
     "type": "public",
-    "rule": "11-01 prior to 2025",
+    "rule": "11-01",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/SK-2019.json
+++ b/test/fixtures/SK-2019.json
@@ -13,7 +13,7 @@
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
   },
@@ -50,7 +50,7 @@
     "end": "2019-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
     "type": "public",
-    "rule": "05-01 prior to 2025",
+    "rule": "05-01",
     "_weekday": "Wed"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2019-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "public",
-    "rule": "05-08 prior to 2025",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Wed"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2019-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
     "type": "public",
-    "rule": "07-05 prior to 2025",
+    "rule": "07-05",
     "_weekday": "Fri"
   },
   {
@@ -86,7 +86,7 @@
     "end": "2019-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
     "type": "public",
-    "rule": "08-29 prior to 2025",
+    "rule": "08-29",
     "_weekday": "Thu"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2019-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "public",
-    "rule": "09-15 prior to 2025",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Sun"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2019-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
     "type": "public",
-    "rule": "11-01 prior to 2025",
+    "rule": "11-01",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SK-2020.json
+++ b/test/fixtures/SK-2020.json
@@ -13,7 +13,7 @@
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
   },
@@ -50,7 +50,7 @@
     "end": "2020-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
     "type": "public",
-    "rule": "05-01 prior to 2025",
+    "rule": "05-01",
     "_weekday": "Fri"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2020-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "public",
-    "rule": "05-08 prior to 2025",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Fri"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2020-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
     "type": "public",
-    "rule": "07-05 prior to 2025",
+    "rule": "07-05",
     "_weekday": "Sun"
   },
   {
@@ -86,7 +86,7 @@
     "end": "2020-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
     "type": "public",
-    "rule": "08-29 prior to 2025",
+    "rule": "08-29",
     "_weekday": "Sat"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2020-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "public",
-    "rule": "09-15 prior to 2025",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Tue"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2020-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
     "type": "public",
-    "rule": "11-01 prior to 2025",
+    "rule": "11-01",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/SK-2021.json
+++ b/test/fixtures/SK-2021.json
@@ -13,7 +13,7 @@
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
   },
@@ -50,7 +50,7 @@
     "end": "2021-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
     "type": "public",
-    "rule": "05-01 prior to 2025",
+    "rule": "05-01",
     "_weekday": "Sat"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2021-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "public",
-    "rule": "05-08 prior to 2025",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Sat"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2021-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
     "type": "public",
-    "rule": "07-05 prior to 2025",
+    "rule": "07-05",
     "_weekday": "Mon"
   },
   {
@@ -86,7 +86,7 @@
     "end": "2021-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
     "type": "public",
-    "rule": "08-29 prior to 2025",
+    "rule": "08-29",
     "_weekday": "Sun"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2021-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "public",
-    "rule": "09-15 prior to 2025",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Wed"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2021-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
     "type": "public",
-    "rule": "11-01 prior to 2025",
+    "rule": "11-01",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/SK-2022.json
+++ b/test/fixtures/SK-2022.json
@@ -13,7 +13,7 @@
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
   },
@@ -50,7 +50,7 @@
     "end": "2022-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
     "type": "public",
-    "rule": "05-01 prior to 2025",
+    "rule": "05-01",
     "_weekday": "Sun"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2022-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "public",
-    "rule": "05-08 prior to 2025",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Sun"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2022-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
     "type": "public",
-    "rule": "07-05 prior to 2025",
+    "rule": "07-05",
     "_weekday": "Tue"
   },
   {
@@ -86,7 +86,7 @@
     "end": "2022-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
     "type": "public",
-    "rule": "08-29 prior to 2025",
+    "rule": "08-29",
     "_weekday": "Mon"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2022-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "public",
-    "rule": "09-15 prior to 2025",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Thu"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2022-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
     "type": "public",
-    "rule": "11-01 prior to 2025",
+    "rule": "11-01",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/SK-2023.json
+++ b/test/fixtures/SK-2023.json
@@ -13,7 +13,7 @@
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
   },
@@ -50,7 +50,7 @@
     "end": "2023-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
     "type": "public",
-    "rule": "05-01 prior to 2025",
+    "rule": "05-01",
     "_weekday": "Mon"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2023-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "public",
-    "rule": "05-08 prior to 2025",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Mon"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2023-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
     "type": "public",
-    "rule": "07-05 prior to 2025",
+    "rule": "07-05",
     "_weekday": "Wed"
   },
   {
@@ -86,7 +86,7 @@
     "end": "2023-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
     "type": "public",
-    "rule": "08-29 prior to 2025",
+    "rule": "08-29",
     "_weekday": "Tue"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2023-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "public",
-    "rule": "09-15 prior to 2025",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Fri"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2023-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
     "type": "public",
-    "rule": "11-01 prior to 2025",
+    "rule": "11-01",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/SK-2024.json
+++ b/test/fixtures/SK-2024.json
@@ -13,7 +13,7 @@
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
   },
@@ -50,7 +50,7 @@
     "end": "2024-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
     "type": "public",
-    "rule": "05-01 prior to 2025",
+    "rule": "05-01",
     "_weekday": "Wed"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2024-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "public",
-    "rule": "05-08 prior to 2025",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Wed"
   },
   {
@@ -77,7 +77,7 @@
     "end": "2024-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
     "type": "public",
-    "rule": "07-05 prior to 2025",
+    "rule": "07-05",
     "_weekday": "Fri"
   },
   {
@@ -86,7 +86,7 @@
     "end": "2024-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
     "type": "public",
-    "rule": "08-29 prior to 2025",
+    "rule": "08-29",
     "_weekday": "Thu"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2024-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "public",
-    "rule": "09-15 prior to 2025",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Sun"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2024-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
     "type": "public",
-    "rule": "11-01 prior to 2025",
+    "rule": "11-01",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/SK-2025.json
+++ b/test/fixtures/SK-2025.json
@@ -13,7 +13,7 @@
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
   },
@@ -49,8 +49,8 @@
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
-    "type": "observance",
-    "rule": "05-01 since 2025",
+    "type": "public",
+    "rule": "05-01",
     "_weekday": "Thu"
   },
   {
@@ -58,8 +58,8 @@
     "start": "2025-05-07T22:00:00.000Z",
     "end": "2025-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
-    "type": "observance",
-    "rule": "05-08 since 2025",
+    "type": "public",
+    "rule": "05-08 prior to 2026",
     "_weekday": "Thu"
   },
   {
@@ -76,8 +76,8 @@
     "start": "2025-07-04T22:00:00.000Z",
     "end": "2025-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
-    "type": "observance",
-    "rule": "07-05 since 2025",
+    "type": "public",
+    "rule": "07-05",
     "_weekday": "Sat"
   },
   {
@@ -85,8 +85,8 @@
     "start": "2025-08-28T22:00:00.000Z",
     "end": "2025-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
-    "type": "observance",
-    "rule": "08-29 since 2025",
+    "type": "public",
+    "rule": "08-29",
     "_weekday": "Fri"
   },
   {
@@ -103,8 +103,8 @@
     "start": "2025-09-14T22:00:00.000Z",
     "end": "2025-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
-    "type": "observance",
-    "rule": "09-15 since 2025",
+    "type": "public",
+    "rule": "09-15 prior to 2026",
     "_weekday": "Mon"
   },
   {
@@ -112,8 +112,8 @@
     "start": "2025-10-31T23:00:00.000Z",
     "end": "2025-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
-    "type": "observance",
-    "rule": "11-01 since 2025",
+    "type": "public",
+    "rule": "11-01",
     "_weekday": "Sat"
   },
   {

--- a/test/fixtures/SK-2026.json
+++ b/test/fixtures/SK-2026.json
@@ -13,7 +13,7 @@
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
   },
@@ -49,8 +49,8 @@
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
-    "type": "observance",
-    "rule": "05-01 since 2025",
+    "type": "public",
+    "rule": "05-01",
     "_weekday": "Fri"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2026-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "observance",
-    "rule": "05-08 since 2025",
+    "rule": "05-08 since 2026",
     "_weekday": "Fri"
   },
   {
@@ -76,8 +76,8 @@
     "start": "2026-07-04T22:00:00.000Z",
     "end": "2026-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
-    "type": "observance",
-    "rule": "07-05 since 2025",
+    "type": "public",
+    "rule": "07-05",
     "_weekday": "Sun"
   },
   {
@@ -85,8 +85,8 @@
     "start": "2026-08-28T22:00:00.000Z",
     "end": "2026-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
-    "type": "observance",
-    "rule": "08-29 since 2025",
+    "type": "public",
+    "rule": "08-29",
     "_weekday": "Sat"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2026-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "observance",
-    "rule": "09-15 since 2025",
+    "rule": "09-15 since 2026",
     "_weekday": "Tue"
   },
   {
@@ -112,8 +112,8 @@
     "start": "2026-10-31T23:00:00.000Z",
     "end": "2026-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
-    "type": "observance",
-    "rule": "11-01 since 2025",
+    "type": "public",
+    "rule": "11-01",
     "_weekday": "Sun"
   },
   {

--- a/test/fixtures/SK-2027.json
+++ b/test/fixtures/SK-2027.json
@@ -13,7 +13,7 @@
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
   },
@@ -49,8 +49,8 @@
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
-    "type": "observance",
-    "rule": "05-01 since 2025",
+    "type": "public",
+    "rule": "05-01",
     "_weekday": "Sat"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2027-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "observance",
-    "rule": "05-08 since 2025",
+    "rule": "05-08 since 2026",
     "_weekday": "Sat"
   },
   {
@@ -76,8 +76,8 @@
     "start": "2027-07-04T22:00:00.000Z",
     "end": "2027-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
-    "type": "observance",
-    "rule": "07-05 since 2025",
+    "type": "public",
+    "rule": "07-05",
     "_weekday": "Mon"
   },
   {
@@ -85,8 +85,8 @@
     "start": "2027-08-28T22:00:00.000Z",
     "end": "2027-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
-    "type": "observance",
-    "rule": "08-29 since 2025",
+    "type": "public",
+    "rule": "08-29",
     "_weekday": "Sun"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2027-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "observance",
-    "rule": "09-15 since 2025",
+    "rule": "09-15 since 2026",
     "_weekday": "Wed"
   },
   {
@@ -112,8 +112,8 @@
     "start": "2027-10-31T23:00:00.000Z",
     "end": "2027-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
-    "type": "observance",
-    "rule": "11-01 since 2025",
+    "type": "public",
+    "rule": "11-01",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/SK-2028.json
+++ b/test/fixtures/SK-2028.json
@@ -13,7 +13,7 @@
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
   },
@@ -49,8 +49,8 @@
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
-    "type": "observance",
-    "rule": "05-01 since 2025",
+    "type": "public",
+    "rule": "05-01",
     "_weekday": "Mon"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2028-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "observance",
-    "rule": "05-08 since 2025",
+    "rule": "05-08 since 2026",
     "_weekday": "Mon"
   },
   {
@@ -76,8 +76,8 @@
     "start": "2028-07-04T22:00:00.000Z",
     "end": "2028-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
-    "type": "observance",
-    "rule": "07-05 since 2025",
+    "type": "public",
+    "rule": "07-05",
     "_weekday": "Wed"
   },
   {
@@ -85,8 +85,8 @@
     "start": "2028-08-28T22:00:00.000Z",
     "end": "2028-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
-    "type": "observance",
-    "rule": "08-29 since 2025",
+    "type": "public",
+    "rule": "08-29",
     "_weekday": "Tue"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2028-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "observance",
-    "rule": "09-15 since 2025",
+    "rule": "09-15 since 2026",
     "_weekday": "Fri"
   },
   {
@@ -112,8 +112,8 @@
     "start": "2028-10-31T23:00:00.000Z",
     "end": "2028-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
-    "type": "observance",
-    "rule": "11-01 since 2025",
+    "type": "public",
+    "rule": "11-01",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/SK-2029.json
+++ b/test/fixtures/SK-2029.json
@@ -13,7 +13,7 @@
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
     "name": "Zjavenie Pána",
-    "type": "observance",
+    "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
   },
@@ -49,8 +49,8 @@
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
     "name": "Sviatok práce",
-    "type": "observance",
-    "rule": "05-01 since 2025",
+    "type": "public",
+    "rule": "05-01",
     "_weekday": "Tue"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2029-05-08T22:00:00.000Z",
     "name": "Deň víťazstva nad fašizmom",
     "type": "observance",
-    "rule": "05-08 since 2025",
+    "rule": "05-08 since 2026",
     "_weekday": "Tue"
   },
   {
@@ -76,8 +76,8 @@
     "start": "2029-07-04T22:00:00.000Z",
     "end": "2029-07-05T22:00:00.000Z",
     "name": "Sviatok svätého Cyrila a Metoda",
-    "type": "observance",
-    "rule": "07-05 since 2025",
+    "type": "public",
+    "rule": "07-05",
     "_weekday": "Thu"
   },
   {
@@ -85,8 +85,8 @@
     "start": "2029-08-28T22:00:00.000Z",
     "end": "2029-08-29T22:00:00.000Z",
     "name": "Výročie Slovenského národného povstania",
-    "type": "observance",
-    "rule": "08-29 since 2025",
+    "type": "public",
+    "rule": "08-29",
     "_weekday": "Wed"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2029-09-15T22:00:00.000Z",
     "name": "Sviatok Panny Márie Sedembolestnej",
     "type": "observance",
-    "rule": "09-15 since 2025",
+    "rule": "09-15 since 2026",
     "_weekday": "Sat"
   },
   {
@@ -112,8 +112,8 @@
     "start": "2029-10-31T23:00:00.000Z",
     "end": "2029-11-01T23:00:00.000Z",
     "name": "Sviatok všetkých svätých",
-    "type": "observance",
-    "rule": "11-01 since 2025",
+    "type": "public",
+    "rule": "11-01",
     "_weekday": "Thu"
   },
   {


### PR DESCRIPTION
The previous fix introduced observance holidays that are in fact public holidays. I changed the wrong observance holidays back to public holidays. 
Also I added more relevant sources - Slovak National Bank and Czech Wikipedia (as it's more up to date than Slovak Wikipedia). 