### PR TITLE
fix(AU): ANZAC Day substitute rule for NSW

### DIFF
--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -100,6 +100,14 @@ holidays:
             substitute: true
             name:
               en: Anzac Day
+            active:
+              - to: "2026-04-25"
+          04-25 and if saturday,sunday then next monday:
+            substitute: true
+            name:
+              en: Anzac Day
+            active:
+              - from: "2026-04-25"
           2nd monday in June:
             name:
               en: Queen's Birthday

--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -90,7 +90,8 @@ holidays:
           1st monday in October:
             name:
               en: Labour Day
-      # @source https://www.legislation.nsw.gov.au/~/pdf/view/act/2010/115/whole
+      # @source https://www.legislation.nsw.gov.au/view/whole/html/inforce/current/act-2010-115
+      # @source https://www.legislation.nsw.gov.au/view/whole/html/inforce/current/sl-2011-0081
       NSW:
         name: New South Wales
         zones:

--- a/test/fixtures/AU-NSW-2026.json
+++ b/test/fixtures/AU-NSW-2026.json
@@ -69,7 +69,7 @@
     "name": "Anzac Day (substitute day)",
     "type": "public",
     "substitute": true,
-    "rule": "04-25 and if saturday then next monday",
+    "rule": "04-25 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/AU-NSW-2027.json
+++ b/test/fixtures/AU-NSW-2027.json
@@ -63,6 +63,16 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2027-04-26 00:00:00",
+    "start": "2027-04-25T14:00:00.000Z",
+    "end": "2027-04-26T14:00:00.000Z",
+    "name": "Anzac Day (substitute day)",
+    "type": "public",
+    "substitute": true,
+    "rule": "04-25 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-05-09 00:00:00",
     "start": "2027-05-08T14:00:00.000Z",
     "end": "2027-05-09T14:00:00.000Z",


### PR DESCRIPTION
Regarding the discussion in #589, I’ve updated the ANZAC Day handling for NSW based on the [Public Holidays Order 2011](https://legislation.nsw.gov.au/view/html/inforce/current/sl-2011-0081), which declares additional public holidays on the following Mondays:

- Monday, 27 April 2026 (since April 25 is a Saturday)
- Monday, 26 April 2027 (since April 25 is a Sunday)

I have implemented this as a general rule rather than year-specific entries. However, since this is based on an Order rather than the Act itself, I’m happy to revert this to specific 2026/2027 entries if you’d prefer a more conservative approach.

Looking forward to your thoughts.