### PR TITLE
build: mark date-holidays-parser as external

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,5 +1,6 @@
 export default {
   input: './src/index.js',
+  external: ['date-holidays-parser'],
   output: {
     dir: 'lib',
     format: 'cjs',


### PR DESCRIPTION
`date-holidays-parser` is loaded at runtime and shouldn't be bundled. The `external` config tells rollup explicitly to leave it out.

**No behavior change** - the package was already loaded at runtime. This just removes the unresolved dependency warning during build.

**Before**

```
$ node --run build

> date-holidays@3.28.0 yaml
> node scripts/holidays2json.cjs


> date-holidays@3.28.0 build:only
> rollup -c


./src/index.js → lib...
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
date-holidays-parser (imported by src/Holidays.js)
created lib in 132ms
```

**After**

```
$ node --run build

> date-holidays@3.28.0 yaml
> node scripts/holidays2json.cjs


> date-holidays@3.28.0 build:only
> rollup -c


./src/index.js → lib...
created lib in 131ms
```