### PR TITLE
[Colombia] Add entry for Monday after 07-09 in CO.yaml

### DIFF
--- a/data/countries/CO.yaml
+++ b/data/countries/CO.yaml
@@ -37,6 +37,8 @@ holidays:
           en: Sacred Heart
       monday after 06-29:
         _name: 06-29
+      monday after 07-09:
+        _name: 07-09
       07-20:
         _name: Independence Day
       08-07:


### PR DESCRIPTION
On June 1st, as per law 2578 of 2026. The government has declared a new holiday in honor to "La virgen de Chiquinquirá" (Virgin of Chiquinquirá) and is mandatory in all the country.

Sources:

[Official Goverment Law](https://lector.ramajudicial.gov.co/SIDN/NORMATIVA/TEXTOS_COMPLETOS/7_LEYES/LEYES%202026/Ley%202578%20de%202026.pdf)

[Portafolio newspaper](https://www.portafolio.co/economia/gobierno/se-nos-aparecio-la-virgen-colombia-tendra-nuevo-festivo-nacional-el-9-de-julio-en-honor-a-chiquinquira-495500)

[El tiempo newspaper](https://www.eltiempo.com/politica/gobierno/colombia-tendra-nuevo-festivo-en-julio-por-dia-de-la-virgen-de-chiquinquira-esto-dice-la-ley-que-sanciono-el-gobierno-3562087)

[El País newspaper](https://elpais.com/america-colombia/2026-06-04/colombia-declara-festivo-el-9-de-julio-en-homenaje-a-la-virgen-de-chiquinquira.html)

[Semana magazine](https://www.semana.com/nacion/articulo/desde-cuando-se-aplicara-el-nuevo-festivo-del-dia-de-la-virgen-de-chiquinquira-en-colombia/202631/)