### PR TITLE
(ZM): Fix holiday definitions for October 18 and add Kenneth Kaunda Day

### DIFF
--- a/data/countries/ZM.yaml
+++ b/data/countries/ZM.yaml
@@ -40,9 +40,14 @@ holidays:
       1st monday in August:
         name:
           en: Farmers' Day
-      "2015-10-18":
+      04-28 and if sunday then next monday:
+        substitute: true
         name:
-          en: National day of Prayers
+          en: Kenneth Kaunda Day
+      10-18 and if sunday then next monday:
+        substitute: true
+        name:
+          en: National Day of Prayer, Fasting and Reconciliation
       10-24 and if sunday then next monday:
         substitute: true
         _name: Independence Day

--- a/data/countries/ZM.yaml
+++ b/data/countries/ZM.yaml
@@ -47,7 +47,7 @@ holidays:
       10-18 and if sunday then next monday:
         substitute: true
         name:
-          en: National Day of Prayer, Fasting and Reconciliation
+          en: National Day of Prayers
       10-24 and if sunday then next monday:
         substitute: true
         _name: Independence Day

--- a/test/fixtures/ZM-2015.json
+++ b/test/fixtures/ZM-2015.json
@@ -45,6 +45,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2015-04-28 00:00:00",
+    "start": "2015-04-27T22:00:00.000Z",
+    "end": "2015-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
@@ -93,10 +102,20 @@
     "date": "2015-10-18 00:00:00",
     "start": "2015-10-17T22:00:00.000Z",
     "end": "2015-10-18T22:00:00.000Z",
-    "name": "National day of Prayers",
+    "name": "National Day of Prayers",
     "type": "public",
-    "rule": "2015-10-18",
+    "rule": "10-18 and if sunday then next monday",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2015-10-19 00:00:00",
+    "start": "2015-10-18T22:00:00.000Z",
+    "end": "2015-10-19T22:00:00.000Z",
+    "name": "National Day of Prayers (substitute day)",
+    "type": "public",
+    "substitute": true,
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2015-10-24 00:00:00",

--- a/test/fixtures/ZM-2016.json
+++ b/test/fixtures/ZM-2016.json
@@ -45,6 +45,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-04-28 00:00:00",
+    "start": "2016-04-27T22:00:00.000Z",
+    "end": "2016-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
@@ -98,6 +107,15 @@
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2016-10-18 00:00:00",
+    "start": "2016-10-17T22:00:00.000Z",
+    "end": "2016-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Tue"
   },
   {
     "date": "2016-10-24 00:00:00",

--- a/test/fixtures/ZM-2017.json
+++ b/test/fixtures/ZM-2017.json
@@ -65,6 +65,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2017-04-28 00:00:00",
+    "start": "2017-04-27T22:00:00.000Z",
+    "end": "2017-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
@@ -108,6 +117,15 @@
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2017-10-18 00:00:00",
+    "start": "2017-10-17T22:00:00.000Z",
+    "end": "2017-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-10-24 00:00:00",

--- a/test/fixtures/ZM-2018.json
+++ b/test/fixtures/ZM-2018.json
@@ -45,6 +45,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2018-04-28 00:00:00",
+    "start": "2018-04-27T22:00:00.000Z",
+    "end": "2018-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
@@ -88,6 +97,15 @@
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2018-10-18 00:00:00",
+    "start": "2018-10-17T22:00:00.000Z",
+    "end": "2018-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Thu"
   },
   {
     "date": "2018-10-24 00:00:00",

--- a/test/fixtures/ZM-2019.json
+++ b/test/fixtures/ZM-2019.json
@@ -45,6 +45,25 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-04-28 00:00:00",
+    "start": "2019-04-27T22:00:00.000Z",
+    "end": "2019-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-04-29 00:00:00",
+    "start": "2019-04-28T22:00:00.000Z",
+    "end": "2019-04-29T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day (substitute day)",
+    "type": "public",
+    "substitute": true,
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
@@ -88,6 +107,15 @@
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2019-10-18 00:00:00",
+    "start": "2019-10-17T22:00:00.000Z",
+    "end": "2019-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Fri"
   },
   {
     "date": "2019-10-24 00:00:00",

--- a/test/fixtures/ZM-2020.json
+++ b/test/fixtures/ZM-2020.json
@@ -45,6 +45,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-04-28 00:00:00",
+    "start": "2020-04-27T22:00:00.000Z",
+    "end": "2020-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
@@ -87,6 +96,25 @@
     "name": "Farmers' Day",
     "type": "public",
     "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-18 00:00:00",
+    "start": "2020-10-17T22:00:00.000Z",
+    "end": "2020-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-10-19 00:00:00",
+    "start": "2020-10-18T22:00:00.000Z",
+    "end": "2020-10-19T22:00:00.000Z",
+    "name": "National Day of Prayers (substitute day)",
+    "type": "public",
+    "substitute": true,
+    "rule": "10-18 and if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ZM-2021.json
+++ b/test/fixtures/ZM-2021.json
@@ -45,6 +45,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-04-28 00:00:00",
+    "start": "2021-04-27T22:00:00.000Z",
+    "end": "2021-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
@@ -87,6 +96,15 @@
     "name": "Farmers' Day",
     "type": "public",
     "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-10-18 00:00:00",
+    "start": "2021-10-17T22:00:00.000Z",
+    "end": "2021-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ZM-2022.json
+++ b/test/fixtures/ZM-2022.json
@@ -45,6 +45,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-04-28 00:00:00",
+    "start": "2022-04-27T22:00:00.000Z",
+    "end": "2022-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
@@ -98,6 +107,15 @@
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2022-10-18 00:00:00",
+    "start": "2022-10-17T22:00:00.000Z",
+    "end": "2022-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Tue"
   },
   {
     "date": "2022-10-24 00:00:00",

--- a/test/fixtures/ZM-2023.json
+++ b/test/fixtures/ZM-2023.json
@@ -65,6 +65,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-04-28 00:00:00",
+    "start": "2023-04-27T22:00:00.000Z",
+    "end": "2023-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
@@ -108,6 +117,15 @@
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2023-10-18 00:00:00",
+    "start": "2023-10-17T22:00:00.000Z",
+    "end": "2023-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-10-24 00:00:00",

--- a/test/fixtures/ZM-2024.json
+++ b/test/fixtures/ZM-2024.json
@@ -45,6 +45,25 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-04-28 00:00:00",
+    "start": "2024-04-27T22:00:00.000Z",
+    "end": "2024-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-04-29 00:00:00",
+    "start": "2024-04-28T22:00:00.000Z",
+    "end": "2024-04-29T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day (substitute day)",
+    "type": "public",
+    "substitute": true,
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
@@ -88,6 +107,15 @@
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2024-10-18 00:00:00",
+    "start": "2024-10-17T22:00:00.000Z",
+    "end": "2024-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Fri"
   },
   {
     "date": "2024-10-24 00:00:00",

--- a/test/fixtures/ZM-2025.json
+++ b/test/fixtures/ZM-2025.json
@@ -45,6 +45,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-04-28 00:00:00",
+    "start": "2025-04-27T22:00:00.000Z",
+    "end": "2025-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
@@ -98,6 +107,15 @@
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2025-10-18 00:00:00",
+    "start": "2025-10-17T22:00:00.000Z",
+    "end": "2025-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Sat"
   },
   {
     "date": "2025-10-24 00:00:00",

--- a/test/fixtures/ZM-2026.json
+++ b/test/fixtures/ZM-2026.json
@@ -45,6 +45,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2026-04-28 00:00:00",
+    "start": "2026-04-27T22:00:00.000Z",
+    "end": "2026-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
@@ -87,6 +96,25 @@
     "name": "Farmers' Day",
     "type": "public",
     "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-18 00:00:00",
+    "start": "2026-10-17T22:00:00.000Z",
+    "end": "2026-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-10-19 00:00:00",
+    "start": "2026-10-18T22:00:00.000Z",
+    "end": "2026-10-19T22:00:00.000Z",
+    "name": "National Day of Prayers (substitute day)",
+    "type": "public",
+    "substitute": true,
+    "rule": "10-18 and if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ZM-2027.json
+++ b/test/fixtures/ZM-2027.json
@@ -45,6 +45,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2027-04-28 00:00:00",
+    "start": "2027-04-27T22:00:00.000Z",
+    "end": "2027-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
@@ -87,6 +96,15 @@
     "name": "Farmers' Day",
     "type": "public",
     "rule": "1st monday in August",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-10-18 00:00:00",
+    "start": "2027-10-17T22:00:00.000Z",
+    "end": "2027-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/ZM-2028.json
+++ b/test/fixtures/ZM-2028.json
@@ -55,6 +55,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2028-04-28 00:00:00",
+    "start": "2028-04-27T22:00:00.000Z",
+    "end": "2028-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
@@ -98,6 +107,15 @@
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2028-10-18 00:00:00",
+    "start": "2028-10-17T22:00:00.000Z",
+    "end": "2028-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-10-24 00:00:00",

--- a/test/fixtures/ZM-2029.json
+++ b/test/fixtures/ZM-2029.json
@@ -45,6 +45,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2029-04-28 00:00:00",
+    "start": "2029-04-27T22:00:00.000Z",
+    "end": "2029-04-28T22:00:00.000Z",
+    "name": "Kenneth Kaunda Day",
+    "type": "public",
+    "rule": "04-28 and if sunday then next monday",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
@@ -88,6 +97,15 @@
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2029-10-18 00:00:00",
+    "start": "2029-10-17T22:00:00.000Z",
+    "end": "2029-10-18T22:00:00.000Z",
+    "name": "National Day of Prayers",
+    "type": "public",
+    "rule": "10-18 and if sunday then next monday",
+    "_weekday": "Thu"
   },
   {
     "date": "2029-10-24 00:00:00",


### PR DESCRIPTION
Correct the definition for October 18 as a recurring holiday and introduce Kenneth Kaunda Day on April 28.