### PR TITLE
fix(AU): 26 Dec substitute rules for NT and SA

### DIFF
--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -148,10 +148,15 @@ holidays:
           12-25 if saturday then next monday if sunday then next tuesday:
             substitute: true
             _name: 12-25
-          12-26 and if saturday then next monday if sunday then next tuesday: false
-          12-26 if saturday then next monday if sunday then next tuesday:
+          12-26 and if saturday then next monday if sunday then next tuesday:
             substitute: true
             _name: 12-26
+            active:
+              - from: "2023-12-26"
+          12-26 if saturday then next monday if sunday then next tuesday:
+            _name: 12-26
+            active:
+              - to: "2023-12-26"
           12-31 19:00:
             _name: 12-31
       # @source https://www.legislation.qld.gov.au/view/html/inforce/current/act-1983-018
@@ -210,10 +215,15 @@ holidays:
           12-25 if saturday then next monday if sunday then next tuesday:
             substitute: true
             _name: 12-25
-          12-26 and if saturday then next monday if sunday then next tuesday: false
-          12-26 if saturday then next monday if sunday then next tuesday:
+          12-26 and if saturday then next monday if sunday then next tuesday:
             substitute: true
             name: Proclamation Day
+            active:
+              - from: "2024-12-26"
+          12-26 if saturday then next monday if sunday then next tuesday:
+            name: Proclamation Day
+            active:
+              - to: "2024-12-26"
           12-31 19:00:
             _name: 12-31
       # @source https://www.legislation.tas.gov.au/view/html/inforce/current/act-2000-096

--- a/test/fixtures/AU-NT-2023.json
+++ b/test/fixtures/AU-NT-2023.json
@@ -131,7 +131,7 @@
     "end": "2023-12-26T14:30:00.000Z",
     "name": "Boxing Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/AU-NT-2024.json
+++ b/test/fixtures/AU-NT-2024.json
@@ -122,7 +122,7 @@
     "end": "2024-12-26T14:30:00.000Z",
     "name": "Boxing Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/AU-NT-2025.json
+++ b/test/fixtures/AU-NT-2025.json
@@ -122,7 +122,7 @@
     "end": "2025-12-26T14:30:00.000Z",
     "name": "Boxing Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/AU-NT-2026.json
+++ b/test/fixtures/AU-NT-2026.json
@@ -117,12 +117,22 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2026-12-26 00:00:00",
+    "start": "2026-12-25T14:30:00.000Z",
+    "end": "2026-12-26T14:30:00.000Z",
+    "name": "Boxing Day",
+    "type": "public",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2026-12-28 00:00:00",
     "start": "2026-12-27T14:30:00.000Z",
     "end": "2026-12-28T14:30:00.000Z",
-    "name": "Boxing Day",
+    "name": "Boxing Day (substitute day)",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "substitute": true,
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NT-2027.json
+++ b/test/fixtures/AU-NT-2027.json
@@ -108,6 +108,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2027-12-26 00:00:00",
+    "start": "2027-12-25T14:30:00.000Z",
+    "end": "2027-12-26T14:30:00.000Z",
+    "name": "Boxing Day",
+    "type": "public",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2027-12-27 00:00:00",
     "start": "2027-12-26T14:30:00.000Z",
     "end": "2027-12-27T14:30:00.000Z",
@@ -120,9 +129,10 @@
     "date": "2027-12-28 00:00:00",
     "start": "2027-12-27T14:30:00.000Z",
     "end": "2027-12-28T14:30:00.000Z",
-    "name": "Boxing Day",
+    "name": "Boxing Day (substitute day)",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "substitute": true,
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/AU-NT-2028.json
+++ b/test/fixtures/AU-NT-2028.json
@@ -131,7 +131,7 @@
     "end": "2028-12-26T14:30:00.000Z",
     "name": "Boxing Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/AU-NT-2029.json
+++ b/test/fixtures/AU-NT-2029.json
@@ -122,7 +122,7 @@
     "end": "2029-12-26T14:30:00.000Z",
     "name": "Boxing Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Wed"
   },
   {

--- a/test/fixtures/AU-SA-2024.json
+++ b/test/fixtures/AU-SA-2024.json
@@ -122,7 +122,7 @@
     "end": "2024-12-26T13:30:00.000Z",
     "name": "Proclamation Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Thu"
   },
   {

--- a/test/fixtures/AU-SA-2025.json
+++ b/test/fixtures/AU-SA-2025.json
@@ -122,7 +122,7 @@
     "end": "2025-12-26T13:30:00.000Z",
     "name": "Proclamation Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Fri"
   },
   {

--- a/test/fixtures/AU-SA-2026.json
+++ b/test/fixtures/AU-SA-2026.json
@@ -117,12 +117,22 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2026-12-26 00:00:00",
+    "start": "2026-12-25T13:30:00.000Z",
+    "end": "2026-12-26T13:30:00.000Z",
+    "name": "Proclamation Day",
+    "type": "public",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2026-12-28 00:00:00",
     "start": "2026-12-27T13:30:00.000Z",
     "end": "2026-12-28T13:30:00.000Z",
     "name": "Proclamation Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "substitute": true,
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-SA-2027.json
+++ b/test/fixtures/AU-SA-2027.json
@@ -108,6 +108,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2027-12-26 00:00:00",
+    "start": "2027-12-25T13:30:00.000Z",
+    "end": "2027-12-26T13:30:00.000Z",
+    "name": "Proclamation Day",
+    "type": "public",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2027-12-27 00:00:00",
     "start": "2027-12-26T13:30:00.000Z",
     "end": "2027-12-27T13:30:00.000Z",
@@ -122,7 +131,8 @@
     "end": "2027-12-28T13:30:00.000Z",
     "name": "Proclamation Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "substitute": true,
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/AU-SA-2028.json
+++ b/test/fixtures/AU-SA-2028.json
@@ -131,7 +131,7 @@
     "end": "2028-12-26T13:30:00.000Z",
     "name": "Proclamation Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {

--- a/test/fixtures/AU-SA-2029.json
+++ b/test/fixtures/AU-SA-2029.json
@@ -122,7 +122,7 @@
     "end": "2029-12-26T13:30:00.000Z",
     "name": "Proclamation Day",
     "type": "public",
-    "rule": "12-26 if saturday then next monday if sunday then next tuesday",
+    "rule": "12-26 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Wed"
   },
   {


### PR DESCRIPTION
I’m opening this to reflect legislative changes regarding Dec 26 substitute holidays. This is based on the same sources used in the Easter Sunday update. The source link updates themselves are in a separate PR (#590).

Thanks for taking a look.