### PR TITLE
Update IT.yaml

### DIFF
--- a/data/countries/IT.yaml
+++ b/data/countries/IT.yaml
@@ -34,10 +34,10 @@ holidays:
           en: Republic Day
       08-15:
         _name: 08-15
-      10-04 since 2026:
-        name:
-          it: San Francesco d'Assisi
-          en: Francis of Assisi
+      #10-04 since 2026:
+      #  name:
+      #    it: San Francesco d'Assisi
+      #    en: Francis of Assisi
       11-01:
         _name: 11-01
       12-08:


### PR DESCRIPTION
Removed national holiday for 10-04 since 2006 because it is simply wrong. No national holiday here in this date.

Probably it is a local-only (single city, not per-state) holiday so it must be removed at all