### PR TITLE
feat(BR): add bank holidays for Carnival and Corpus Christi

### DIFF
--- a/data/countries/BR.yaml
+++ b/data/countries/BR.yaml
@@ -32,7 +32,27 @@ holidays:
         name:
           pt: Dia de Tiradentes
           en: Tiradentes' Day
-      easter -50 PT110H:
+      easter -50 PT48H:
+        name:
+          pt: Carnaval
+          en: Carnival
+        type: optional
+      # Carnival Monday & Tuesday — national bank holidays (banks closed) per
+      # Resolução CMN nº 4.880, art. 6. Modeled as two separate days because
+      # Carnival Tuesday is also a state public holiday in Rio de Janeiro
+      # (states.RJ, easter -47), which overrides this national entry.
+      # @source https://www.bcb.gov.br/estabilidadefinanceira/exibenormativo?tipo=Resolu%C3%A7%C3%A3o%20CMN&numero=4880
+      easter -48:
+        name:
+          pt: Carnaval
+          en: Carnival
+        type: bank
+      easter -47:
+        name:
+          pt: Carnaval
+          en: Carnival
+        type: bank
+      easter -46 PT14H:
         name:
           pt: Carnaval
           en: Carnival
@@ -47,9 +67,10 @@ holidays:
       2nd sunday in May:
         _name: Mothers Day
         type: observance
+      # @source https://www.bcb.gov.br/estabilidadefinanceira/exibenormativo?tipo=Resolu%C3%A7%C3%A3o%20CMN&numero=4880
       easter 60:
         _name: easter 60
-        type: optional
+        type: bank
       06-12:
         name:
           pt: Dia dos Namorados

--- a/test/fixtures/BR-2015.json
+++ b/test/fixtures/BR-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
     "end": "2015-02-18T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2016.json
+++ b/test/fixtures/BR-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
     "end": "2016-02-10T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2017.json
+++ b/test/fixtures/BR-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2018.json
+++ b/test/fixtures/BR-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
     "end": "2018-02-14T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2019.json
+++ b/test/fixtures/BR-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2020.json
+++ b/test/fixtures/BR-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2021.json
+++ b/test/fixtures/BR-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2022.json
+++ b/test/fixtures/BR-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2023.json
+++ b/test/fixtures/BR-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2024.json
+++ b/test/fixtures/BR-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2025.json
+++ b/test/fixtures/BR-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2026.json
+++ b/test/fixtures/BR-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2027.json
+++ b/test/fixtures/BR-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2028.json
+++ b/test/fixtures/BR-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-2029.json
+++ b/test/fixtures/BR-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2015.json
+++ b/test/fixtures/BR-AC-2015.json
@@ -20,11 +20,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T05:00:00.000Z",
+    "end": "2015-02-16T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T05:00:00.000Z",
+    "end": "2015-02-17T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T05:00:00.000Z",
+    "end": "2015-02-18T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T05:00:00.000Z",
     "end": "2015-02-18T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-03-08 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2015-06-04T05:00:00.000Z",
     "end": "2015-06-05T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2016.json
+++ b/test/fixtures/BR-AC-2016.json
@@ -20,11 +20,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T05:00:00.000Z",
+    "end": "2016-02-08T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T05:00:00.000Z",
+    "end": "2016-02-09T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T05:00:00.000Z",
+    "end": "2016-02-10T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T05:00:00.000Z",
     "end": "2016-02-10T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-08 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2016-05-26T05:00:00.000Z",
     "end": "2016-05-27T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2017.json
+++ b/test/fixtures/BR-AC-2017.json
@@ -20,11 +20,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T05:00:00.000Z",
+    "end": "2017-02-27T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T05:00:00.000Z",
+    "end": "2017-02-28T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T05:00:00.000Z",
+    "end": "2017-03-01T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T05:00:00.000Z",
     "end": "2017-03-01T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-03-08 00:00:00",
@@ -103,7 +130,7 @@
     "start": "2017-06-15T05:00:00.000Z",
     "end": "2017-06-16T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2018.json
+++ b/test/fixtures/BR-AC-2018.json
@@ -20,11 +20,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T05:00:00.000Z",
+    "end": "2018-02-12T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T05:00:00.000Z",
+    "end": "2018-02-13T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T05:00:00.000Z",
+    "end": "2018-02-14T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T05:00:00.000Z",
     "end": "2018-02-14T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-08 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2018-05-31T05:00:00.000Z",
     "end": "2018-06-01T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2019.json
+++ b/test/fixtures/BR-AC-2019.json
@@ -20,11 +20,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T05:00:00.000Z",
+    "end": "2019-03-04T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T05:00:00.000Z",
+    "end": "2019-03-05T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T05:00:00.000Z",
+    "end": "2019-03-06T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T05:00:00.000Z",
     "end": "2019-03-06T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-03-08 00:00:00",
@@ -103,7 +130,7 @@
     "start": "2019-06-20T05:00:00.000Z",
     "end": "2019-06-21T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2020.json
+++ b/test/fixtures/BR-AC-2020.json
@@ -20,11 +20,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T05:00:00.000Z",
+    "end": "2020-02-24T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T05:00:00.000Z",
+    "end": "2020-02-25T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T05:00:00.000Z",
+    "end": "2020-02-26T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T05:00:00.000Z",
     "end": "2020-02-26T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-03-08 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2020-06-11T05:00:00.000Z",
     "end": "2020-06-12T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2021.json
+++ b/test/fixtures/BR-AC-2021.json
@@ -20,11 +20,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T05:00:00.000Z",
+    "end": "2021-02-15T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T05:00:00.000Z",
+    "end": "2021-02-16T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T05:00:00.000Z",
+    "end": "2021-02-17T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T05:00:00.000Z",
     "end": "2021-02-17T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-03-08 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2021-06-03T05:00:00.000Z",
     "end": "2021-06-04T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2022.json
+++ b/test/fixtures/BR-AC-2022.json
@@ -20,11 +20,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T05:00:00.000Z",
+    "end": "2022-02-28T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T05:00:00.000Z",
+    "end": "2022-03-01T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T05:00:00.000Z",
+    "end": "2022-03-02T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T05:00:00.000Z",
     "end": "2022-03-02T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-03-08 00:00:00",
@@ -103,7 +130,7 @@
     "start": "2022-06-16T05:00:00.000Z",
     "end": "2022-06-17T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2023.json
+++ b/test/fixtures/BR-AC-2023.json
@@ -20,11 +20,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T05:00:00.000Z",
+    "end": "2023-02-20T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T05:00:00.000Z",
+    "end": "2023-02-21T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T05:00:00.000Z",
+    "end": "2023-02-22T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T05:00:00.000Z",
     "end": "2023-02-22T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-03-08 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2023-06-08T05:00:00.000Z",
     "end": "2023-06-09T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2024.json
+++ b/test/fixtures/BR-AC-2024.json
@@ -20,11 +20,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T05:00:00.000Z",
+    "end": "2024-02-12T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T05:00:00.000Z",
+    "end": "2024-02-13T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T05:00:00.000Z",
+    "end": "2024-02-14T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T05:00:00.000Z",
     "end": "2024-02-14T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-08 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2024-05-30T05:00:00.000Z",
     "end": "2024-05-31T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2025.json
+++ b/test/fixtures/BR-AC-2025.json
@@ -20,11 +20,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T05:00:00.000Z",
+    "end": "2025-03-03T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T05:00:00.000Z",
+    "end": "2025-03-04T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T05:00:00.000Z",
+    "end": "2025-03-05T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T05:00:00.000Z",
     "end": "2025-03-05T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-03-08 00:00:00",
@@ -103,7 +130,7 @@
     "start": "2025-06-19T05:00:00.000Z",
     "end": "2025-06-20T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2026.json
+++ b/test/fixtures/BR-AC-2026.json
@@ -20,11 +20,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T05:00:00.000Z",
+    "end": "2026-02-16T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T05:00:00.000Z",
+    "end": "2026-02-17T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T05:00:00.000Z",
+    "end": "2026-02-18T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T05:00:00.000Z",
     "end": "2026-02-18T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-03-08 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2026-06-04T05:00:00.000Z",
     "end": "2026-06-05T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2027.json
+++ b/test/fixtures/BR-AC-2027.json
@@ -20,11 +20,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T05:00:00.000Z",
+    "end": "2027-02-08T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T05:00:00.000Z",
+    "end": "2027-02-09T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T05:00:00.000Z",
+    "end": "2027-02-10T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T05:00:00.000Z",
     "end": "2027-02-10T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-08 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2027-05-27T05:00:00.000Z",
     "end": "2027-05-28T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2028.json
+++ b/test/fixtures/BR-AC-2028.json
@@ -20,11 +20,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T05:00:00.000Z",
+    "end": "2028-02-28T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T05:00:00.000Z",
+    "end": "2028-02-29T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T05:00:00.000Z",
+    "end": "2028-03-01T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T05:00:00.000Z",
     "end": "2028-03-01T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-03-08 00:00:00",
@@ -103,7 +130,7 @@
     "start": "2028-06-15T05:00:00.000Z",
     "end": "2028-06-16T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AC-2029.json
+++ b/test/fixtures/BR-AC-2029.json
@@ -20,11 +20,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T05:00:00.000Z",
+    "end": "2029-02-12T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T05:00:00.000Z",
+    "end": "2029-02-13T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T05:00:00.000Z",
+    "end": "2029-02-14T05:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T05:00:00.000Z",
     "end": "2029-02-14T19:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-08 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2029-05-31T05:00:00.000Z",
     "end": "2029-06-01T05:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2015.json
+++ b/test/fixtures/BR-AL-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2016.json
+++ b/test/fixtures/BR-AL-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2017.json
+++ b/test/fixtures/BR-AL-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2018.json
+++ b/test/fixtures/BR-AL-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2019.json
+++ b/test/fixtures/BR-AL-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2020.json
+++ b/test/fixtures/BR-AL-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2021.json
+++ b/test/fixtures/BR-AL-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2022.json
+++ b/test/fixtures/BR-AL-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2023.json
+++ b/test/fixtures/BR-AL-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2024.json
+++ b/test/fixtures/BR-AL-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2025.json
+++ b/test/fixtures/BR-AL-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2026.json
+++ b/test/fixtures/BR-AL-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2027.json
+++ b/test/fixtures/BR-AL-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2028.json
+++ b/test/fixtures/BR-AL-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AL-2029.json
+++ b/test/fixtures/BR-AL-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2015.json
+++ b/test/fixtures/BR-AM-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T04:00:00.000Z",
+    "end": "2015-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T04:00:00.000Z",
     "end": "2015-02-18T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T04:00:00.000Z",
     "end": "2015-06-05T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2016.json
+++ b/test/fixtures/BR-AM-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T04:00:00.000Z",
+    "end": "2016-02-08T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T04:00:00.000Z",
     "end": "2016-02-10T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T04:00:00.000Z",
     "end": "2016-05-27T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2017.json
+++ b/test/fixtures/BR-AM-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T04:00:00.000Z",
+    "end": "2017-02-27T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T04:00:00.000Z",
     "end": "2017-03-01T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T04:00:00.000Z",
     "end": "2017-06-16T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2018.json
+++ b/test/fixtures/BR-AM-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T04:00:00.000Z",
+    "end": "2018-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T04:00:00.000Z",
     "end": "2018-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T04:00:00.000Z",
     "end": "2018-06-01T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2019.json
+++ b/test/fixtures/BR-AM-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T04:00:00.000Z",
+    "end": "2019-03-04T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T04:00:00.000Z",
     "end": "2019-03-06T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T04:00:00.000Z",
     "end": "2019-06-21T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2020.json
+++ b/test/fixtures/BR-AM-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T04:00:00.000Z",
+    "end": "2020-02-24T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T04:00:00.000Z",
     "end": "2020-02-26T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T04:00:00.000Z",
     "end": "2020-06-12T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2021.json
+++ b/test/fixtures/BR-AM-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T04:00:00.000Z",
+    "end": "2021-02-15T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T04:00:00.000Z",
     "end": "2021-02-17T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T04:00:00.000Z",
     "end": "2021-06-04T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2022.json
+++ b/test/fixtures/BR-AM-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T04:00:00.000Z",
+    "end": "2022-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T04:00:00.000Z",
     "end": "2022-03-02T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T04:00:00.000Z",
     "end": "2022-06-17T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2023.json
+++ b/test/fixtures/BR-AM-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T04:00:00.000Z",
+    "end": "2023-02-20T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T04:00:00.000Z",
     "end": "2023-02-22T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T04:00:00.000Z",
     "end": "2023-06-09T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2024.json
+++ b/test/fixtures/BR-AM-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T04:00:00.000Z",
+    "end": "2024-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T04:00:00.000Z",
     "end": "2024-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T04:00:00.000Z",
     "end": "2024-05-31T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2025.json
+++ b/test/fixtures/BR-AM-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T04:00:00.000Z",
+    "end": "2025-03-03T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T04:00:00.000Z",
     "end": "2025-03-05T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T04:00:00.000Z",
     "end": "2025-06-20T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2026.json
+++ b/test/fixtures/BR-AM-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T04:00:00.000Z",
+    "end": "2026-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T04:00:00.000Z",
     "end": "2026-02-18T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T04:00:00.000Z",
     "end": "2026-06-05T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2027.json
+++ b/test/fixtures/BR-AM-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T04:00:00.000Z",
+    "end": "2027-02-08T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T04:00:00.000Z",
     "end": "2027-02-10T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T04:00:00.000Z",
     "end": "2027-05-28T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2028.json
+++ b/test/fixtures/BR-AM-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T04:00:00.000Z",
+    "end": "2028-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T04:00:00.000Z",
+    "end": "2028-02-29T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T04:00:00.000Z",
+    "end": "2028-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T04:00:00.000Z",
     "end": "2028-03-01T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T04:00:00.000Z",
     "end": "2028-06-16T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AM-2029.json
+++ b/test/fixtures/BR-AM-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T04:00:00.000Z",
+    "end": "2029-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T04:00:00.000Z",
+    "end": "2029-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T04:00:00.000Z",
+    "end": "2029-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T04:00:00.000Z",
     "end": "2029-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T04:00:00.000Z",
     "end": "2029-06-01T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2015.json
+++ b/test/fixtures/BR-AP-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-03-19 00:00:00",
@@ -77,7 +104,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2016.json
+++ b/test/fixtures/BR-AP-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-19 00:00:00",
@@ -77,7 +104,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2017.json
+++ b/test/fixtures/BR-AP-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-03-19 00:00:00",
@@ -86,7 +113,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2018.json
+++ b/test/fixtures/BR-AP-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-19 00:00:00",
@@ -77,7 +104,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2019.json
+++ b/test/fixtures/BR-AP-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-03-19 00:00:00",
@@ -86,7 +113,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2020.json
+++ b/test/fixtures/BR-AP-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-03-19 00:00:00",
@@ -77,7 +104,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2021.json
+++ b/test/fixtures/BR-AP-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-03-19 00:00:00",
@@ -77,7 +104,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2022.json
+++ b/test/fixtures/BR-AP-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-03-19 00:00:00",
@@ -86,7 +113,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2023.json
+++ b/test/fixtures/BR-AP-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-03-19 00:00:00",
@@ -77,7 +104,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2024.json
+++ b/test/fixtures/BR-AP-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-19 00:00:00",
@@ -77,7 +104,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2025.json
+++ b/test/fixtures/BR-AP-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-03-19 00:00:00",
@@ -86,7 +113,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2026.json
+++ b/test/fixtures/BR-AP-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-03-19 00:00:00",
@@ -77,7 +104,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2027.json
+++ b/test/fixtures/BR-AP-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-19 00:00:00",
@@ -77,7 +104,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2028.json
+++ b/test/fixtures/BR-AP-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-03-19 00:00:00",
@@ -86,7 +113,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-AP-2029.json
+++ b/test/fixtures/BR-AP-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-19 00:00:00",
@@ -77,7 +104,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2015.json
+++ b/test/fixtures/BR-BA-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2016.json
+++ b/test/fixtures/BR-BA-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2017.json
+++ b/test/fixtures/BR-BA-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2018.json
+++ b/test/fixtures/BR-BA-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2019.json
+++ b/test/fixtures/BR-BA-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2020.json
+++ b/test/fixtures/BR-BA-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2021.json
+++ b/test/fixtures/BR-BA-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2022.json
+++ b/test/fixtures/BR-BA-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2023.json
+++ b/test/fixtures/BR-BA-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2024.json
+++ b/test/fixtures/BR-BA-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2025.json
+++ b/test/fixtures/BR-BA-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2026.json
+++ b/test/fixtures/BR-BA-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2027.json
+++ b/test/fixtures/BR-BA-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2028.json
+++ b/test/fixtures/BR-BA-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-BA-2029.json
+++ b/test/fixtures/BR-BA-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2015.json
+++ b/test/fixtures/BR-CE-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2016.json
+++ b/test/fixtures/BR-CE-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2017.json
+++ b/test/fixtures/BR-CE-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-03-25 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2018.json
+++ b/test/fixtures/BR-CE-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2019.json
+++ b/test/fixtures/BR-CE-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-03-25 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2020.json
+++ b/test/fixtures/BR-CE-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2021.json
+++ b/test/fixtures/BR-CE-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2022.json
+++ b/test/fixtures/BR-CE-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-03-25 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2023.json
+++ b/test/fixtures/BR-CE-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2024.json
+++ b/test/fixtures/BR-CE-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2025.json
+++ b/test/fixtures/BR-CE-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-03-25 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2026.json
+++ b/test/fixtures/BR-CE-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2027.json
+++ b/test/fixtures/BR-CE-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2028.json
+++ b/test/fixtures/BR-CE-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-03-25 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-CE-2029.json
+++ b/test/fixtures/BR-CE-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2015.json
+++ b/test/fixtures/BR-DF-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
     "end": "2015-02-18T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2016.json
+++ b/test/fixtures/BR-DF-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
     "end": "2016-02-10T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2017.json
+++ b/test/fixtures/BR-DF-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2018.json
+++ b/test/fixtures/BR-DF-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
     "end": "2018-02-14T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2019.json
+++ b/test/fixtures/BR-DF-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2020.json
+++ b/test/fixtures/BR-DF-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2021.json
+++ b/test/fixtures/BR-DF-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2022.json
+++ b/test/fixtures/BR-DF-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2023.json
+++ b/test/fixtures/BR-DF-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2024.json
+++ b/test/fixtures/BR-DF-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2025.json
+++ b/test/fixtures/BR-DF-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2026.json
+++ b/test/fixtures/BR-DF-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2027.json
+++ b/test/fixtures/BR-DF-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2028.json
+++ b/test/fixtures/BR-DF-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-DF-2029.json
+++ b/test/fixtures/BR-DF-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2015.json
+++ b/test/fixtures/BR-MA-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2016.json
+++ b/test/fixtures/BR-MA-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2017.json
+++ b/test/fixtures/BR-MA-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2018.json
+++ b/test/fixtures/BR-MA-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2019.json
+++ b/test/fixtures/BR-MA-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2020.json
+++ b/test/fixtures/BR-MA-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2021.json
+++ b/test/fixtures/BR-MA-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2022.json
+++ b/test/fixtures/BR-MA-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2023.json
+++ b/test/fixtures/BR-MA-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2024.json
+++ b/test/fixtures/BR-MA-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2025.json
+++ b/test/fixtures/BR-MA-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2026.json
+++ b/test/fixtures/BR-MA-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2027.json
+++ b/test/fixtures/BR-MA-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2028.json
+++ b/test/fixtures/BR-MA-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MA-2029.json
+++ b/test/fixtures/BR-MA-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2015.json
+++ b/test/fixtures/BR-MG-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
     "end": "2015-02-18T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2016.json
+++ b/test/fixtures/BR-MG-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
     "end": "2016-02-10T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2017.json
+++ b/test/fixtures/BR-MG-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2018.json
+++ b/test/fixtures/BR-MG-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
     "end": "2018-02-14T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2019.json
+++ b/test/fixtures/BR-MG-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2020.json
+++ b/test/fixtures/BR-MG-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2021.json
+++ b/test/fixtures/BR-MG-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2022.json
+++ b/test/fixtures/BR-MG-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2023.json
+++ b/test/fixtures/BR-MG-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2024.json
+++ b/test/fixtures/BR-MG-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2025.json
+++ b/test/fixtures/BR-MG-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2026.json
+++ b/test/fixtures/BR-MG-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2027.json
+++ b/test/fixtures/BR-MG-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2028.json
+++ b/test/fixtures/BR-MG-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-2029.json
+++ b/test/fixtures/BR-MG-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2015.json
+++ b/test/fixtures/BR-MG-BH-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
     "end": "2015-02-18T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2016.json
+++ b/test/fixtures/BR-MG-BH-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
     "end": "2016-02-10T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2017.json
+++ b/test/fixtures/BR-MG-BH-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2018.json
+++ b/test/fixtures/BR-MG-BH-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
     "end": "2018-02-14T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2019.json
+++ b/test/fixtures/BR-MG-BH-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2020.json
+++ b/test/fixtures/BR-MG-BH-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2021.json
+++ b/test/fixtures/BR-MG-BH-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2022.json
+++ b/test/fixtures/BR-MG-BH-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2023.json
+++ b/test/fixtures/BR-MG-BH-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2024.json
+++ b/test/fixtures/BR-MG-BH-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2025.json
+++ b/test/fixtures/BR-MG-BH-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2026.json
+++ b/test/fixtures/BR-MG-BH-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2027.json
+++ b/test/fixtures/BR-MG-BH-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2028.json
+++ b/test/fixtures/BR-MG-BH-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MG-BH-2029.json
+++ b/test/fixtures/BR-MG-BH-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2015.json
+++ b/test/fixtures/BR-MS-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T04:00:00.000Z",
     "end": "2015-06-05T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2016.json
+++ b/test/fixtures/BR-MS-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T04:00:00.000Z",
     "end": "2016-05-27T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2017.json
+++ b/test/fixtures/BR-MS-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T04:00:00.000Z",
+    "end": "2017-02-27T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T04:00:00.000Z",
     "end": "2017-03-01T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T04:00:00.000Z",
     "end": "2017-06-16T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2018.json
+++ b/test/fixtures/BR-MS-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T04:00:00.000Z",
     "end": "2018-06-01T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2019.json
+++ b/test/fixtures/BR-MS-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T04:00:00.000Z",
+    "end": "2019-03-04T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T04:00:00.000Z",
     "end": "2019-03-06T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T04:00:00.000Z",
     "end": "2019-06-21T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2020.json
+++ b/test/fixtures/BR-MS-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T04:00:00.000Z",
+    "end": "2020-02-24T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T04:00:00.000Z",
     "end": "2020-02-26T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T04:00:00.000Z",
     "end": "2020-06-12T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2021.json
+++ b/test/fixtures/BR-MS-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T04:00:00.000Z",
+    "end": "2021-02-15T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T04:00:00.000Z",
     "end": "2021-02-17T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T04:00:00.000Z",
     "end": "2021-06-04T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2022.json
+++ b/test/fixtures/BR-MS-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T04:00:00.000Z",
+    "end": "2022-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T04:00:00.000Z",
     "end": "2022-03-02T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T04:00:00.000Z",
     "end": "2022-06-17T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2023.json
+++ b/test/fixtures/BR-MS-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T04:00:00.000Z",
+    "end": "2023-02-20T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T04:00:00.000Z",
     "end": "2023-02-22T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T04:00:00.000Z",
     "end": "2023-06-09T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2024.json
+++ b/test/fixtures/BR-MS-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T04:00:00.000Z",
+    "end": "2024-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T04:00:00.000Z",
     "end": "2024-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T04:00:00.000Z",
     "end": "2024-05-31T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2025.json
+++ b/test/fixtures/BR-MS-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T04:00:00.000Z",
+    "end": "2025-03-03T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T04:00:00.000Z",
     "end": "2025-03-05T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T04:00:00.000Z",
     "end": "2025-06-20T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2026.json
+++ b/test/fixtures/BR-MS-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T04:00:00.000Z",
+    "end": "2026-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T04:00:00.000Z",
     "end": "2026-02-18T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T04:00:00.000Z",
     "end": "2026-06-05T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2027.json
+++ b/test/fixtures/BR-MS-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T04:00:00.000Z",
+    "end": "2027-02-08T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T04:00:00.000Z",
     "end": "2027-02-10T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T04:00:00.000Z",
     "end": "2027-05-28T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2028.json
+++ b/test/fixtures/BR-MS-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T04:00:00.000Z",
+    "end": "2028-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T04:00:00.000Z",
+    "end": "2028-02-29T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T04:00:00.000Z",
+    "end": "2028-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T04:00:00.000Z",
     "end": "2028-03-01T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T04:00:00.000Z",
     "end": "2028-06-16T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MS-2029.json
+++ b/test/fixtures/BR-MS-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T04:00:00.000Z",
+    "end": "2029-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T04:00:00.000Z",
+    "end": "2029-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T04:00:00.000Z",
+    "end": "2029-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T04:00:00.000Z",
     "end": "2029-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T04:00:00.000Z",
     "end": "2029-06-01T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2015.json
+++ b/test/fixtures/BR-MT-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T04:00:00.000Z",
     "end": "2015-06-05T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2016.json
+++ b/test/fixtures/BR-MT-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T04:00:00.000Z",
     "end": "2016-05-27T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2017.json
+++ b/test/fixtures/BR-MT-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T04:00:00.000Z",
+    "end": "2017-02-27T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T04:00:00.000Z",
     "end": "2017-03-01T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T04:00:00.000Z",
     "end": "2017-06-16T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2018.json
+++ b/test/fixtures/BR-MT-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T04:00:00.000Z",
     "end": "2018-06-01T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2019.json
+++ b/test/fixtures/BR-MT-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T04:00:00.000Z",
+    "end": "2019-03-04T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T04:00:00.000Z",
     "end": "2019-03-06T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T04:00:00.000Z",
     "end": "2019-06-21T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2020.json
+++ b/test/fixtures/BR-MT-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T04:00:00.000Z",
+    "end": "2020-02-24T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T04:00:00.000Z",
     "end": "2020-02-26T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T04:00:00.000Z",
     "end": "2020-06-12T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2021.json
+++ b/test/fixtures/BR-MT-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T04:00:00.000Z",
+    "end": "2021-02-15T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T04:00:00.000Z",
     "end": "2021-02-17T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T04:00:00.000Z",
     "end": "2021-06-04T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2022.json
+++ b/test/fixtures/BR-MT-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T04:00:00.000Z",
+    "end": "2022-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T04:00:00.000Z",
     "end": "2022-03-02T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T04:00:00.000Z",
     "end": "2022-06-17T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2023.json
+++ b/test/fixtures/BR-MT-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T04:00:00.000Z",
+    "end": "2023-02-20T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T04:00:00.000Z",
     "end": "2023-02-22T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T04:00:00.000Z",
     "end": "2023-06-09T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2024.json
+++ b/test/fixtures/BR-MT-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T04:00:00.000Z",
+    "end": "2024-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T04:00:00.000Z",
     "end": "2024-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T04:00:00.000Z",
     "end": "2024-05-31T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2025.json
+++ b/test/fixtures/BR-MT-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T04:00:00.000Z",
+    "end": "2025-03-03T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T04:00:00.000Z",
     "end": "2025-03-05T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T04:00:00.000Z",
     "end": "2025-06-20T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2026.json
+++ b/test/fixtures/BR-MT-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T04:00:00.000Z",
+    "end": "2026-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T04:00:00.000Z",
     "end": "2026-02-18T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T04:00:00.000Z",
     "end": "2026-06-05T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2027.json
+++ b/test/fixtures/BR-MT-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T04:00:00.000Z",
+    "end": "2027-02-08T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T04:00:00.000Z",
     "end": "2027-02-10T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T04:00:00.000Z",
     "end": "2027-05-28T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2028.json
+++ b/test/fixtures/BR-MT-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T04:00:00.000Z",
+    "end": "2028-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T04:00:00.000Z",
+    "end": "2028-02-29T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T04:00:00.000Z",
+    "end": "2028-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T04:00:00.000Z",
     "end": "2028-03-01T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T04:00:00.000Z",
     "end": "2028-06-16T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-MT-2029.json
+++ b/test/fixtures/BR-MT-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T04:00:00.000Z",
+    "end": "2029-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T04:00:00.000Z",
+    "end": "2029-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T04:00:00.000Z",
+    "end": "2029-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T04:00:00.000Z",
     "end": "2029-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T04:00:00.000Z",
     "end": "2029-06-01T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2015.json
+++ b/test/fixtures/BR-PA-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2016.json
+++ b/test/fixtures/BR-PA-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2017.json
+++ b/test/fixtures/BR-PA-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2018.json
+++ b/test/fixtures/BR-PA-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2019.json
+++ b/test/fixtures/BR-PA-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2020.json
+++ b/test/fixtures/BR-PA-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2021.json
+++ b/test/fixtures/BR-PA-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2022.json
+++ b/test/fixtures/BR-PA-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2023.json
+++ b/test/fixtures/BR-PA-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2024.json
+++ b/test/fixtures/BR-PA-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2025.json
+++ b/test/fixtures/BR-PA-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2026.json
+++ b/test/fixtures/BR-PA-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2027.json
+++ b/test/fixtures/BR-PA-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2028.json
+++ b/test/fixtures/BR-PA-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PA-2029.json
+++ b/test/fixtures/BR-PA-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2015.json
+++ b/test/fixtures/BR-PB-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2016.json
+++ b/test/fixtures/BR-PB-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2017.json
+++ b/test/fixtures/BR-PB-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2018.json
+++ b/test/fixtures/BR-PB-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2019.json
+++ b/test/fixtures/BR-PB-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2020.json
+++ b/test/fixtures/BR-PB-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2021.json
+++ b/test/fixtures/BR-PB-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2022.json
+++ b/test/fixtures/BR-PB-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2023.json
+++ b/test/fixtures/BR-PB-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2024.json
+++ b/test/fixtures/BR-PB-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2025.json
+++ b/test/fixtures/BR-PB-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2026.json
+++ b/test/fixtures/BR-PB-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2027.json
+++ b/test/fixtures/BR-PB-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2028.json
+++ b/test/fixtures/BR-PB-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PB-2029.json
+++ b/test/fixtures/BR-PB-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2015.json
+++ b/test/fixtures/BR-PE-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-03-01 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2016.json
+++ b/test/fixtures/BR-PE-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-06 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2017.json
+++ b/test/fixtures/BR-PE-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-03-05 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2018.json
+++ b/test/fixtures/BR-PE-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-04 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2019.json
+++ b/test/fixtures/BR-PE-2019.json
@@ -11,10 +11,10 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
-    "end": "2019-03-06T17:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
   },
   {
@@ -25,6 +25,33 @@
     "type": "public",
     "rule": "1st sunday in March",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
+    "end": "2019-03-06T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2020.json
+++ b/test/fixtures/BR-PE-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-03-01 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2021.json
+++ b/test/fixtures/BR-PE-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-03-07 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2022.json
+++ b/test/fixtures/BR-PE-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-03-06 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2023.json
+++ b/test/fixtures/BR-PE-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-03-05 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2024.json
+++ b/test/fixtures/BR-PE-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-03 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2025.json
+++ b/test/fixtures/BR-PE-2025.json
@@ -11,10 +11,10 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
-    "end": "2025-03-05T17:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
   },
   {
@@ -25,6 +25,33 @@
     "type": "public",
     "rule": "1st sunday in March",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
+    "end": "2025-03-05T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2026.json
+++ b/test/fixtures/BR-PE-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-03-01 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2027.json
+++ b/test/fixtures/BR-PE-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-07 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2028.json
+++ b/test/fixtures/BR-PE-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-03-05 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-2029.json
+++ b/test/fixtures/BR-PE-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-04 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2015.json
+++ b/test/fixtures/BR-PE-RE-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-03-01 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2016.json
+++ b/test/fixtures/BR-PE-RE-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-06 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2017.json
+++ b/test/fixtures/BR-PE-RE-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-03-05 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2018.json
+++ b/test/fixtures/BR-PE-RE-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-04 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2019.json
+++ b/test/fixtures/BR-PE-RE-2019.json
@@ -11,10 +11,10 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
-    "end": "2019-03-06T17:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
   },
   {
@@ -25,6 +25,33 @@
     "type": "public",
     "rule": "1st sunday in March",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
+    "end": "2019-03-06T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2020.json
+++ b/test/fixtures/BR-PE-RE-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-03-01 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2021.json
+++ b/test/fixtures/BR-PE-RE-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-03-07 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2022.json
+++ b/test/fixtures/BR-PE-RE-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-03-06 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2023.json
+++ b/test/fixtures/BR-PE-RE-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-03-05 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2024.json
+++ b/test/fixtures/BR-PE-RE-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-03 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2025.json
+++ b/test/fixtures/BR-PE-RE-2025.json
@@ -11,10 +11,10 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
-    "end": "2025-03-05T17:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
   },
   {
@@ -25,6 +25,33 @@
     "type": "public",
     "rule": "1st sunday in March",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
+    "end": "2025-03-05T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2026.json
+++ b/test/fixtures/BR-PE-RE-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-03-01 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2027.json
+++ b/test/fixtures/BR-PE-RE-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-07 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2028.json
+++ b/test/fixtures/BR-PE-RE-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-03-05 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PE-RE-2029.json
+++ b/test/fixtures/BR-PE-RE-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-04 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2015.json
+++ b/test/fixtures/BR-PI-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2016.json
+++ b/test/fixtures/BR-PI-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2017.json
+++ b/test/fixtures/BR-PI-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2018.json
+++ b/test/fixtures/BR-PI-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2019.json
+++ b/test/fixtures/BR-PI-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2020.json
+++ b/test/fixtures/BR-PI-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2021.json
+++ b/test/fixtures/BR-PI-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2022.json
+++ b/test/fixtures/BR-PI-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2023.json
+++ b/test/fixtures/BR-PI-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2024.json
+++ b/test/fixtures/BR-PI-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2025.json
+++ b/test/fixtures/BR-PI-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2026.json
+++ b/test/fixtures/BR-PI-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2027.json
+++ b/test/fixtures/BR-PI-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2028.json
+++ b/test/fixtures/BR-PI-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PI-2029.json
+++ b/test/fixtures/BR-PI-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2015.json
+++ b/test/fixtures/BR-PR-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
     "end": "2015-02-18T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2016.json
+++ b/test/fixtures/BR-PR-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
     "end": "2016-02-10T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2017.json
+++ b/test/fixtures/BR-PR-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2018.json
+++ b/test/fixtures/BR-PR-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
     "end": "2018-02-14T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2019.json
+++ b/test/fixtures/BR-PR-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2020.json
+++ b/test/fixtures/BR-PR-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2021.json
+++ b/test/fixtures/BR-PR-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2022.json
+++ b/test/fixtures/BR-PR-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2023.json
+++ b/test/fixtures/BR-PR-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2024.json
+++ b/test/fixtures/BR-PR-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2025.json
+++ b/test/fixtures/BR-PR-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2026.json
+++ b/test/fixtures/BR-PR-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2027.json
+++ b/test/fixtures/BR-PR-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2028.json
+++ b/test/fixtures/BR-PR-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-2029.json
+++ b/test/fixtures/BR-PR-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2015.json
+++ b/test/fixtures/BR-PR-CU-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
     "end": "2015-02-18T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2016.json
+++ b/test/fixtures/BR-PR-CU-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
     "end": "2016-02-10T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2017.json
+++ b/test/fixtures/BR-PR-CU-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2018.json
+++ b/test/fixtures/BR-PR-CU-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
     "end": "2018-02-14T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2019.json
+++ b/test/fixtures/BR-PR-CU-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2020.json
+++ b/test/fixtures/BR-PR-CU-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2021.json
+++ b/test/fixtures/BR-PR-CU-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2022.json
+++ b/test/fixtures/BR-PR-CU-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2023.json
+++ b/test/fixtures/BR-PR-CU-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2024.json
+++ b/test/fixtures/BR-PR-CU-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2025.json
+++ b/test/fixtures/BR-PR-CU-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2026.json
+++ b/test/fixtures/BR-PR-CU-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2027.json
+++ b/test/fixtures/BR-PR-CU-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2028.json
+++ b/test/fixtures/BR-PR-CU-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-PR-CU-2029.json
+++ b/test/fixtures/BR-PR-CU-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2015.json
+++ b/test/fixtures/BR-RJ-2015.json
@@ -11,11 +11,20 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
-    "end": "2015-02-18T16:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2015-02-17 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
+    "end": "2015-02-18T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -85,7 +103,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2016.json
+++ b/test/fixtures/BR-RJ-2016.json
@@ -11,11 +11,20 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
-    "end": "2016-02-10T16:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2016-02-09 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
+    "end": "2016-02-10T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -85,7 +103,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2017.json
+++ b/test/fixtures/BR-RJ-2017.json
@@ -11,11 +11,20 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
-    "end": "2017-03-01T17:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2017-02-28 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
+    "end": "2017-03-01T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2018.json
+++ b/test/fixtures/BR-RJ-2018.json
@@ -11,11 +11,20 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
-    "end": "2018-02-14T16:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2018-02-13 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
+    "end": "2018-02-14T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -85,7 +103,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2019.json
+++ b/test/fixtures/BR-RJ-2019.json
@@ -11,11 +11,20 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
-    "end": "2019-03-06T17:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2019-03-05 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
+    "end": "2019-03-06T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2020.json
+++ b/test/fixtures/BR-RJ-2020.json
@@ -11,11 +11,20 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
-    "end": "2020-02-26T17:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2020-02-25 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
+    "end": "2020-02-26T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -85,7 +103,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2021.json
+++ b/test/fixtures/BR-RJ-2021.json
@@ -11,11 +11,20 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
-    "end": "2021-02-17T17:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2021-02-16 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
+    "end": "2021-02-17T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -85,7 +103,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2022.json
+++ b/test/fixtures/BR-RJ-2022.json
@@ -11,11 +11,20 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
-    "end": "2022-03-02T17:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2022-03-01 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
+    "end": "2022-03-02T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2023.json
+++ b/test/fixtures/BR-RJ-2023.json
@@ -11,11 +11,20 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
-    "end": "2023-02-22T17:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2023-02-21 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
+    "end": "2023-02-22T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -85,7 +103,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2024.json
+++ b/test/fixtures/BR-RJ-2024.json
@@ -11,11 +11,20 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
-    "end": "2024-02-14T17:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2024-02-13 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
+    "end": "2024-02-14T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -85,7 +103,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2025.json
+++ b/test/fixtures/BR-RJ-2025.json
@@ -11,11 +11,20 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
-    "end": "2025-03-05T17:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2025-03-04 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
+    "end": "2025-03-05T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2026.json
+++ b/test/fixtures/BR-RJ-2026.json
@@ -11,11 +11,20 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
-    "end": "2026-02-18T17:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2026-02-17 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
+    "end": "2026-02-18T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -85,7 +103,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2027.json
+++ b/test/fixtures/BR-RJ-2027.json
@@ -11,11 +11,20 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
-    "end": "2027-02-10T17:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2027-02-09 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
+    "end": "2027-02-10T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -85,7 +103,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2028.json
+++ b/test/fixtures/BR-RJ-2028.json
@@ -11,11 +11,20 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
-    "end": "2028-03-01T17:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2028-02-29 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
+    "end": "2028-03-01T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-2029.json
+++ b/test/fixtures/BR-RJ-2029.json
@@ -11,11 +11,20 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
-    "end": "2029-02-14T17:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2029-02-13 00:00:00",
@@ -25,6 +34,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
+    "end": "2029-02-14T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -85,7 +103,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2015.json
+++ b/test/fixtures/BR-RJ-RJ-2015.json
@@ -20,11 +20,20 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
-    "end": "2015-02-18T16:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2015-02-17 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
+    "end": "2015-02-18T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2016.json
+++ b/test/fixtures/BR-RJ-RJ-2016.json
@@ -20,11 +20,20 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
-    "end": "2016-02-10T16:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2016-02-09 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
+    "end": "2016-02-10T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2017.json
+++ b/test/fixtures/BR-RJ-RJ-2017.json
@@ -20,11 +20,20 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
-    "end": "2017-03-01T17:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2017-02-28 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
+    "end": "2017-03-01T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -103,7 +121,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2018.json
+++ b/test/fixtures/BR-RJ-RJ-2018.json
@@ -20,11 +20,20 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
-    "end": "2018-02-14T16:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2018-02-13 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
+    "end": "2018-02-14T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2019.json
+++ b/test/fixtures/BR-RJ-RJ-2019.json
@@ -20,11 +20,20 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
-    "end": "2019-03-06T17:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2019-03-05 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
+    "end": "2019-03-06T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -103,7 +121,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2020.json
+++ b/test/fixtures/BR-RJ-RJ-2020.json
@@ -20,11 +20,20 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
-    "end": "2020-02-26T17:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2020-02-25 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
+    "end": "2020-02-26T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2021.json
+++ b/test/fixtures/BR-RJ-RJ-2021.json
@@ -20,11 +20,20 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
-    "end": "2021-02-17T17:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2021-02-16 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
+    "end": "2021-02-17T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2022.json
+++ b/test/fixtures/BR-RJ-RJ-2022.json
@@ -20,11 +20,20 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
-    "end": "2022-03-02T17:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2022-03-01 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
+    "end": "2022-03-02T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -103,7 +121,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2023.json
+++ b/test/fixtures/BR-RJ-RJ-2023.json
@@ -20,11 +20,20 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
-    "end": "2023-02-22T17:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2023-02-21 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
+    "end": "2023-02-22T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2024.json
+++ b/test/fixtures/BR-RJ-RJ-2024.json
@@ -20,11 +20,20 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
-    "end": "2024-02-14T17:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2024-02-13 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
+    "end": "2024-02-14T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2025.json
+++ b/test/fixtures/BR-RJ-RJ-2025.json
@@ -20,11 +20,20 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
-    "end": "2025-03-05T17:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2025-03-04 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
+    "end": "2025-03-05T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -103,7 +121,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2026.json
+++ b/test/fixtures/BR-RJ-RJ-2026.json
@@ -20,11 +20,20 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
-    "end": "2026-02-18T17:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2026-02-17 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
+    "end": "2026-02-18T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2027.json
+++ b/test/fixtures/BR-RJ-RJ-2027.json
@@ -20,11 +20,20 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
-    "end": "2027-02-10T17:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2027-02-09 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
+    "end": "2027-02-10T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2028.json
+++ b/test/fixtures/BR-RJ-RJ-2028.json
@@ -20,11 +20,20 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
-    "end": "2028-03-01T17:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2028-02-29 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
+    "end": "2028-03-01T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -103,7 +121,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RJ-RJ-2029.json
+++ b/test/fixtures/BR-RJ-RJ-2029.json
@@ -20,11 +20,20 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
-    "end": "2029-02-14T17:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
+    "rule": "easter -50 PT48H",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
   },
   {
     "date": "2029-02-13 00:00:00",
@@ -34,6 +43,15 @@
     "type": "public",
     "rule": "easter -47",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
+    "end": "2029-02-14T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -94,7 +112,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2015.json
+++ b/test/fixtures/BR-RN-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2016.json
+++ b/test/fixtures/BR-RN-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2017.json
+++ b/test/fixtures/BR-RN-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2018.json
+++ b/test/fixtures/BR-RN-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2019.json
+++ b/test/fixtures/BR-RN-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2020.json
+++ b/test/fixtures/BR-RN-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2021.json
+++ b/test/fixtures/BR-RN-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2022.json
+++ b/test/fixtures/BR-RN-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2023.json
+++ b/test/fixtures/BR-RN-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2024.json
+++ b/test/fixtures/BR-RN-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2025.json
+++ b/test/fixtures/BR-RN-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2026.json
+++ b/test/fixtures/BR-RN-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2027.json
+++ b/test/fixtures/BR-RN-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2028.json
+++ b/test/fixtures/BR-RN-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RN-2029.json
+++ b/test/fixtures/BR-RN-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2015.json
+++ b/test/fixtures/BR-RO-2015.json
@@ -20,11 +20,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T04:00:00.000Z",
+    "end": "2015-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T04:00:00.000Z",
     "end": "2015-02-18T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2015-06-04T04:00:00.000Z",
     "end": "2015-06-05T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2016.json
+++ b/test/fixtures/BR-RO-2016.json
@@ -20,11 +20,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T04:00:00.000Z",
+    "end": "2016-02-08T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T04:00:00.000Z",
     "end": "2016-02-10T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2016-05-26T04:00:00.000Z",
     "end": "2016-05-27T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2017.json
+++ b/test/fixtures/BR-RO-2017.json
@@ -20,11 +20,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T04:00:00.000Z",
+    "end": "2017-02-27T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T04:00:00.000Z",
     "end": "2017-03-01T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2017-06-15T04:00:00.000Z",
     "end": "2017-06-16T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2018.json
+++ b/test/fixtures/BR-RO-2018.json
@@ -20,11 +20,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T04:00:00.000Z",
+    "end": "2018-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T04:00:00.000Z",
     "end": "2018-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2018-05-31T04:00:00.000Z",
     "end": "2018-06-01T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2019.json
+++ b/test/fixtures/BR-RO-2019.json
@@ -20,11 +20,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T04:00:00.000Z",
+    "end": "2019-03-04T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T04:00:00.000Z",
     "end": "2019-03-06T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -94,7 +121,7 @@
     "start": "2019-06-20T04:00:00.000Z",
     "end": "2019-06-21T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2020.json
+++ b/test/fixtures/BR-RO-2020.json
@@ -20,11 +20,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T04:00:00.000Z",
+    "end": "2020-02-24T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T04:00:00.000Z",
     "end": "2020-02-26T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2020-06-11T04:00:00.000Z",
     "end": "2020-06-12T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2021.json
+++ b/test/fixtures/BR-RO-2021.json
@@ -20,11 +20,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T04:00:00.000Z",
+    "end": "2021-02-15T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T04:00:00.000Z",
     "end": "2021-02-17T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2021-06-03T04:00:00.000Z",
     "end": "2021-06-04T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2022.json
+++ b/test/fixtures/BR-RO-2022.json
@@ -20,11 +20,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T04:00:00.000Z",
+    "end": "2022-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T04:00:00.000Z",
     "end": "2022-03-02T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2022-06-16T04:00:00.000Z",
     "end": "2022-06-17T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2023.json
+++ b/test/fixtures/BR-RO-2023.json
@@ -20,11 +20,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T04:00:00.000Z",
+    "end": "2023-02-20T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T04:00:00.000Z",
     "end": "2023-02-22T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2023-06-08T04:00:00.000Z",
     "end": "2023-06-09T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2024.json
+++ b/test/fixtures/BR-RO-2024.json
@@ -20,11 +20,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T04:00:00.000Z",
+    "end": "2024-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T04:00:00.000Z",
     "end": "2024-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2024-05-30T04:00:00.000Z",
     "end": "2024-05-31T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2025.json
+++ b/test/fixtures/BR-RO-2025.json
@@ -20,11 +20,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T04:00:00.000Z",
+    "end": "2025-03-03T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T04:00:00.000Z",
     "end": "2025-03-05T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -94,7 +121,7 @@
     "start": "2025-06-19T04:00:00.000Z",
     "end": "2025-06-20T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2026.json
+++ b/test/fixtures/BR-RO-2026.json
@@ -20,11 +20,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T04:00:00.000Z",
+    "end": "2026-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T04:00:00.000Z",
     "end": "2026-02-18T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2026-06-04T04:00:00.000Z",
     "end": "2026-06-05T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2027.json
+++ b/test/fixtures/BR-RO-2027.json
@@ -20,11 +20,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T04:00:00.000Z",
+    "end": "2027-02-08T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T04:00:00.000Z",
     "end": "2027-02-10T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2027-05-27T04:00:00.000Z",
     "end": "2027-05-28T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2028.json
+++ b/test/fixtures/BR-RO-2028.json
@@ -20,11 +20,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T04:00:00.000Z",
+    "end": "2028-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T04:00:00.000Z",
+    "end": "2028-02-29T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T04:00:00.000Z",
+    "end": "2028-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T04:00:00.000Z",
     "end": "2028-03-01T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2028-06-15T04:00:00.000Z",
     "end": "2028-06-16T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RO-2029.json
+++ b/test/fixtures/BR-RO-2029.json
@@ -20,11 +20,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T04:00:00.000Z",
+    "end": "2029-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T04:00:00.000Z",
+    "end": "2029-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T04:00:00.000Z",
+    "end": "2029-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T04:00:00.000Z",
     "end": "2029-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2029-05-31T04:00:00.000Z",
     "end": "2029-06-01T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2015.json
+++ b/test/fixtures/BR-RR-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T04:00:00.000Z",
+    "end": "2015-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T04:00:00.000Z",
+    "end": "2015-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T04:00:00.000Z",
+    "end": "2015-02-18T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T04:00:00.000Z",
     "end": "2015-02-18T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T04:00:00.000Z",
     "end": "2015-06-05T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2016.json
+++ b/test/fixtures/BR-RR-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T04:00:00.000Z",
+    "end": "2016-02-08T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T04:00:00.000Z",
+    "end": "2016-02-09T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T04:00:00.000Z",
+    "end": "2016-02-10T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T04:00:00.000Z",
     "end": "2016-02-10T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T04:00:00.000Z",
     "end": "2016-05-27T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2017.json
+++ b/test/fixtures/BR-RR-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T04:00:00.000Z",
+    "end": "2017-02-27T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T04:00:00.000Z",
+    "end": "2017-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T04:00:00.000Z",
+    "end": "2017-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T04:00:00.000Z",
     "end": "2017-03-01T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T04:00:00.000Z",
     "end": "2017-06-16T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2018.json
+++ b/test/fixtures/BR-RR-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T04:00:00.000Z",
+    "end": "2018-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T04:00:00.000Z",
+    "end": "2018-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T04:00:00.000Z",
+    "end": "2018-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T04:00:00.000Z",
     "end": "2018-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T04:00:00.000Z",
     "end": "2018-06-01T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2019.json
+++ b/test/fixtures/BR-RR-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T04:00:00.000Z",
+    "end": "2019-03-04T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T04:00:00.000Z",
+    "end": "2019-03-05T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T04:00:00.000Z",
+    "end": "2019-03-06T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T04:00:00.000Z",
     "end": "2019-03-06T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T04:00:00.000Z",
     "end": "2019-06-21T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2020.json
+++ b/test/fixtures/BR-RR-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T04:00:00.000Z",
+    "end": "2020-02-24T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T04:00:00.000Z",
+    "end": "2020-02-25T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T04:00:00.000Z",
+    "end": "2020-02-26T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T04:00:00.000Z",
     "end": "2020-02-26T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T04:00:00.000Z",
     "end": "2020-06-12T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2021.json
+++ b/test/fixtures/BR-RR-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T04:00:00.000Z",
+    "end": "2021-02-15T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T04:00:00.000Z",
+    "end": "2021-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T04:00:00.000Z",
+    "end": "2021-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T04:00:00.000Z",
     "end": "2021-02-17T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T04:00:00.000Z",
     "end": "2021-06-04T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2022.json
+++ b/test/fixtures/BR-RR-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T04:00:00.000Z",
+    "end": "2022-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T04:00:00.000Z",
+    "end": "2022-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T04:00:00.000Z",
+    "end": "2022-03-02T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T04:00:00.000Z",
     "end": "2022-03-02T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T04:00:00.000Z",
     "end": "2022-06-17T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2023.json
+++ b/test/fixtures/BR-RR-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T04:00:00.000Z",
+    "end": "2023-02-20T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T04:00:00.000Z",
+    "end": "2023-02-21T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T04:00:00.000Z",
+    "end": "2023-02-22T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T04:00:00.000Z",
     "end": "2023-02-22T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T04:00:00.000Z",
     "end": "2023-06-09T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2024.json
+++ b/test/fixtures/BR-RR-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T04:00:00.000Z",
+    "end": "2024-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T04:00:00.000Z",
+    "end": "2024-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T04:00:00.000Z",
+    "end": "2024-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T04:00:00.000Z",
     "end": "2024-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T04:00:00.000Z",
     "end": "2024-05-31T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2025.json
+++ b/test/fixtures/BR-RR-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T04:00:00.000Z",
+    "end": "2025-03-03T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T04:00:00.000Z",
+    "end": "2025-03-04T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T04:00:00.000Z",
+    "end": "2025-03-05T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T04:00:00.000Z",
     "end": "2025-03-05T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T04:00:00.000Z",
     "end": "2025-06-20T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2026.json
+++ b/test/fixtures/BR-RR-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T04:00:00.000Z",
+    "end": "2026-02-16T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T04:00:00.000Z",
+    "end": "2026-02-17T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T04:00:00.000Z",
+    "end": "2026-02-18T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T04:00:00.000Z",
     "end": "2026-02-18T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T04:00:00.000Z",
     "end": "2026-06-05T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2027.json
+++ b/test/fixtures/BR-RR-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T04:00:00.000Z",
+    "end": "2027-02-08T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T04:00:00.000Z",
+    "end": "2027-02-09T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T04:00:00.000Z",
+    "end": "2027-02-10T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T04:00:00.000Z",
     "end": "2027-02-10T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T04:00:00.000Z",
     "end": "2027-05-28T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2028.json
+++ b/test/fixtures/BR-RR-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T04:00:00.000Z",
+    "end": "2028-02-28T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T04:00:00.000Z",
+    "end": "2028-02-29T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T04:00:00.000Z",
+    "end": "2028-03-01T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T04:00:00.000Z",
     "end": "2028-03-01T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T04:00:00.000Z",
     "end": "2028-06-16T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RR-2029.json
+++ b/test/fixtures/BR-RR-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T04:00:00.000Z",
+    "end": "2029-02-12T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T04:00:00.000Z",
+    "end": "2029-02-13T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T04:00:00.000Z",
+    "end": "2029-02-14T04:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T04:00:00.000Z",
     "end": "2029-02-14T18:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T04:00:00.000Z",
     "end": "2029-06-01T04:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2015.json
+++ b/test/fixtures/BR-RS-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
     "end": "2015-02-18T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2016.json
+++ b/test/fixtures/BR-RS-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
     "end": "2016-02-10T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2017.json
+++ b/test/fixtures/BR-RS-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2018.json
+++ b/test/fixtures/BR-RS-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
     "end": "2018-02-14T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2019.json
+++ b/test/fixtures/BR-RS-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2020.json
+++ b/test/fixtures/BR-RS-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2021.json
+++ b/test/fixtures/BR-RS-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2022.json
+++ b/test/fixtures/BR-RS-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2023.json
+++ b/test/fixtures/BR-RS-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2024.json
+++ b/test/fixtures/BR-RS-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2025.json
+++ b/test/fixtures/BR-RS-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2026.json
+++ b/test/fixtures/BR-RS-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2027.json
+++ b/test/fixtures/BR-RS-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2028.json
+++ b/test/fixtures/BR-RS-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-RS-2029.json
+++ b/test/fixtures/BR-RS-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2015.json
+++ b/test/fixtures/BR-SC-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
     "end": "2015-02-18T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2016.json
+++ b/test/fixtures/BR-SC-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
     "end": "2016-02-10T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2017.json
+++ b/test/fixtures/BR-SC-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2018.json
+++ b/test/fixtures/BR-SC-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
     "end": "2018-02-14T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2019.json
+++ b/test/fixtures/BR-SC-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2020.json
+++ b/test/fixtures/BR-SC-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2021.json
+++ b/test/fixtures/BR-SC-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2022.json
+++ b/test/fixtures/BR-SC-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2023.json
+++ b/test/fixtures/BR-SC-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2024.json
+++ b/test/fixtures/BR-SC-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2025.json
+++ b/test/fixtures/BR-SC-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2026.json
+++ b/test/fixtures/BR-SC-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2027.json
+++ b/test/fixtures/BR-SC-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2028.json
+++ b/test/fixtures/BR-SC-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SC-2029.json
+++ b/test/fixtures/BR-SC-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2015.json
+++ b/test/fixtures/BR-SE-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2016.json
+++ b/test/fixtures/BR-SE-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2017.json
+++ b/test/fixtures/BR-SE-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2018.json
+++ b/test/fixtures/BR-SE-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2019.json
+++ b/test/fixtures/BR-SE-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2020.json
+++ b/test/fixtures/BR-SE-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2021.json
+++ b/test/fixtures/BR-SE-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2022.json
+++ b/test/fixtures/BR-SE-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2023.json
+++ b/test/fixtures/BR-SE-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2024.json
+++ b/test/fixtures/BR-SE-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2025.json
+++ b/test/fixtures/BR-SE-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2026.json
+++ b/test/fixtures/BR-SE-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2027.json
+++ b/test/fixtures/BR-SE-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2028.json
+++ b/test/fixtures/BR-SE-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SE-2029.json
+++ b/test/fixtures/BR-SE-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2015.json
+++ b/test/fixtures/BR-SP-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
     "end": "2015-02-18T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2016.json
+++ b/test/fixtures/BR-SP-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
     "end": "2016-02-10T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2017.json
+++ b/test/fixtures/BR-SP-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2018.json
+++ b/test/fixtures/BR-SP-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
     "end": "2018-02-14T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2019.json
+++ b/test/fixtures/BR-SP-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2020.json
+++ b/test/fixtures/BR-SP-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2021.json
+++ b/test/fixtures/BR-SP-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2022.json
+++ b/test/fixtures/BR-SP-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2023.json
+++ b/test/fixtures/BR-SP-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2024.json
+++ b/test/fixtures/BR-SP-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2025.json
+++ b/test/fixtures/BR-SP-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2026.json
+++ b/test/fixtures/BR-SP-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2027.json
+++ b/test/fixtures/BR-SP-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2028.json
+++ b/test/fixtures/BR-SP-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-2029.json
+++ b/test/fixtures/BR-SP-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",
@@ -67,7 +94,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-SP-SP-2015.json
+++ b/test/fixtures/BR-SP-SP-2015.json
@@ -20,11 +20,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
     "end": "2015-02-18T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-04-03 00:00:00",

--- a/test/fixtures/BR-SP-SP-2016.json
+++ b/test/fixtures/BR-SP-SP-2016.json
@@ -20,11 +20,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
     "end": "2016-02-10T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-25 00:00:00",

--- a/test/fixtures/BR-SP-SP-2017.json
+++ b/test/fixtures/BR-SP-SP-2017.json
@@ -20,11 +20,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-04-14 00:00:00",

--- a/test/fixtures/BR-SP-SP-2018.json
+++ b/test/fixtures/BR-SP-SP-2018.json
@@ -20,11 +20,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
     "end": "2018-02-14T16:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-30 00:00:00",

--- a/test/fixtures/BR-SP-SP-2019.json
+++ b/test/fixtures/BR-SP-SP-2019.json
@@ -20,11 +20,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-04-19 00:00:00",

--- a/test/fixtures/BR-SP-SP-2020.json
+++ b/test/fixtures/BR-SP-SP-2020.json
@@ -20,11 +20,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-04-10 00:00:00",

--- a/test/fixtures/BR-SP-SP-2021.json
+++ b/test/fixtures/BR-SP-SP-2021.json
@@ -20,11 +20,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-04-02 00:00:00",

--- a/test/fixtures/BR-SP-SP-2022.json
+++ b/test/fixtures/BR-SP-SP-2022.json
@@ -20,11 +20,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-04-15 00:00:00",

--- a/test/fixtures/BR-SP-SP-2023.json
+++ b/test/fixtures/BR-SP-SP-2023.json
@@ -20,11 +20,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-04-07 00:00:00",

--- a/test/fixtures/BR-SP-SP-2024.json
+++ b/test/fixtures/BR-SP-SP-2024.json
@@ -20,11 +20,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-29 00:00:00",

--- a/test/fixtures/BR-SP-SP-2025.json
+++ b/test/fixtures/BR-SP-SP-2025.json
@@ -20,11 +20,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-04-18 00:00:00",

--- a/test/fixtures/BR-SP-SP-2026.json
+++ b/test/fixtures/BR-SP-SP-2026.json
@@ -20,11 +20,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-04-03 00:00:00",

--- a/test/fixtures/BR-SP-SP-2027.json
+++ b/test/fixtures/BR-SP-SP-2027.json
@@ -20,11 +20,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-26 00:00:00",

--- a/test/fixtures/BR-SP-SP-2028.json
+++ b/test/fixtures/BR-SP-SP-2028.json
@@ -20,11 +20,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-04-14 00:00:00",

--- a/test/fixtures/BR-SP-SP-2029.json
+++ b/test/fixtures/BR-SP-SP-2029.json
@@ -20,11 +20,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-30 00:00:00",

--- a/test/fixtures/BR-TO-2015.json
+++ b/test/fixtures/BR-TO-2015.json
@@ -11,11 +11,38 @@
   {
     "date": "2015-02-14 00:00:00",
     "start": "2015-02-14T03:00:00.000Z",
+    "end": "2015-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T03:00:00.000Z",
+    "end": "2015-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T03:00:00.000Z",
+    "end": "2015-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T03:00:00.000Z",
     "end": "2015-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2015-03-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2015-06-04T03:00:00.000Z",
     "end": "2015-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2016.json
+++ b/test/fixtures/BR-TO-2016.json
@@ -11,11 +11,38 @@
   {
     "date": "2016-02-06 00:00:00",
     "start": "2016-02-06T03:00:00.000Z",
+    "end": "2016-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T03:00:00.000Z",
+    "end": "2016-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T03:00:00.000Z",
+    "end": "2016-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T03:00:00.000Z",
     "end": "2016-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2016-03-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2016-05-26T03:00:00.000Z",
     "end": "2016-05-27T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2017.json
+++ b/test/fixtures/BR-TO-2017.json
@@ -11,11 +11,38 @@
   {
     "date": "2017-02-25 00:00:00",
     "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
     "end": "2017-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2017-03-18 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2017-06-15T03:00:00.000Z",
     "end": "2017-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2018.json
+++ b/test/fixtures/BR-TO-2018.json
@@ -11,11 +11,38 @@
   {
     "date": "2018-02-10 00:00:00",
     "start": "2018-02-10T03:00:00.000Z",
+    "end": "2018-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T03:00:00.000Z",
+    "end": "2018-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T03:00:00.000Z",
+    "end": "2018-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T03:00:00.000Z",
     "end": "2018-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-03-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2018-05-31T03:00:00.000Z",
     "end": "2018-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2019.json
+++ b/test/fixtures/BR-TO-2019.json
@@ -11,11 +11,38 @@
   {
     "date": "2019-03-02 00:00:00",
     "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
     "end": "2019-03-06T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2019-03-18 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2019-06-20T03:00:00.000Z",
     "end": "2019-06-21T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2020.json
+++ b/test/fixtures/BR-TO-2020.json
@@ -11,11 +11,38 @@
   {
     "date": "2020-02-22 00:00:00",
     "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
     "end": "2020-02-26T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2020-03-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2020-06-11T03:00:00.000Z",
     "end": "2020-06-12T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2021.json
+++ b/test/fixtures/BR-TO-2021.json
@@ -11,11 +11,38 @@
   {
     "date": "2021-02-13 00:00:00",
     "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
     "end": "2021-02-17T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2021-03-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2021-06-03T03:00:00.000Z",
     "end": "2021-06-04T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2022.json
+++ b/test/fixtures/BR-TO-2022.json
@@ -11,11 +11,38 @@
   {
     "date": "2022-02-26 00:00:00",
     "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
     "end": "2022-03-02T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2022-03-18 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2022-06-16T03:00:00.000Z",
     "end": "2022-06-17T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2023.json
+++ b/test/fixtures/BR-TO-2023.json
@@ -11,11 +11,38 @@
   {
     "date": "2023-02-18 00:00:00",
     "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
     "end": "2023-02-22T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-03-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2023-06-08T03:00:00.000Z",
     "end": "2023-06-09T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2024.json
+++ b/test/fixtures/BR-TO-2024.json
@@ -11,11 +11,38 @@
   {
     "date": "2024-02-10 00:00:00",
     "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
     "end": "2024-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2024-03-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2024-05-30T03:00:00.000Z",
     "end": "2024-05-31T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2025.json
+++ b/test/fixtures/BR-TO-2025.json
@@ -11,11 +11,38 @@
   {
     "date": "2025-03-01 00:00:00",
     "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
     "end": "2025-03-05T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-03-18 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2025-06-19T03:00:00.000Z",
     "end": "2025-06-20T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2026.json
+++ b/test/fixtures/BR-TO-2026.json
@@ -11,11 +11,38 @@
   {
     "date": "2026-02-14 00:00:00",
     "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
     "end": "2026-02-18T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-03-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2026-06-04T03:00:00.000Z",
     "end": "2026-06-05T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2027.json
+++ b/test/fixtures/BR-TO-2027.json
@@ -11,11 +11,38 @@
   {
     "date": "2027-02-06 00:00:00",
     "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
     "end": "2027-02-10T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2027-03-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2027-05-27T03:00:00.000Z",
     "end": "2027-05-28T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2028.json
+++ b/test/fixtures/BR-TO-2028.json
@@ -11,11 +11,38 @@
   {
     "date": "2028-02-26 00:00:00",
     "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
     "end": "2028-03-01T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-03-18 00:00:00",
@@ -85,7 +112,7 @@
     "start": "2028-06-15T03:00:00.000Z",
     "end": "2028-06-16T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },

--- a/test/fixtures/BR-TO-2029.json
+++ b/test/fixtures/BR-TO-2029.json
@@ -11,11 +11,38 @@
   {
     "date": "2029-02-10 00:00:00",
     "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
     "end": "2029-02-14T17:00:00.000Z",
     "name": "Carnaval",
     "type": "optional",
-    "rule": "easter -50 PT110H",
-    "_weekday": "Sat"
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
   },
   {
     "date": "2029-03-18 00:00:00",
@@ -76,7 +103,7 @@
     "start": "2029-05-31T03:00:00.000Z",
     "end": "2029-06-01T03:00:00.000Z",
     "name": "Corpo de Deus",
-    "type": "optional",
+    "type": "bank",
     "rule": "easter 60",
     "_weekday": "Thu"
   },


### PR DESCRIPTION
## Summary

Adds Brazilian **bank holidays** for Carnival and Corpus Christi, following the Central Bank of Brazil's Resolução CMN nº 4.880 (art. 6), which lists Carnival Monday/Tuesday and Corpus Christi as non-business days for banks even though they are not national public holidays.

## Changes (`data/countries/BR.yaml`)

- **Carnival Monday & Tuesday** (`easter -48`, `easter -47`) → `type: bank`.
- **Corpus Christi** (`easter 60`) → reclassified `optional` → `bank`.
- **Carnival Saturday & Sunday** (`easter -50 PT48H`) → kept as `optional` (cultural celebration); this replaces the previous single multi-day `easter -50 PT110H` entry.
- **Ash Wednesday** (`easter -46 PT14H`) → kept as `optional` until 14:00 (half-day custom), preserving the original behavior. It is a reduced-hours working day (art. 2), not a closure, so it is **not** a `bank` holiday.

## Notes

- Carnival Monday/Tuesday are modeled as two separate rules (not a single multi-day block) so that Rio de Janeiro's state-level **public** holiday on Carnival Tuesday still takes precedence via type priority. Verified in the RJ fixtures: Tuesday resolves to `public`, Monday to `bank`.
- São Paulo city's `public` Corpus Christi likewise still overrides the national `bank` entry.

## Source

Resolução CMN nº 4.880, de 23/12/2020 — art. 6
https://www.bcb.gov.br/estabilidadefinanceira/exibenormativo?tipo=Resolu%C3%A7%C3%A3o%20CMN&numero=4880

## Testing

- Regenerated data (`npm run yaml`) and fixtures (`mocha test/all.mocha.js --writetests --countries BR`).
- Full test suite passes (`npm test`): 5346 passing.
- Confirmed only `BR*` fixtures changed; no other countries affected.
