### PR TITLE
feat(KR): Constitution Day becomes public holiday from 2026

### DIFF
--- a/data/countries/KR.yaml
+++ b/data/countries/KR.yaml
@@ -33,9 +33,18 @@ holidays:
         name:
           en: Memorial Day
           ko: 현충일
+      # Constitution Day was observance until 2025, became public holiday from 2026
       07-17:
-        _name: Constitution Day
+        name:
+          en: Constitution Day
+          ko: 제헌절
         type: observance
+        active:
+          - to: 2025
+      07-17 since 2026:
+        name:
+          en: Constitution Day
+          ko: 제헌절
       08-15:
         name:
           en: Liberation Day


### PR DESCRIPTION
## Summary

South Korea's Constitution Day (제헌절, July 17th) has been reinstated as a public holiday starting from 2026.

### Changes
- Constitution Day (07-17) was an observance until 2025
- From 2026, it becomes a public holiday in South Korea
- Added `active` period to preserve observance status for historical dates (until 2025)
- Added new entry with `since 2026` for public holiday status

### Background
The South Korean government has decided to restore Constitution Day as a public holiday from 2026. Previously, it was downgraded to an observance day in 2008.

### Testing
- Verified that 07-17 shows as `observance` for years <= 2025
- Verified that 07-17 shows as `public` holiday for years >= 2026