### PR TITLE
Convert Florian in Austria from public to observance

### DIFF
--- a/data/countries/AT.yaml
+++ b/data/countries/AT.yaml
@@ -96,6 +96,8 @@ holidays:
           05-04:
             name:
               de-at: Florian
+            type: observance
+            note: Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.
       "5":
         names:
           de: Land Salzburg

--- a/test/fixtures/AT-4-2015.json
+++ b/test/fixtures/AT-4-2015.json
@@ -67,7 +67,8 @@
     "start": "2015-05-03T22:00:00.000Z",
     "end": "2015-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-4-2016.json
+++ b/test/fixtures/AT-4-2016.json
@@ -67,7 +67,8 @@
     "start": "2016-05-03T22:00:00.000Z",
     "end": "2016-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-4-2017.json
+++ b/test/fixtures/AT-4-2017.json
@@ -67,7 +67,8 @@
     "start": "2017-05-03T22:00:00.000Z",
     "end": "2017-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-4-2018.json
+++ b/test/fixtures/AT-4-2018.json
@@ -67,7 +67,8 @@
     "start": "2018-05-03T22:00:00.000Z",
     "end": "2018-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-4-2019.json
+++ b/test/fixtures/AT-4-2019.json
@@ -58,7 +58,8 @@
     "start": "2019-05-03T22:00:00.000Z",
     "end": "2019-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-4-2020.json
+++ b/test/fixtures/AT-4-2020.json
@@ -58,7 +58,8 @@
     "start": "2020-05-03T22:00:00.000Z",
     "end": "2020-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-4-2021.json
+++ b/test/fixtures/AT-4-2021.json
@@ -58,7 +58,8 @@
     "start": "2021-05-03T22:00:00.000Z",
     "end": "2021-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-4-2022.json
+++ b/test/fixtures/AT-4-2022.json
@@ -58,7 +58,8 @@
     "start": "2022-05-03T22:00:00.000Z",
     "end": "2022-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-4-2023.json
+++ b/test/fixtures/AT-4-2023.json
@@ -58,7 +58,8 @@
     "start": "2023-05-03T22:00:00.000Z",
     "end": "2023-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-4-2024.json
+++ b/test/fixtures/AT-4-2024.json
@@ -58,7 +58,8 @@
     "start": "2024-05-03T22:00:00.000Z",
     "end": "2024-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-4-2025.json
+++ b/test/fixtures/AT-4-2025.json
@@ -58,7 +58,8 @@
     "start": "2025-05-03T22:00:00.000Z",
     "end": "2025-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-4-2026.json
+++ b/test/fixtures/AT-4-2026.json
@@ -58,7 +58,8 @@
     "start": "2026-05-03T22:00:00.000Z",
     "end": "2026-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-4-2027.json
+++ b/test/fixtures/AT-4-2027.json
@@ -58,7 +58,8 @@
     "start": "2027-05-03T22:00:00.000Z",
     "end": "2027-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-4-2028.json
+++ b/test/fixtures/AT-4-2028.json
@@ -58,7 +58,8 @@
     "start": "2028-05-03T22:00:00.000Z",
     "end": "2028-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-4-2029.json
+++ b/test/fixtures/AT-4-2029.json
@@ -58,7 +58,8 @@
     "start": "2029-05-03T22:00:00.000Z",
     "end": "2029-05-04T22:00:00.000Z",
     "name": "Florian",
-    "type": "public",
+    "type": "observance",
+    "note": "Da der St. Florian aber in Oberösterreich eine besondere Bedeutung als Patron einhält, gilt er dort als Landesfeiertag und ist offiziell schulfrei. Für Arbeitnehmer:innen gilt er jedoch als normaler Arbeitstag.",
     "rule": "05-04",
     "_weekday": "Fri"
   },


### PR DESCRIPTION
On this day, only schools are closed: https://news.kununu.com/florianitag-feiertag/#:~:text=Da%20der%20St.%20Florian%20aber,er%20jedoch%20als%20normaler%20Arbeitstag.

So the day should be of type observance instead of public.