### PR TITLE
fix(BE): use Belgian holiday names and update sources

### DIFF
--- a/data/countries/BE.yaml
+++ b/data/countries/BE.yaml
@@ -1,5 +1,7 @@
 holidays:
-  # @attrib https://de.m.wikipedia.org/wiki/Feiertage_in_Belgien
+  # @source https://www.emploi.belgique.be/fr/themes/international/detachement/conditions-de-travail-respecter-en-cas-de-detachement-en-2
+  # @source https://www.werk.belgie.be/nl/themas/internationaal/detachering/na-te-leven-arbeidsvoorwaarden-geval-van-detachering-naar-3
+  # @attrib https://nl.wikipedia.org/wiki/Feestdagen_in_Belgi%C3%AB
   # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Belgium
   BE:
     names:
@@ -29,23 +31,35 @@ holidays:
         _name: easter
         type: observance
       easter 1:
-        _name: easter 1
+        name:
+          fr: Lundi de Pâques
+          nl: Paasmaandag
+          de: Ostermontag
       05-01:
         _name: 05-01
       2nd sunday in May:
         _name: Mothers Day
         type: observance
       easter 39:
-        _name: easter 39
+        name:
+          nl: Hemelvaartsdag
+          fr: Ascension
+          de: Christi Himmelfahrt
       easter 49:
         _name: easter 49
         type: observance
       easter 50:
-        _name: easter 50
+        name:
+          fr: Lundi de Pentecôte
+          nl: Pinkstermaandag
+          de: Pfingstmontag
       07-21:
         _name: National Holiday
       08-15:
-        _name: 08-15
+        name:
+          fr: Assomption
+          nl: Tenhemelopneming
+          de: Mariä Himmelfahrt
       11-01:
         _name: 11-01
       11-02:

--- a/test/fixtures/BE-VLG-2015.json
+++ b/test/fixtures/BE-VLG-2015.json
@@ -39,7 +39,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-05T22:00:00.000Z",
     "end": "2015-04-06T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2015-05-14 00:00:00",
     "start": "2015-05-13T22:00:00.000Z",
     "end": "2015-05-14T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2015-05-25 00:00:00",
     "start": "2015-05-24T22:00:00.000Z",
     "end": "2015-05-25T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"

--- a/test/fixtures/BE-VLG-2016.json
+++ b/test/fixtures/BE-VLG-2016.json
@@ -39,7 +39,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-27T22:00:00.000Z",
     "end": "2016-03-28T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2016-05-05 00:00:00",
     "start": "2016-05-04T22:00:00.000Z",
     "end": "2016-05-05T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2016-05-16 00:00:00",
     "start": "2016-05-15T22:00:00.000Z",
     "end": "2016-05-16T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"

--- a/test/fixtures/BE-VLG-2017.json
+++ b/test/fixtures/BE-VLG-2017.json
@@ -39,7 +39,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T22:00:00.000Z",
     "end": "2017-04-17T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2017-05-25 00:00:00",
     "start": "2017-05-24T22:00:00.000Z",
     "end": "2017-05-25T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2017-06-05 00:00:00",
     "start": "2017-06-04T22:00:00.000Z",
     "end": "2017-06-05T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"

--- a/test/fixtures/BE-VLG-2018.json
+++ b/test/fixtures/BE-VLG-2018.json
@@ -39,7 +39,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-01T22:00:00.000Z",
     "end": "2018-04-02T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2018-05-10 00:00:00",
     "start": "2018-05-09T22:00:00.000Z",
     "end": "2018-05-10T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2018-05-21 00:00:00",
     "start": "2018-05-20T22:00:00.000Z",
     "end": "2018-05-21T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"

--- a/test/fixtures/BE-VLG-2019.json
+++ b/test/fixtures/BE-VLG-2019.json
@@ -39,7 +39,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-21T22:00:00.000Z",
     "end": "2019-04-22T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2019-05-30 00:00:00",
     "start": "2019-05-29T22:00:00.000Z",
     "end": "2019-05-30T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2019-06-10 00:00:00",
     "start": "2019-06-09T22:00:00.000Z",
     "end": "2019-06-10T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"

--- a/test/fixtures/BE-VLG-2020.json
+++ b/test/fixtures/BE-VLG-2020.json
@@ -39,7 +39,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-12T22:00:00.000Z",
     "end": "2020-04-13T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2020-05-21 00:00:00",
     "start": "2020-05-20T22:00:00.000Z",
     "end": "2020-05-21T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2020-06-01 00:00:00",
     "start": "2020-05-31T22:00:00.000Z",
     "end": "2020-06-01T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"

--- a/test/fixtures/BE-VLG-2021.json
+++ b/test/fixtures/BE-VLG-2021.json
@@ -39,7 +39,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-04T22:00:00.000Z",
     "end": "2021-04-05T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2021-05-13 00:00:00",
     "start": "2021-05-12T22:00:00.000Z",
     "end": "2021-05-13T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2021-05-24 00:00:00",
     "start": "2021-05-23T22:00:00.000Z",
     "end": "2021-05-24T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"

--- a/test/fixtures/BE-VLG-2022.json
+++ b/test/fixtures/BE-VLG-2022.json
@@ -39,7 +39,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-17T22:00:00.000Z",
     "end": "2022-04-18T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2022-05-26 00:00:00",
     "start": "2022-05-25T22:00:00.000Z",
     "end": "2022-05-26T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2022-06-06 00:00:00",
     "start": "2022-06-05T22:00:00.000Z",
     "end": "2022-06-06T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"

--- a/test/fixtures/BE-VLG-2023.json
+++ b/test/fixtures/BE-VLG-2023.json
@@ -39,7 +39,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-09T22:00:00.000Z",
     "end": "2023-04-10T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2023-05-18 00:00:00",
     "start": "2023-05-17T22:00:00.000Z",
     "end": "2023-05-18T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2023-05-29 00:00:00",
     "start": "2023-05-28T22:00:00.000Z",
     "end": "2023-05-29T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"

--- a/test/fixtures/BE-VLG-2024.json
+++ b/test/fixtures/BE-VLG-2024.json
@@ -39,7 +39,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-03-31T22:00:00.000Z",
     "end": "2024-04-01T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2024-05-09 00:00:00",
     "start": "2024-05-08T22:00:00.000Z",
     "end": "2024-05-09T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2024-05-20 00:00:00",
     "start": "2024-05-19T22:00:00.000Z",
     "end": "2024-05-20T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"

--- a/test/fixtures/BE-VLG-2025.json
+++ b/test/fixtures/BE-VLG-2025.json
@@ -39,7 +39,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T22:00:00.000Z",
     "end": "2025-04-21T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2025-05-29 00:00:00",
     "start": "2025-05-28T22:00:00.000Z",
     "end": "2025-05-29T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T22:00:00.000Z",
     "end": "2025-06-09T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"

--- a/test/fixtures/BE-VLG-2026.json
+++ b/test/fixtures/BE-VLG-2026.json
@@ -39,7 +39,7 @@
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-05T22:00:00.000Z",
     "end": "2026-04-06T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2026-05-14 00:00:00",
     "start": "2026-05-13T22:00:00.000Z",
     "end": "2026-05-14T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2026-05-25 00:00:00",
     "start": "2026-05-24T22:00:00.000Z",
     "end": "2026-05-25T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"

--- a/test/fixtures/BE-VLG-2027.json
+++ b/test/fixtures/BE-VLG-2027.json
@@ -39,7 +39,7 @@
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-28T22:00:00.000Z",
     "end": "2027-03-29T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2027-05-06 00:00:00",
     "start": "2027-05-05T22:00:00.000Z",
     "end": "2027-05-06T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2027-05-17 00:00:00",
     "start": "2027-05-16T22:00:00.000Z",
     "end": "2027-05-17T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"

--- a/test/fixtures/BE-VLG-2028.json
+++ b/test/fixtures/BE-VLG-2028.json
@@ -39,7 +39,7 @@
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T22:00:00.000Z",
     "end": "2028-04-17T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2028-05-25 00:00:00",
     "start": "2028-05-24T22:00:00.000Z",
     "end": "2028-05-25T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2028-06-05 00:00:00",
     "start": "2028-06-04T22:00:00.000Z",
     "end": "2028-06-05T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"

--- a/test/fixtures/BE-VLG-2029.json
+++ b/test/fixtures/BE-VLG-2029.json
@@ -39,7 +39,7 @@
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-01T22:00:00.000Z",
     "end": "2029-04-02T22:00:00.000Z",
-    "name": "Tweede paasdag",
+    "name": "Paasmaandag",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2029-05-10 00:00:00",
     "start": "2029-05-09T22:00:00.000Z",
     "end": "2029-05-10T22:00:00.000Z",
-    "name": "O.L.H. Hemelvaart",
+    "name": "Hemelvaartsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2029-05-21 00:00:00",
     "start": "2029-05-20T22:00:00.000Z",
     "end": "2029-05-21T22:00:00.000Z",
-    "name": "Tweede pinksterdag",
+    "name": "Pinkstermaandag",
     "type": "public",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "O.L.V. Hemelvaart",
+    "name": "Tenhemelopneming",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"


### PR DESCRIPTION
Belgian Dutch uses different terms than generic Dutch, like Paasmaandag instead of Tweede paasdag.