### PR TITLE
chore: replace mobile Wikipedia URLs with universal ones

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -33,11 +33,11 @@ CC BY-SA 3.0 Attributions
 
 https://cs.wikipedia.org/wiki/St%C3%A1tn%C3%AD_sv%C3%A1tky_Slovenska
 https://da.wikipedia.org/wiki/Danske_helligdage
-https://de.m.wikipedia.org/wiki/Feiertage_in_%C3%96sterreich
-https://de.m.wikipedia.org/wiki/Feiertage_in_Deutschland
-https://de.m.wikipedia.org/wiki/Feiertage_in_Italien
-https://de.m.wikipedia.org/wiki/Feiertage_in_der_Schweiz
-https://de.m.wikipedia.org/wiki/Kanada#Feiertage
+https://de.wikipedia.org/wiki/Feiertage_in_%C3%96sterreich
+https://de.wikipedia.org/wiki/Feiertage_in_Deutschland
+https://de.wikipedia.org/wiki/Feiertage_in_Italien
+https://de.wikipedia.org/wiki/Feiertage_in_der_Schweiz
+https://de.wikipedia.org/wiki/Kanada#Feiertage
 https://de.wikipedia.org/wiki/Feiertage_in_Island
 https://de.wikipedia.org/wiki/Feiertage_in_Liechtenstein#Gesetzliche_Feiertage
 https://de.wikipedia.org/wiki/Feiertage_in_Polen
@@ -173,7 +173,7 @@ https://en.wikipedia.org/wiki/Suriname#National_holidays
 https://en.wikipedia.org/wiki/Vesak
 https://en.wikipedia.org/wiki/Vesak#Dates_of_observance
 https://en.wikipedia.org/wiki/Washington%27s_Birthday
-https://es.m.wikipedia.org/wiki/Calendario_laboral
+https://es.wikipedia.org/wiki/Calendario_laboral
 https://es.wikipedia.org/wiki/Anexo:Dís_festivos_en_Colombia
 https://es.wikipedia.org/wiki/Anexo:Festividades_y_celebraciones#Panam.C3.A1
 https://es.wikipedia.org/wiki/Guinea_Ecuatorial
@@ -224,7 +224,7 @@ https://pt.wikipedia.org/wiki/Feriados_no_Brasil
 https://pt.wikipedia.org/wiki/Mo%C3%A7ambique#Feriados
 https://ro.wikipedia.org/wiki/Republica_Moldova
 https://ro.wikipedia.org/wiki/Ziua_vinului_(Republica_Moldova)
-https://ru.m.wikipedia.org/wiki/%D0%9F%D1%80%D0%B0%D0%B7%D0%B4%D0%BD%D0%B8%D0%BA%D0%B8_%D0%A0%D0%BE%D1%81%D1%81%D0%B8%D0%B8
+https://ru.wikipedia.org/wiki/%D0%9F%D1%80%D0%B0%D0%B7%D0%B4%D0%BD%D0%B8%D0%BA%D0%B8_%D0%A0%D0%BE%D1%81%D1%81%D0%B8%D0%B8
 https://sv.wikipedia.org/wiki/Helgdagar_i_Sverige
 https://sv.wikipedia.org/wiki/Sveriges_nationaldag#Svenska_flaggans_dag
 https://ur.wikipedia.org/wiki/%D8%AA%D8%B9%D8%B7%DB%8C%D9%84%D8%A7%D8%AA_%D9%BE%D8%A7%DA%A9%D8%B3%D8%AA%D8%A7%D9%86

--- a/data/countries/0.yaml
+++ b/data/countries/0.yaml
@@ -3,7 +3,7 @@
 # @license CC-BY-SA-3
 #
 # For country codes check:
-# <https://en.m.wikipedia.org/wiki/List_of_Internet_top-level_domains#Country_code_top-level_domains>
+# <https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#Country_code_top-level_domains>
 #
 # For country codes / divisions / subdivisions - ISO 3166-2:
 # <http://www.unicode.org/cldr/charts/30/supplemental/territory_subdivisions.html>

--- a/data/countries/AT.yaml
+++ b/data/countries/AT.yaml
@@ -1,5 +1,5 @@
 holidays:
-  # @attrib https://de.m.wikipedia.org/wiki/Feiertage_in_%C3%96sterreich
+  # @attrib https://de.wikipedia.org/wiki/Feiertage_in_%C3%96sterreich
   AT:
     names:
       de-at: Österreich

--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -1,5 +1,5 @@
 holidays:
-  # @attrib https://de.m.wikipedia.org/wiki/Kanada#Feiertage
+  # @attrib https://de.wikipedia.org/wiki/Kanada#Feiertage
   # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Canada
   # @source http://manpages.ubuntu.com/manpages/wily/man3/DateTime::TimeZone::Catalog.3pm.html
   # @source https://educaloi.qc.ca/en/capsules/public-holidays/

--- a/data/countries/CH.yaml
+++ b/data/countries/CH.yaml
@@ -3,7 +3,7 @@ holidays:
   # @source https://www.ch.ch/de/ferien-und-feiertage/
   # @source https://www.ejpd.admin.ch/dam/data/bj/publiservice/service/zivilprozessrecht/kant-feiertage.pdf
   # @attrib https://fr.wikipedia.org/wiki/Jours_f%C3%A9ri%C3%A9s_en_Suisse
-  # @attrib https://de.m.wikipedia.org/wiki/Feiertage_in_der_Schweiz
+  # @attrib https://de.wikipedia.org/wiki/Feiertage_in_der_Schweiz
   # @source https://fr.wikipedia.org/wiki/Berchtoldstag
   CH:
     names:

--- a/data/countries/DE.yaml
+++ b/data/countries/DE.yaml
@@ -1,4 +1,4 @@
-# @attrib https://de.m.wikipedia.org/wiki/Feiertage_in_Deutschland
+# @attrib https://de.wikipedia.org/wiki/Feiertage_in_Deutschland
 holidays:
   DE:
     names:

--- a/data/countries/ES.yaml
+++ b/data/countries/ES.yaml
@@ -1,5 +1,5 @@
 holidays:
-  # @attrib https://es.m.wikipedia.org/wiki/Calendario_laboral
+  # @attrib https://es.wikipedia.org/wiki/Calendario_laboral
   # @source https://www.boe.es/boe/dias/2018/10/20/pdfs/BOE-A-2018-14369.pdf (2019)
   # @source https://www.boe.es/boe/dias/2019/10/11/pdfs/BOE-A-2019-14552.pdf (2020)
   # @source https://www.boe.es/boe/dias/2020/11/02/pdfs/BOE-A-2020-13343.pdf (2021)

--- a/data/countries/IT.yaml
+++ b/data/countries/IT.yaml
@@ -1,5 +1,5 @@
 holidays:
-  # @attrib https://de.m.wikipedia.org/wiki/Feiertage_in_Italien
+  # @attrib https://de.wikipedia.org/wiki/Feiertage_in_Italien
   # @source https://www.quirinale.it/elementi/141022
   IT:
     names:

--- a/data/countries/RU.yaml
+++ b/data/countries/RU.yaml
@@ -1,6 +1,6 @@
 holidays:
   # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Russia
-  # @attrib https://ru.m.wikipedia.org/wiki/%D0%9F%D1%80%D0%B0%D0%B7%D0%B4%D0%BD%D0%B8%D0%BA%D0%B8_%D0%A0%D0%BE%D1%81%D1%81%D0%B8%D0%B8
+  # @attrib https://ru.wikipedia.org/wiki/%D0%9F%D1%80%D0%B0%D0%B7%D0%B4%D0%BD%D0%B8%D0%BA%D0%B8_%D0%A0%D0%BE%D1%81%D1%81%D0%B8%D0%B8
   # @source http://government.ru/docs/43282/
   RU:
     names:

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -105,7 +105,7 @@ holidays:
 - `<region_code_?>` is a short code representing the region (any ascii based string)
 
 For country codes check: <br>  
-<https://en.m.wikipedia.org/wiki/List_of_Internet_top-level_domains#Country_code_top-level_domains>
+<https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#Country_code_top-level_domains>
 
 For country codes / divisions / subdivisions - ISO 3166-2: <br>
 <http://www.unicode.org/cldr/charts/30/supplemental/territory_subdivisions.html>


### PR DESCRIPTION
Maybe I'm missing something, but I can't see any reason why mobile URLs should be used for some countries and for others not.