### PR TITLE
fix(UA): split Easter and Trinity Monday carry-over by period

### DIFF
--- a/data/countries/UA.yaml
+++ b/data/countries/UA.yaml
@@ -28,10 +28,26 @@ holidays:
         substitute: true
       03-08 and if saturday, sunday then next monday:
         _name: 03-08
-      orthodox and if sunday then next monday:
+      orthodox and if sunday then next monday since 1995 and prior to 1998:
         _name: orthodox
-      orthodox 49 and if sunday then next monday:
+        substitute: true
+      orthodox since 1991 and prior to 1995:
+        _name: orthodox
+      orthodox since 1998 and prior to 2000:
+        _name: orthodox
+      orthodox and if sunday then next monday since 2000:
+        _name: orthodox
+        substitute: true
+      orthodox 49 and if sunday then next monday since 1995 and prior to 1998:
         _name: easter 49
+        substitute: true
+      orthodox 49 since 1991 and prior to 1995:
+        _name: easter 49
+      orthodox 49 since 1998 and prior to 2000:
+        _name: easter 49
+      orthodox 49 and if sunday then next monday since 2000:
+        _name: easter 49
+        substitute: true
       05-01 and if saturday, sunday then next tuesday:
         _name: 05-01
         substitute: true

--- a/test/fixtures/UA-2015.json
+++ b/test/fixtures/UA-2015.json
@@ -50,16 +50,17 @@
     "end": "2015-04-12T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2015-04-13 00:00:00",
     "start": "2015-04-12T21:00:00.000Z",
     "end": "2015-04-13T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -115,16 +116,17 @@
     "end": "2015-05-31T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2015-06-01 00:00:00",
     "start": "2015-05-31T21:00:00.000Z",
     "end": "2015-06-01T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2016.json
+++ b/test/fixtures/UA-2016.json
@@ -51,7 +51,7 @@
     "end": "2016-05-01T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
@@ -67,9 +67,10 @@
     "date": "2016-05-02 00:00:00",
     "start": "2016-05-01T21:00:00.000Z",
     "end": "2016-05-02T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -106,16 +107,17 @@
     "end": "2016-06-19T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2016-06-20 00:00:00",
     "start": "2016-06-19T21:00:00.000Z",
     "end": "2016-06-20T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2017.json
+++ b/test/fixtures/UA-2017.json
@@ -61,16 +61,17 @@
     "end": "2017-04-16T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T21:00:00.000Z",
     "end": "2017-04-17T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -106,16 +107,17 @@
     "end": "2017-06-04T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2017-06-05 00:00:00",
     "start": "2017-06-04T21:00:00.000Z",
     "end": "2017-06-05T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2018.json
+++ b/test/fixtures/UA-2018.json
@@ -51,16 +51,17 @@
     "end": "2018-04-08T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2018-04-09 00:00:00",
     "start": "2018-04-08T21:00:00.000Z",
     "end": "2018-04-09T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -87,16 +88,17 @@
     "end": "2018-05-27T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2018-05-28 00:00:00",
     "start": "2018-05-27T21:00:00.000Z",
     "end": "2018-05-28T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2019.json
+++ b/test/fixtures/UA-2019.json
@@ -41,16 +41,17 @@
     "end": "2019-04-28T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2019-04-29 00:00:00",
     "start": "2019-04-28T21:00:00.000Z",
     "end": "2019-04-29T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -77,16 +78,17 @@
     "end": "2019-06-16T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2019-06-17 00:00:00",
     "start": "2019-06-16T21:00:00.000Z",
     "end": "2019-06-17T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2020.json
+++ b/test/fixtures/UA-2020.json
@@ -50,16 +50,17 @@
     "end": "2020-04-19T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2020-04-20 00:00:00",
     "start": "2020-04-19T21:00:00.000Z",
     "end": "2020-04-20T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -96,16 +97,17 @@
     "end": "2020-06-07T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2020-06-08 00:00:00",
     "start": "2020-06-07T21:00:00.000Z",
     "end": "2020-06-08T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2021.json
+++ b/test/fixtures/UA-2021.json
@@ -60,16 +60,17 @@
     "end": "2021-05-02T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2021-05-03 00:00:00",
     "start": "2021-05-02T21:00:00.000Z",
     "end": "2021-05-03T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -107,16 +108,17 @@
     "end": "2021-06-20T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2021-06-21 00:00:00",
     "start": "2021-06-20T21:00:00.000Z",
     "end": "2021-06-21T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2022.json
+++ b/test/fixtures/UA-2022.json
@@ -61,16 +61,17 @@
     "end": "2022-04-24T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T21:00:00.000Z",
     "end": "2022-04-25T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -107,16 +108,17 @@
     "end": "2022-06-12T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2022-06-13 00:00:00",
     "start": "2022-06-12T21:00:00.000Z",
     "end": "2022-06-13T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2023.json
+++ b/test/fixtures/UA-2023.json
@@ -42,16 +42,17 @@
     "end": "2023-04-16T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2023-04-17 00:00:00",
     "start": "2023-04-16T21:00:00.000Z",
     "end": "2023-04-17T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -78,16 +79,17 @@
     "end": "2023-06-04T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2023-06-05 00:00:00",
     "start": "2023-06-04T21:00:00.000Z",
     "end": "2023-06-05T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2024.json
+++ b/test/fixtures/UA-2024.json
@@ -41,16 +41,17 @@
     "end": "2024-05-05T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2024-05-06 00:00:00",
     "start": "2024-05-05T21:00:00.000Z",
     "end": "2024-05-06T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -68,16 +69,17 @@
     "end": "2024-06-23T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2024-06-24 00:00:00",
     "start": "2024-06-23T21:00:00.000Z",
     "end": "2024-06-24T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2025.json
+++ b/test/fixtures/UA-2025.json
@@ -41,16 +41,17 @@
     "end": "2025-04-20T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T21:00:00.000Z",
     "end": "2025-04-21T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -77,16 +78,17 @@
     "end": "2025-06-08T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T21:00:00.000Z",
     "end": "2025-06-09T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2026.json
+++ b/test/fixtures/UA-2026.json
@@ -41,16 +41,17 @@
     "end": "2026-04-12T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2026-04-13 00:00:00",
     "start": "2026-04-12T21:00:00.000Z",
     "end": "2026-04-13T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -87,16 +88,17 @@
     "end": "2026-05-31T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2026-06-01 00:00:00",
     "start": "2026-05-31T21:00:00.000Z",
     "end": "2026-06-01T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2027.json
+++ b/test/fixtures/UA-2027.json
@@ -51,16 +51,17 @@
     "end": "2027-05-02T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2027-05-03 00:00:00",
     "start": "2027-05-02T21:00:00.000Z",
     "end": "2027-05-03T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -98,16 +99,17 @@
     "end": "2027-06-20T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2027-06-21 00:00:00",
     "start": "2027-06-20T21:00:00.000Z",
     "end": "2027-06-21T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2028.json
+++ b/test/fixtures/UA-2028.json
@@ -52,16 +52,17 @@
     "end": "2028-04-16T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T21:00:00.000Z",
     "end": "2028-04-17T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -88,16 +89,17 @@
     "end": "2028-06-04T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2028-06-05 00:00:00",
     "start": "2028-06-04T21:00:00.000Z",
     "end": "2028-06-05T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {

--- a/test/fixtures/UA-2029.json
+++ b/test/fixtures/UA-2029.json
@@ -32,16 +32,17 @@
     "end": "2029-04-08T21:00:00.000Z",
     "name": "Великдень",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2029-04-09 00:00:00",
     "start": "2029-04-08T21:00:00.000Z",
     "end": "2029-04-09T21:00:00.000Z",
-    "name": "Великдень",
+    "name": "Великдень (замінити день)",
     "type": "public",
-    "rule": "orthodox and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {
@@ -68,16 +69,17 @@
     "end": "2029-05-27T21:00:00.000Z",
     "name": "Трійця",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Sun"
   },
   {
     "date": "2029-05-28 00:00:00",
     "start": "2029-05-27T21:00:00.000Z",
     "end": "2029-05-28T21:00:00.000Z",
-    "name": "Трійця",
+    "name": "Трійця (замінити день)",
     "type": "public",
-    "rule": "orthodox 49 and if sunday then next monday",
+    "substitute": true,
+    "rule": "orthodox 49 and if sunday then next monday since 2000",
     "_weekday": "Mon"
   },
   {


### PR DESCRIPTION
Model UA Orthodox holidays with historical ranges:
- 1995-1997: Monday after Easter/Trinity is a non-working substitute day
- 1998-1999: no Monday substitute day
- since 2000: Monday substitute day restored

Source: https://uk.wikipedia.org/wiki/Святкові_і_неробочі_дні_в_Україні