### PR TITLE
feat(JE): add Summer Bank Holiday to Jersey holidays

### DIFF
--- a/data/countries/JE.yaml
+++ b/data/countries/JE.yaml
@@ -12,3 +12,7 @@ holidays:
       05-09:
         name:
           en: Liberation Day
+      # @source https://www.gov.je/leisure/events/whatson/pages/bankholidaydates.aspx
+      1st monday before 09-01:
+        name:
+          en: Summer Bank Holiday

--- a/test/fixtures/JE-2015.json
+++ b/test/fixtures/JE-2015.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2015-08-31 00:00:00",
+    "start": "2015-08-30T23:00:00.000Z",
+    "end": "2015-08-31T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-25T00:00:00.000Z",
     "end": "2015-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2016.json
+++ b/test/fixtures/JE-2016.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2016-08-29 00:00:00",
+    "start": "2016-08-28T23:00:00.000Z",
+    "end": "2016-08-29T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-25T00:00:00.000Z",
     "end": "2016-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2017.json
+++ b/test/fixtures/JE-2017.json
@@ -91,6 +91,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2017-08-28 00:00:00",
+    "start": "2017-08-27T23:00:00.000Z",
+    "end": "2017-08-28T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-25T00:00:00.000Z",
     "end": "2017-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2018.json
+++ b/test/fixtures/JE-2018.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2018-08-27 00:00:00",
+    "start": "2018-08-26T23:00:00.000Z",
+    "end": "2018-08-27T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-25T00:00:00.000Z",
     "end": "2018-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2019.json
+++ b/test/fixtures/JE-2019.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2019-08-26 00:00:00",
+    "start": "2019-08-25T23:00:00.000Z",
+    "end": "2019-08-26T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-25T00:00:00.000Z",
     "end": "2019-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2020.json
+++ b/test/fixtures/JE-2020.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2020-08-31 00:00:00",
+    "start": "2020-08-30T23:00:00.000Z",
+    "end": "2020-08-31T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-25T00:00:00.000Z",
     "end": "2020-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2021.json
+++ b/test/fixtures/JE-2021.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-08-30 00:00:00",
+    "start": "2021-08-29T23:00:00.000Z",
+    "end": "2021-08-30T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-25T00:00:00.000Z",
     "end": "2021-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2022.json
+++ b/test/fixtures/JE-2022.json
@@ -100,6 +100,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2022-08-29 00:00:00",
+    "start": "2022-08-28T23:00:00.000Z",
+    "end": "2022-08-29T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-09-19 00:00:00",
     "start": "2022-09-18T23:00:00.000Z",
     "end": "2022-09-19T23:00:00.000Z",

--- a/test/fixtures/JE-2023.json
+++ b/test/fixtures/JE-2023.json
@@ -100,6 +100,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2023-08-28 00:00:00",
+    "start": "2023-08-27T23:00:00.000Z",
+    "end": "2023-08-28T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-25T00:00:00.000Z",
     "end": "2023-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2024.json
+++ b/test/fixtures/JE-2024.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2024-08-26 00:00:00",
+    "start": "2024-08-25T23:00:00.000Z",
+    "end": "2024-08-26T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-25T00:00:00.000Z",
     "end": "2024-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2025.json
+++ b/test/fixtures/JE-2025.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2025-08-25 00:00:00",
+    "start": "2025-08-24T23:00:00.000Z",
+    "end": "2025-08-25T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-25T00:00:00.000Z",
     "end": "2025-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2026.json
+++ b/test/fixtures/JE-2026.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2026-08-31 00:00:00",
+    "start": "2026-08-30T23:00:00.000Z",
+    "end": "2026-08-31T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-25T00:00:00.000Z",
     "end": "2026-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2027.json
+++ b/test/fixtures/JE-2027.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2027-08-30 00:00:00",
+    "start": "2027-08-29T23:00:00.000Z",
+    "end": "2027-08-30T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-25T00:00:00.000Z",
     "end": "2027-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2028.json
+++ b/test/fixtures/JE-2028.json
@@ -91,6 +91,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2028-08-28 00:00:00",
+    "start": "2028-08-27T23:00:00.000Z",
+    "end": "2028-08-28T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-25T00:00:00.000Z",
     "end": "2028-12-26T00:00:00.000Z",

--- a/test/fixtures/JE-2029.json
+++ b/test/fixtures/JE-2029.json
@@ -81,6 +81,15 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2029-08-27 00:00:00",
+    "start": "2029-08-26T23:00:00.000Z",
+    "end": "2029-08-27T23:00:00.000Z",
+    "name": "Summer Bank Holiday",
+    "type": "public",
+    "rule": "1st monday before 09-01",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-25T00:00:00.000Z",
     "end": "2029-12-26T00:00:00.000Z",


### PR DESCRIPTION
Source: https://www.gov.je/leisure/events/whatson/pages/bankholidaydates.aspx


By the way: I might be submitting more PRs. I'm planning to replace the manually maintained public holidays in [opening_hours.js](https://github.com/opening-hours/opening_hours.js/) with yours. To prepare that, I'm currently comparing the data sets and trying to resolve any inconsistencies I notice.