### PR TITLE
chore: husky setup modernization

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install commitlint --edit "$1"

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no-install commitlint --edit "$1"
+commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-# npm run yaml
-# npm test
+npm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 # npm run yaml
 # npm test

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,1 +1,21 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }
+module.exports = {
+	extends: ['@commitlint/config-conventional'],
+	rules: {
+		'type-enum': [
+			2,
+			'always',
+			[
+				'break',
+				'feat',
+				'fix',
+				'chore',
+				'docs',
+				'refactor',
+				'revert',
+				'test'
+			]
+		],
+		'subject-case': [2, 'never', ['start-case', 'pascal-case']],
+		'scope-case': [0]
+	}
+}

--- a/package.json
+++ b/package.json
@@ -221,38 +221,6 @@
     "yaml": "node scripts/holidays2json.cjs",
     "prepare": "husky"
   },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ],
-    "rules": {
-      "type-enum": [
-        2,
-        "always",
-        [
-          "break",
-          "feat",
-          "fix",
-          "chore",
-          "docs",
-          "refactor",
-          "revert",
-          "test"
-        ]
-      ],
-      "subject-case": [
-        2,
-        "never",
-        [
-          "start-case",
-          "pascal-case"
-        ]
-      ],
-      "scope-case": [
-        0
-      ]
-    }
-  },
   "browserslist": [
     "> 1%",
     "last 2 versions",

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "webpack": "webpack",
     "webpack:analyze": "webpack",
     "yaml": "node scripts/holidays2json.cjs",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
Noticed a deprecation warning when committing, so I had a look at the setup and cleaned a few things up.

- Updated `prepare` script to use the modern `husky` command
- Consolidated commitlint config in one place (was split between `package.json` and `.commitlint.config.cjs`)
- Simplified the commit-msg hook (removed unnecessary `npx --no-install`)
- Activated pre-commit hook to run lint before commits

Only the last change actually affects the workflow (lint check). The rest is just getting ahead of v10 deprecations.

----

The mentioned warning

```bash
$ git commit --amend --no-edit
husky - DEPRECATED

Please remove the following two lines from .husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```