### PR TITLE
fix(GP MQ): Fix Victor Schoelcher Day is not public holiday

### DIFF
--- a/data/countries/GP.yaml
+++ b/data/countries/GP.yaml
@@ -1,3 +1,4 @@
+# @source https://www.guadeloupe.gouv.fr/layout/set/print/Outils/Liens-utiles/Folder/Professionnels-Toutes-les-demarches#!/particuliers/page/F2405
 # @attrib https://fr.wikipedia.org/wiki/Guadeloupe#C%C3%A9l%C3%A9brations,_festivit%C3%A9s_et_jours_f%C3%A9ri%C3%A9s
 # @source https://www.public-holidays.us/FR_FR_2021_Guadeloupe
 holidays:
@@ -19,5 +20,7 @@ holidays:
         _name: Abolition of Slavery
       07-21:
         name:
-          fr: Jour de Victor Shoelcher
-          en: Victor Shoelcher Day
+          fr: Jour de Victor Schoelcher
+          en: Victor Schoelcher Day
+        type: optional
+        note: Government offices closed

--- a/data/countries/MQ.yaml
+++ b/data/countries/MQ.yaml
@@ -1,3 +1,4 @@
+# @source https://www.martinique.gouv.fr/Vous-etes/Association#!/particuliers/page/F2405
 # @source https://www.public-holidays.us/FR_FR_2021_Martinique
 # @source https://www.joursferies.fr/pays/martinique.php
 holidays:
@@ -19,4 +20,6 @@ holidays:
       07-21:
         name:
           fr: Jour de Victor Schoelcher
-          en: Victor Shoelcher Day
+          en: Victor Schoelcher Day
+        type: optional
+        note: Government offices closed

--- a/test/fixtures/FR-GP-2015.json
+++ b/test/fixtures/FR-GP-2015.json
@@ -93,8 +93,9 @@
     "date": "2015-07-21 00:00:00",
     "start": "2015-07-21T04:00:00.000Z",
     "end": "2015-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/FR-GP-2016.json
+++ b/test/fixtures/FR-GP-2016.json
@@ -93,8 +93,9 @@
     "date": "2016-07-21 00:00:00",
     "start": "2016-07-21T04:00:00.000Z",
     "end": "2016-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Thu"
   },

--- a/test/fixtures/FR-GP-2017.json
+++ b/test/fixtures/FR-GP-2017.json
@@ -93,8 +93,9 @@
     "date": "2017-07-21 00:00:00",
     "start": "2017-07-21T04:00:00.000Z",
     "end": "2017-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/FR-GP-2018.json
+++ b/test/fixtures/FR-GP-2018.json
@@ -93,8 +93,9 @@
     "date": "2018-07-21 00:00:00",
     "start": "2018-07-21T04:00:00.000Z",
     "end": "2018-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sat"
   },

--- a/test/fixtures/FR-GP-2019.json
+++ b/test/fixtures/FR-GP-2019.json
@@ -93,8 +93,9 @@
     "date": "2019-07-21 00:00:00",
     "start": "2019-07-21T04:00:00.000Z",
     "end": "2019-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sun"
   },

--- a/test/fixtures/FR-GP-2020.json
+++ b/test/fixtures/FR-GP-2020.json
@@ -93,8 +93,9 @@
     "date": "2020-07-21 00:00:00",
     "start": "2020-07-21T04:00:00.000Z",
     "end": "2020-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/FR-GP-2021.json
+++ b/test/fixtures/FR-GP-2021.json
@@ -93,8 +93,9 @@
     "date": "2021-07-21 00:00:00",
     "start": "2021-07-21T04:00:00.000Z",
     "end": "2021-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Wed"
   },

--- a/test/fixtures/FR-GP-2022.json
+++ b/test/fixtures/FR-GP-2022.json
@@ -93,8 +93,9 @@
     "date": "2022-07-21 00:00:00",
     "start": "2022-07-21T04:00:00.000Z",
     "end": "2022-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Thu"
   },

--- a/test/fixtures/FR-GP-2023.json
+++ b/test/fixtures/FR-GP-2023.json
@@ -93,8 +93,9 @@
     "date": "2023-07-21 00:00:00",
     "start": "2023-07-21T04:00:00.000Z",
     "end": "2023-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/FR-GP-2024.json
+++ b/test/fixtures/FR-GP-2024.json
@@ -93,8 +93,9 @@
     "date": "2024-07-21 00:00:00",
     "start": "2024-07-21T04:00:00.000Z",
     "end": "2024-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sun"
   },

--- a/test/fixtures/FR-GP-2025.json
+++ b/test/fixtures/FR-GP-2025.json
@@ -93,8 +93,9 @@
     "date": "2025-07-21 00:00:00",
     "start": "2025-07-21T04:00:00.000Z",
     "end": "2025-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Mon"
   },

--- a/test/fixtures/FR-GP-2026.json
+++ b/test/fixtures/FR-GP-2026.json
@@ -93,8 +93,9 @@
     "date": "2026-07-21 00:00:00",
     "start": "2026-07-21T04:00:00.000Z",
     "end": "2026-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/FR-GP-2027.json
+++ b/test/fixtures/FR-GP-2027.json
@@ -93,8 +93,9 @@
     "date": "2027-07-21 00:00:00",
     "start": "2027-07-21T04:00:00.000Z",
     "end": "2027-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Wed"
   },

--- a/test/fixtures/FR-GP-2028.json
+++ b/test/fixtures/FR-GP-2028.json
@@ -93,8 +93,9 @@
     "date": "2028-07-21 00:00:00",
     "start": "2028-07-21T04:00:00.000Z",
     "end": "2028-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/FR-GP-2029.json
+++ b/test/fixtures/FR-GP-2029.json
@@ -93,8 +93,9 @@
     "date": "2029-07-21 00:00:00",
     "start": "2029-07-21T04:00:00.000Z",
     "end": "2029-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sat"
   },

--- a/test/fixtures/FR-MQ-2015.json
+++ b/test/fixtures/FR-MQ-2015.json
@@ -103,7 +103,8 @@
     "start": "2015-07-21T04:00:00.000Z",
     "end": "2015-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/FR-MQ-2016.json
+++ b/test/fixtures/FR-MQ-2016.json
@@ -103,7 +103,8 @@
     "start": "2016-07-21T04:00:00.000Z",
     "end": "2016-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Thu"
   },

--- a/test/fixtures/FR-MQ-2017.json
+++ b/test/fixtures/FR-MQ-2017.json
@@ -103,7 +103,8 @@
     "start": "2017-07-21T04:00:00.000Z",
     "end": "2017-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/FR-MQ-2018.json
+++ b/test/fixtures/FR-MQ-2018.json
@@ -103,7 +103,8 @@
     "start": "2018-07-21T04:00:00.000Z",
     "end": "2018-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sat"
   },

--- a/test/fixtures/FR-MQ-2019.json
+++ b/test/fixtures/FR-MQ-2019.json
@@ -103,7 +103,8 @@
     "start": "2019-07-21T04:00:00.000Z",
     "end": "2019-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sun"
   },

--- a/test/fixtures/FR-MQ-2020.json
+++ b/test/fixtures/FR-MQ-2020.json
@@ -103,7 +103,8 @@
     "start": "2020-07-21T04:00:00.000Z",
     "end": "2020-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/FR-MQ-2021.json
+++ b/test/fixtures/FR-MQ-2021.json
@@ -103,7 +103,8 @@
     "start": "2021-07-21T04:00:00.000Z",
     "end": "2021-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Wed"
   },

--- a/test/fixtures/FR-MQ-2022.json
+++ b/test/fixtures/FR-MQ-2022.json
@@ -103,7 +103,8 @@
     "start": "2022-07-21T04:00:00.000Z",
     "end": "2022-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Thu"
   },

--- a/test/fixtures/FR-MQ-2023.json
+++ b/test/fixtures/FR-MQ-2023.json
@@ -103,7 +103,8 @@
     "start": "2023-07-21T04:00:00.000Z",
     "end": "2023-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/FR-MQ-2024.json
+++ b/test/fixtures/FR-MQ-2024.json
@@ -103,7 +103,8 @@
     "start": "2024-07-21T04:00:00.000Z",
     "end": "2024-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sun"
   },

--- a/test/fixtures/FR-MQ-2025.json
+++ b/test/fixtures/FR-MQ-2025.json
@@ -103,7 +103,8 @@
     "start": "2025-07-21T04:00:00.000Z",
     "end": "2025-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Mon"
   },

--- a/test/fixtures/FR-MQ-2026.json
+++ b/test/fixtures/FR-MQ-2026.json
@@ -103,7 +103,8 @@
     "start": "2026-07-21T04:00:00.000Z",
     "end": "2026-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/FR-MQ-2027.json
+++ b/test/fixtures/FR-MQ-2027.json
@@ -103,7 +103,8 @@
     "start": "2027-07-21T04:00:00.000Z",
     "end": "2027-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Wed"
   },

--- a/test/fixtures/FR-MQ-2028.json
+++ b/test/fixtures/FR-MQ-2028.json
@@ -103,7 +103,8 @@
     "start": "2028-07-21T04:00:00.000Z",
     "end": "2028-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/FR-MQ-2029.json
+++ b/test/fixtures/FR-MQ-2029.json
@@ -103,7 +103,8 @@
     "start": "2029-07-21T04:00:00.000Z",
     "end": "2029-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sat"
   },

--- a/test/fixtures/GP-2015.json
+++ b/test/fixtures/GP-2015.json
@@ -93,8 +93,9 @@
     "date": "2015-07-21 00:00:00",
     "start": "2015-07-21T04:00:00.000Z",
     "end": "2015-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/GP-2016.json
+++ b/test/fixtures/GP-2016.json
@@ -93,8 +93,9 @@
     "date": "2016-07-21 00:00:00",
     "start": "2016-07-21T04:00:00.000Z",
     "end": "2016-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Thu"
   },

--- a/test/fixtures/GP-2017.json
+++ b/test/fixtures/GP-2017.json
@@ -93,8 +93,9 @@
     "date": "2017-07-21 00:00:00",
     "start": "2017-07-21T04:00:00.000Z",
     "end": "2017-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/GP-2018.json
+++ b/test/fixtures/GP-2018.json
@@ -93,8 +93,9 @@
     "date": "2018-07-21 00:00:00",
     "start": "2018-07-21T04:00:00.000Z",
     "end": "2018-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sat"
   },

--- a/test/fixtures/GP-2019.json
+++ b/test/fixtures/GP-2019.json
@@ -93,8 +93,9 @@
     "date": "2019-07-21 00:00:00",
     "start": "2019-07-21T04:00:00.000Z",
     "end": "2019-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GP-2020.json
+++ b/test/fixtures/GP-2020.json
@@ -93,8 +93,9 @@
     "date": "2020-07-21 00:00:00",
     "start": "2020-07-21T04:00:00.000Z",
     "end": "2020-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/GP-2021.json
+++ b/test/fixtures/GP-2021.json
@@ -93,8 +93,9 @@
     "date": "2021-07-21 00:00:00",
     "start": "2021-07-21T04:00:00.000Z",
     "end": "2021-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Wed"
   },

--- a/test/fixtures/GP-2022.json
+++ b/test/fixtures/GP-2022.json
@@ -93,8 +93,9 @@
     "date": "2022-07-21 00:00:00",
     "start": "2022-07-21T04:00:00.000Z",
     "end": "2022-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Thu"
   },

--- a/test/fixtures/GP-2023.json
+++ b/test/fixtures/GP-2023.json
@@ -93,8 +93,9 @@
     "date": "2023-07-21 00:00:00",
     "start": "2023-07-21T04:00:00.000Z",
     "end": "2023-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/GP-2024.json
+++ b/test/fixtures/GP-2024.json
@@ -93,8 +93,9 @@
     "date": "2024-07-21 00:00:00",
     "start": "2024-07-21T04:00:00.000Z",
     "end": "2024-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sun"
   },

--- a/test/fixtures/GP-2025.json
+++ b/test/fixtures/GP-2025.json
@@ -93,8 +93,9 @@
     "date": "2025-07-21 00:00:00",
     "start": "2025-07-21T04:00:00.000Z",
     "end": "2025-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Mon"
   },

--- a/test/fixtures/GP-2026.json
+++ b/test/fixtures/GP-2026.json
@@ -93,8 +93,9 @@
     "date": "2026-07-21 00:00:00",
     "start": "2026-07-21T04:00:00.000Z",
     "end": "2026-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/GP-2027.json
+++ b/test/fixtures/GP-2027.json
@@ -93,8 +93,9 @@
     "date": "2027-07-21 00:00:00",
     "start": "2027-07-21T04:00:00.000Z",
     "end": "2027-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Wed"
   },

--- a/test/fixtures/GP-2028.json
+++ b/test/fixtures/GP-2028.json
@@ -93,8 +93,9 @@
     "date": "2028-07-21 00:00:00",
     "start": "2028-07-21T04:00:00.000Z",
     "end": "2028-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/GP-2029.json
+++ b/test/fixtures/GP-2029.json
@@ -93,8 +93,9 @@
     "date": "2029-07-21 00:00:00",
     "start": "2029-07-21T04:00:00.000Z",
     "end": "2029-07-22T04:00:00.000Z",
-    "name": "Jour de Victor Shoelcher",
-    "type": "public",
+    "name": "Jour de Victor Schoelcher",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sat"
   },

--- a/test/fixtures/MQ-2015.json
+++ b/test/fixtures/MQ-2015.json
@@ -103,7 +103,8 @@
     "start": "2015-07-21T04:00:00.000Z",
     "end": "2015-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/MQ-2016.json
+++ b/test/fixtures/MQ-2016.json
@@ -103,7 +103,8 @@
     "start": "2016-07-21T04:00:00.000Z",
     "end": "2016-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Thu"
   },

--- a/test/fixtures/MQ-2017.json
+++ b/test/fixtures/MQ-2017.json
@@ -103,7 +103,8 @@
     "start": "2017-07-21T04:00:00.000Z",
     "end": "2017-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/MQ-2018.json
+++ b/test/fixtures/MQ-2018.json
@@ -103,7 +103,8 @@
     "start": "2018-07-21T04:00:00.000Z",
     "end": "2018-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sat"
   },

--- a/test/fixtures/MQ-2019.json
+++ b/test/fixtures/MQ-2019.json
@@ -103,7 +103,8 @@
     "start": "2019-07-21T04:00:00.000Z",
     "end": "2019-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sun"
   },

--- a/test/fixtures/MQ-2020.json
+++ b/test/fixtures/MQ-2020.json
@@ -103,7 +103,8 @@
     "start": "2020-07-21T04:00:00.000Z",
     "end": "2020-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/MQ-2021.json
+++ b/test/fixtures/MQ-2021.json
@@ -103,7 +103,8 @@
     "start": "2021-07-21T04:00:00.000Z",
     "end": "2021-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Wed"
   },

--- a/test/fixtures/MQ-2022.json
+++ b/test/fixtures/MQ-2022.json
@@ -103,7 +103,8 @@
     "start": "2022-07-21T04:00:00.000Z",
     "end": "2022-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Thu"
   },

--- a/test/fixtures/MQ-2023.json
+++ b/test/fixtures/MQ-2023.json
@@ -103,7 +103,8 @@
     "start": "2023-07-21T04:00:00.000Z",
     "end": "2023-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/MQ-2024.json
+++ b/test/fixtures/MQ-2024.json
@@ -103,7 +103,8 @@
     "start": "2024-07-21T04:00:00.000Z",
     "end": "2024-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sun"
   },

--- a/test/fixtures/MQ-2025.json
+++ b/test/fixtures/MQ-2025.json
@@ -103,7 +103,8 @@
     "start": "2025-07-21T04:00:00.000Z",
     "end": "2025-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Mon"
   },

--- a/test/fixtures/MQ-2026.json
+++ b/test/fixtures/MQ-2026.json
@@ -103,7 +103,8 @@
     "start": "2026-07-21T04:00:00.000Z",
     "end": "2026-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Tue"
   },

--- a/test/fixtures/MQ-2027.json
+++ b/test/fixtures/MQ-2027.json
@@ -103,7 +103,8 @@
     "start": "2027-07-21T04:00:00.000Z",
     "end": "2027-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Wed"
   },

--- a/test/fixtures/MQ-2028.json
+++ b/test/fixtures/MQ-2028.json
@@ -103,7 +103,8 @@
     "start": "2028-07-21T04:00:00.000Z",
     "end": "2028-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Fri"
   },

--- a/test/fixtures/MQ-2029.json
+++ b/test/fixtures/MQ-2029.json
@@ -103,7 +103,8 @@
     "start": "2029-07-21T04:00:00.000Z",
     "end": "2029-07-22T04:00:00.000Z",
     "name": "Jour de Victor Schoelcher",
-    "type": "public",
+    "type": "optional",
+    "note": "Government offices closed",
     "rule": "07-21",
     "_weekday": "Sat"
   },


### PR DESCRIPTION
According https://www.guadeloupe.gouv.fr/layout/set/print/Outils/Liens-utiles/Folder/Professionnels-Toutes-les-demarches#!/particuliers/page/F2405 and https://www.martinique.gouv.fr/Vous-etes/Association#!/particuliers/page/F2405, Victor Schoelcher Day is not public holiday. In some sources, he is an observed holiday only for government offices.