### PR TITLE
review(AR): update holidays against official sources

### DIFF
--- a/data/countries/AR.yaml
+++ b/data/countries/AR.yaml
@@ -316,6 +316,23 @@ holidays:
         name:
           en: National Holiday for the World Football Champions in the FIFA World Cup QATAR 2022
           es: Feriado Nacional de los Campeones Mundiales de Fútbol en la Copa Mundial de la FIFA CATAR 2022
+      # 2026 non-working days for tourism purposes
+      # @source https://www.argentina.gob.ar/normativa/nacional/resoluci%C3%B3n-164-2025-421799
+      "2026-03-23":
+        name:
+          en: Tourism Purposes Non-Working Day
+          es: Día no laborable con fines turísticos
+        type: optional
+      "2026-07-10":
+        name:
+          en: Tourism Purposes Non-Working Day
+          es: Día no laborable con fines turísticos
+        type: optional
+      "2026-12-07":
+        name:
+          en: Tourism Purposes Non-Working Day
+          es: Día no laborable con fines turísticos
+        type: optional
       # National Census
       # @source https://www.argentina.gob.ar/normativa/nacional/ley-22307-202349
       "1980-10-22":

--- a/data/countries/AR.yaml
+++ b/data/countries/AR.yaml
@@ -109,11 +109,11 @@ holidays:
           - from: "1988-05-18"
             to: "2000-12-15"
       # introduced in 2016
-      # @source https://www.argentina.gob.ar/normativa/nacional/ley-27258-262574/texto
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-27258-262574
       06-17 if tuesday,wednesday then previous monday if thursday then next monday:
         name:
           en: Anniversary of the Passing to Immortality of General Martín Miguel de Güemes
-          es: Día Paso a la Inmortalidad del General Martín Miguel de Güemes
+          es: Paso a la Inmortalidad del General Don Martín Miguel de Güemes
         active:
           - from: "2016-06-11"
       # Introduced in 1938

--- a/data/countries/AR.yaml
+++ b/data/countries/AR.yaml
@@ -86,8 +86,8 @@ holidays:
         _name: 05-01
       05-25:
         name:
-          en: Day of the First National Government
-          es: Primer Gobierno Patrio
+          en: Day of the May Revolution
+          es: Día de la Revolución de Mayo
       # Holiday moved from 04-02 in 1984
       # @source https://www.argentina.gob.ar/normativa/nacional/decreto-901-1984-65455
       06-10:

--- a/data/countries/AR.yaml
+++ b/data/countries/AR.yaml
@@ -109,7 +109,7 @@ holidays:
             to: "2000-12-15"
       # introduced in 2016
       # @source https://www.argentina.gob.ar/normativa/nacional/ley-27258-262574
-      06-17 if tuesday,wednesday then previous monday if thursday then next monday:
+      06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday:
         name:
           en: Anniversary of the Passing to Immortality of General Martín Miguel de Güemes
           es: Paso a la Inmortalidad del General Don Martín Miguel de Güemes

--- a/data/countries/AR.yaml
+++ b/data/countries/AR.yaml
@@ -1,7 +1,6 @@
 holidays:
-  # @source http://www.mininterior.gov.ar/tramitesyservicios/feriados.php
-  # @source https://www.argentina.gob.ar/interior/feriados-nacionales-2021
-  # @source https://www.argentina.gob.ar/interior/feriados-nacionales-2022
+  # @source https://www.argentina.gob.ar/feriados
+  # @source https://www.argentina.gob.ar/jefatura/feriados-nacionales-2026
   AR:
     names:
       es: Argentina

--- a/data/countries/AR.yaml
+++ b/data/countries/AR.yaml
@@ -285,7 +285,9 @@ holidays:
       # Introduced in 1995
       # @source https://www.argentina.gob.ar/normativa/nacional/ley-24445-782/texto
       12-08:
-        _name: 12-08
+        name:
+          en: Immaculate Conception of Mary
+          es: Inmaculada Concepción de María
         active:
           - from: "1995-01-11"
       "12-24 12:00":

--- a/data/countries/AR.yaml
+++ b/data/countries/AR.yaml
@@ -120,9 +120,14 @@ holidays:
       # @source https://www.argentina.gob.ar/normativa/nacional/ley-12361-232587/texto
       # Made fixed (non-movable) in 1991
       # @source https://www.argentina.gob.ar/normativa/nacional/ley-24023-422/texto
+      # Holiday name changed in 1995
+      # Note: the norm does not explicitly say "renamed"; this is inferred from
+      # the wording shift between Ley 12.361 ("Día de la Bandera") and
+      # Ley 24.445 Art. 4 ("paso a la inmortalidad del General Manuel Belgrano").
+      # @source https://www.argentina.gob.ar/normativa/nacional/ley-24445-782/texto
       # Became fixed again in 2010
       # @source https://www.argentina.gob.ar/normativa/nacional/decreto-1584-2010-174389/texto
-      06-20:
+      "06-20 #1":
         name:
           en: National Flag Day
           es: Día de la Bandera
@@ -131,6 +136,12 @@ holidays:
             to: "1988-05-23"
           - from: "1991-12-18"
             to: "1995-01-10"
+      "06-20 #2":
+        name:
+          en: Anniversary of the Passing to Immortality of General Manuel Belgrano
+          es: Paso a la Inmortalidad del General D. Manuel Belgrano
+        active:
+          # Fixed-date form resumes in 2010; name change itself is modeled from 1995.
           - from: "2010-11-03"
       # Made movable in 1988
       # @source https://biblioteca.afip.gob.ar/dcp/LEY_C_023555_1988_04_28
@@ -145,8 +156,8 @@ holidays:
       # @source https://www.argentina.gob.ar/normativa/nacional/ley-24445-782/texto
       3rd monday in June:
         name:
-          en: National Flag Day
-          es: Día de la Bandera
+          en: Anniversary of the Passing to Immortality of General Manuel Belgrano
+          es: Paso a la Inmortalidad del General D. Manuel Belgrano
         active:
           - from: "1995-01-11"
             to: "2010-11-02"

--- a/test/fixtures/AR-2015.json
+++ b/test/fixtures/AR-2015.json
@@ -84,7 +84,7 @@
     "date": "2015-05-25 00:00:00",
     "start": "2015-05-25T03:00:00.000Z",
     "end": "2015-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Mon"
@@ -93,9 +93,9 @@
     "date": "2015-06-20 00:00:00",
     "start": "2015-06-20T03:00:00.000Z",
     "end": "2015-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Sat"
   },
   {
@@ -147,7 +147,7 @@
     "date": "2015-12-08 00:00:00",
     "start": "2015-12-08T03:00:00.000Z",
     "end": "2015-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Tue"

--- a/test/fixtures/AR-2016.json
+++ b/test/fixtures/AR-2016.json
@@ -75,27 +75,27 @@
     "date": "2016-05-25 00:00:00",
     "start": "2016-05-25T03:00:00.000Z",
     "end": "2016-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Wed"
   },
   {
-    "date": "2016-06-17 00:00:00",
-    "start": "2016-06-17T03:00:00.000Z",
-    "end": "2016-06-18T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "date": "2016-06-20 00:00:00",
+    "start": "2016-06-20T03:00:00.000Z",
+    "end": "2016-06-21T03:00:00.000Z",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
-    "_weekday": "Fri"
+    "rule": "06-20 #2",
+    "_weekday": "Mon"
   },
   {
     "date": "2016-06-20 00:00:00",
     "start": "2016-06-20T03:00:00.000Z",
     "end": "2016-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -147,7 +147,7 @@
     "date": "2016-12-08 00:00:00",
     "start": "2016-12-08T03:00:00.000Z",
     "end": "2016-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Thu"

--- a/test/fixtures/AR-2017.json
+++ b/test/fixtures/AR-2017.json
@@ -75,7 +75,7 @@
     "date": "2017-05-25 00:00:00",
     "start": "2017-05-25T03:00:00.000Z",
     "end": "2017-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Thu"
@@ -84,18 +84,18 @@
     "date": "2017-06-17 00:00:00",
     "start": "2017-06-17T03:00:00.000Z",
     "end": "2017-06-18T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Sat"
   },
   {
     "date": "2017-06-20 00:00:00",
     "start": "2017-06-20T03:00:00.000Z",
     "end": "2017-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Tue"
   },
   {
@@ -138,7 +138,7 @@
     "date": "2017-12-08 00:00:00",
     "start": "2017-12-08T03:00:00.000Z",
     "end": "2017-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Fri"

--- a/test/fixtures/AR-2018.json
+++ b/test/fixtures/AR-2018.json
@@ -84,7 +84,7 @@
     "date": "2018-05-25 00:00:00",
     "start": "2018-05-25T03:00:00.000Z",
     "end": "2018-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Fri"
@@ -93,18 +93,18 @@
     "date": "2018-06-17 00:00:00",
     "start": "2018-06-17T03:00:00.000Z",
     "end": "2018-06-18T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Sun"
   },
   {
     "date": "2018-06-20 00:00:00",
     "start": "2018-06-20T03:00:00.000Z",
     "end": "2018-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Wed"
   },
   {
@@ -147,7 +147,7 @@
     "date": "2018-12-08 00:00:00",
     "start": "2018-12-08T03:00:00.000Z",
     "end": "2018-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sat"

--- a/test/fixtures/AR-2019.json
+++ b/test/fixtures/AR-2019.json
@@ -75,7 +75,7 @@
     "date": "2019-05-25 00:00:00",
     "start": "2019-05-25T03:00:00.000Z",
     "end": "2019-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Sat"
@@ -84,18 +84,18 @@
     "date": "2019-06-17 00:00:00",
     "start": "2019-06-17T03:00:00.000Z",
     "end": "2019-06-18T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
     "date": "2019-06-20 00:00:00",
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Thu"
   },
   {
@@ -165,7 +165,7 @@
     "date": "2019-12-08 00:00:00",
     "start": "2019-12-08T03:00:00.000Z",
     "end": "2019-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sun"

--- a/test/fixtures/AR-2020.json
+++ b/test/fixtures/AR-2020.json
@@ -84,7 +84,7 @@
     "date": "2020-05-25 00:00:00",
     "start": "2020-05-25T03:00:00.000Z",
     "end": "2020-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Mon"
@@ -93,18 +93,18 @@
     "date": "2020-06-15 00:00:00",
     "start": "2020-06-15T03:00:00.000Z",
     "end": "2020-06-16T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
     "date": "2020-06-20 00:00:00",
     "start": "2020-06-20T03:00:00.000Z",
     "end": "2020-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Sat"
   },
   {
@@ -165,7 +165,7 @@
     "date": "2020-12-08 00:00:00",
     "start": "2020-12-08T03:00:00.000Z",
     "end": "2020-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Tue"

--- a/test/fixtures/AR-2021.json
+++ b/test/fixtures/AR-2021.json
@@ -84,7 +84,7 @@
     "date": "2021-05-25 00:00:00",
     "start": "2021-05-25T03:00:00.000Z",
     "end": "2021-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Tue"
@@ -93,18 +93,18 @@
     "date": "2021-06-20 00:00:00",
     "start": "2021-06-20T03:00:00.000Z",
     "end": "2021-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Sun"
   },
   {
     "date": "2021-06-21 00:00:00",
     "start": "2021-06-21T03:00:00.000Z",
     "end": "2021-06-22T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -165,7 +165,7 @@
     "date": "2021-12-08 00:00:00",
     "start": "2021-12-08T03:00:00.000Z",
     "end": "2021-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Wed"

--- a/test/fixtures/AR-2022.json
+++ b/test/fixtures/AR-2022.json
@@ -84,27 +84,27 @@
     "date": "2022-05-25 00:00:00",
     "start": "2022-05-25T03:00:00.000Z",
     "end": "2022-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Wed"
   },
   {
-    "date": "2022-06-17 00:00:00",
-    "start": "2022-06-17T03:00:00.000Z",
-    "end": "2022-06-18T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "date": "2022-06-20 00:00:00",
+    "start": "2022-06-20T03:00:00.000Z",
+    "end": "2022-06-21T03:00:00.000Z",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
-    "_weekday": "Fri"
+    "rule": "06-20 #2",
+    "_weekday": "Mon"
   },
   {
     "date": "2022-06-20 00:00:00",
     "start": "2022-06-20T03:00:00.000Z",
     "end": "2022-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -165,7 +165,7 @@
     "date": "2022-12-08 00:00:00",
     "start": "2022-12-08T03:00:00.000Z",
     "end": "2022-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Thu"

--- a/test/fixtures/AR-2023.json
+++ b/test/fixtures/AR-2023.json
@@ -75,7 +75,7 @@
     "date": "2023-05-25 00:00:00",
     "start": "2023-05-25T03:00:00.000Z",
     "end": "2023-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Thu"
@@ -93,9 +93,9 @@
     "date": "2023-06-17 00:00:00",
     "start": "2023-06-17T03:00:00.000Z",
     "end": "2023-06-18T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Sat"
   },
   {
@@ -111,9 +111,9 @@
     "date": "2023-06-20 00:00:00",
     "start": "2023-06-20T03:00:00.000Z",
     "end": "2023-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Tue"
   },
   {
@@ -165,7 +165,7 @@
     "date": "2023-12-08 00:00:00",
     "start": "2023-12-08T03:00:00.000Z",
     "end": "2023-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Fri"

--- a/test/fixtures/AR-2024.json
+++ b/test/fixtures/AR-2024.json
@@ -84,7 +84,7 @@
     "date": "2024-05-25 00:00:00",
     "start": "2024-05-25T03:00:00.000Z",
     "end": "2024-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Sat"
@@ -93,18 +93,18 @@
     "date": "2024-06-17 00:00:00",
     "start": "2024-06-17T03:00:00.000Z",
     "end": "2024-06-18T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
     "date": "2024-06-20 00:00:00",
     "start": "2024-06-20T03:00:00.000Z",
     "end": "2024-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Thu"
   },
   {
@@ -165,7 +165,7 @@
     "date": "2024-12-08 00:00:00",
     "start": "2024-12-08T03:00:00.000Z",
     "end": "2024-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sun"

--- a/test/fixtures/AR-2025.json
+++ b/test/fixtures/AR-2025.json
@@ -84,7 +84,7 @@
     "date": "2025-05-25 00:00:00",
     "start": "2025-05-25T03:00:00.000Z",
     "end": "2025-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Sun"
@@ -93,18 +93,18 @@
     "date": "2025-06-16 00:00:00",
     "start": "2025-06-16T03:00:00.000Z",
     "end": "2025-06-17T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
     "date": "2025-06-20 00:00:00",
     "start": "2025-06-20T03:00:00.000Z",
     "end": "2025-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Fri"
   },
   {
@@ -165,7 +165,7 @@
     "date": "2025-12-08 00:00:00",
     "start": "2025-12-08T03:00:00.000Z",
     "end": "2025-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Mon"

--- a/test/fixtures/AR-2026.json
+++ b/test/fixtures/AR-2026.json
@@ -27,6 +27,15 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2026-03-23 00:00:00",
+    "start": "2026-03-23T03:00:00.000Z",
+    "end": "2026-03-24T03:00:00.000Z",
+    "name": "Día no laborable con fines turísticos",
+    "type": "optional",
+    "rule": "2026-03-23",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-03-24 00:00:00",
     "start": "2026-03-24T03:00:00.000Z",
     "end": "2026-03-25T03:00:00.000Z",
@@ -75,7 +84,7 @@
     "date": "2026-05-25 00:00:00",
     "start": "2026-05-25T03:00:00.000Z",
     "end": "2026-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Mon"
@@ -84,18 +93,18 @@
     "date": "2026-06-15 00:00:00",
     "start": "2026-06-15T03:00:00.000Z",
     "end": "2026-06-16T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
     "date": "2026-06-20 00:00:00",
     "start": "2026-06-20T03:00:00.000Z",
     "end": "2026-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Sat"
   },
   {
@@ -106,6 +115,15 @@
     "type": "public",
     "rule": "07-09",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2026-07-10 00:00:00",
+    "start": "2026-07-10T03:00:00.000Z",
+    "end": "2026-07-11T03:00:00.000Z",
+    "name": "Día no laborable con fines turísticos",
+    "type": "optional",
+    "rule": "2026-07-10",
+    "_weekday": "Fri"
   },
   {
     "date": "2026-08-17 00:00:00",
@@ -135,10 +153,19 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2026-12-07 00:00:00",
+    "start": "2026-12-07T03:00:00.000Z",
+    "end": "2026-12-08T03:00:00.000Z",
+    "name": "Día no laborable con fines turísticos",
+    "type": "optional",
+    "rule": "2026-12-07",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-12-08 00:00:00",
     "start": "2026-12-08T03:00:00.000Z",
     "end": "2026-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Tue"

--- a/test/fixtures/AR-2027.json
+++ b/test/fixtures/AR-2027.json
@@ -75,7 +75,7 @@
     "date": "2027-05-25 00:00:00",
     "start": "2027-05-25T03:00:00.000Z",
     "end": "2027-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Tue"
@@ -84,18 +84,18 @@
     "date": "2027-06-20 00:00:00",
     "start": "2027-06-20T03:00:00.000Z",
     "end": "2027-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Sun"
   },
   {
     "date": "2027-06-21 00:00:00",
     "start": "2027-06-21T03:00:00.000Z",
     "end": "2027-06-22T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -138,7 +138,7 @@
     "date": "2027-12-08 00:00:00",
     "start": "2027-12-08T03:00:00.000Z",
     "end": "2027-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Wed"

--- a/test/fixtures/AR-2028.json
+++ b/test/fixtures/AR-2028.json
@@ -75,7 +75,7 @@
     "date": "2028-05-25 00:00:00",
     "start": "2028-05-25T03:00:00.000Z",
     "end": "2028-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Thu"
@@ -84,18 +84,18 @@
     "date": "2028-06-17 00:00:00",
     "start": "2028-06-17T03:00:00.000Z",
     "end": "2028-06-18T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Sat"
   },
   {
     "date": "2028-06-20 00:00:00",
     "start": "2028-06-20T03:00:00.000Z",
     "end": "2028-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Tue"
   },
   {
@@ -138,7 +138,7 @@
     "date": "2028-12-08 00:00:00",
     "start": "2028-12-08T03:00:00.000Z",
     "end": "2028-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Fri"

--- a/test/fixtures/AR-2029.json
+++ b/test/fixtures/AR-2029.json
@@ -75,7 +75,7 @@
     "date": "2029-05-25 00:00:00",
     "start": "2029-05-25T03:00:00.000Z",
     "end": "2029-05-26T03:00:00.000Z",
-    "name": "Primer Gobierno Patrio",
+    "name": "Día de la Revolución de Mayo",
     "type": "public",
     "rule": "05-25",
     "_weekday": "Fri"
@@ -84,18 +84,18 @@
     "date": "2029-06-17 00:00:00",
     "start": "2029-06-17T03:00:00.000Z",
     "end": "2029-06-18T03:00:00.000Z",
-    "name": "Día Paso a la Inmortalidad del General Martín Miguel de Güemes",
+    "name": "Paso a la Inmortalidad del General Don Martín Miguel de Güemes",
     "type": "public",
-    "rule": "06-17 if tuesday,wednesday then previous monday if thursday then next monday",
+    "rule": "06-17 if tuesday,wednesday then previous monday if thursday,friday then next monday",
     "_weekday": "Sun"
   },
   {
     "date": "2029-06-20 00:00:00",
     "start": "2029-06-20T03:00:00.000Z",
     "end": "2029-06-21T03:00:00.000Z",
-    "name": "Día de la Bandera",
+    "name": "Paso a la Inmortalidad del General D. Manuel Belgrano",
     "type": "public",
-    "rule": "06-20",
+    "rule": "06-20 #2",
     "_weekday": "Wed"
   },
   {
@@ -138,7 +138,7 @@
     "date": "2029-12-08 00:00:00",
     "start": "2029-12-08T03:00:00.000Z",
     "end": "2029-12-09T03:00:00.000Z",
-    "name": "La inmaculada concepción",
+    "name": "Inmaculada Concepción de María",
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sat"


### PR DESCRIPTION
While comparing the [holiday data in opening_hours.js](https://github.com/opening-hours/opening_hours.js/blob/main/src/holidays/ar.yaml) and `date-holidays` for Argentina, I noticed a few differences. I checked them against official sources and updated the data accordingly in this PR.

See commit messages for more details.