### PR TITLE
chore(GB): align naming with GOV.UK and remove old source

### DIFF
--- a/data/countries/GB.yaml
+++ b/data/countries/GB.yaml
@@ -552,7 +552,7 @@ holidays:
           1st monday before 09-01:
             name:
               en: Summer bank holiday
-        regions: {}
+        # regions:
         # AGY:
         #   name: Anglesey
         # BGE:

--- a/data/countries/GB.yaml
+++ b/data/countries/GB.yaml
@@ -64,7 +64,6 @@ holidays:
         name:
           en: Queen’s Platinum Jubilee
       # @source https://www.gov.uk/government/news/bank-holiday-announced-for-her-majesty-queen-elizabeth-iis-state-funeral-on-monday-19-september
-      # @source https://gov.gg/monarch
       "2022-09-19":
         name:
           en: Queen Elizabeth's Funeral Day

--- a/data/countries/GB.yaml
+++ b/data/countries/GB.yaml
@@ -402,26 +402,26 @@ holidays:
         days:
           03-17:
             name:
-              en: "St Patrick's Day"
+              en: "St Patrick’s Day"
           substitutes 03-17 if saturday then next monday:
             substitute: true
             name:
-              en: "St Patrick's Day"
+              en: "St Patrick’s Day"
           substitutes 03-17 if sunday then next monday:
             substitute: true
             name:
-              en: "St Patrick's Day"
+              en: "St Patrick’s Day"
           07-12:
             name:
-              en: "Battle of the Boyne, Orangemen’s Day"
+              en: "Battle of the Boyne (Orangemen’s Day)"
           substitutes 07-12 if saturday then next monday:
             substitute: true
             name:
-              en: Battle of the Boyne
+              en: "Battle of the Boyne (Orangemen’s Day)"
           substitutes 07-12 if sunday then next monday:
             substitute: true
             name:
-              en: Battle of the Boyne
+              en: "Battle of the Boyne (Orangemen’s Day)"
           1st monday before 09-01:
             name:
               en: Summer bank holiday

--- a/test/fixtures/GB-NIR-2015.json
+++ b/test/fixtures/GB-NIR-2015.json
@@ -21,7 +21,7 @@
     "date": "2015-03-17 00:00:00",
     "start": "2015-03-17T00:00:00.000Z",
     "end": "2015-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2015-07-12 00:00:00",
     "start": "2015-07-11T23:00:00.000Z",
     "end": "2015-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Sun"
@@ -93,7 +93,7 @@
     "date": "2015-07-13 00:00:00",
     "start": "2015-07-12T23:00:00.000Z",
     "end": "2015-07-13T23:00:00.000Z",
-    "name": "Battle of the Boyne (substitute day)",
+    "name": "Battle of the Boyne (Orangemen’s Day) (substitute day)",
     "type": "public",
     "substitute": true,
     "rule": "substitutes 07-12 if sunday then next monday",

--- a/test/fixtures/GB-NIR-2016.json
+++ b/test/fixtures/GB-NIR-2016.json
@@ -21,7 +21,7 @@
     "date": "2016-03-17 00:00:00",
     "start": "2016-03-17T00:00:00.000Z",
     "end": "2016-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2016-07-12 00:00:00",
     "start": "2016-07-11T23:00:00.000Z",
     "end": "2016-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Tue"

--- a/test/fixtures/GB-NIR-2017.json
+++ b/test/fixtures/GB-NIR-2017.json
@@ -22,7 +22,7 @@
     "date": "2017-03-17 00:00:00",
     "start": "2017-03-17T00:00:00.000Z",
     "end": "2017-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Fri"
@@ -94,7 +94,7 @@
     "date": "2017-07-12 00:00:00",
     "start": "2017-07-11T23:00:00.000Z",
     "end": "2017-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Wed"

--- a/test/fixtures/GB-NIR-2018.json
+++ b/test/fixtures/GB-NIR-2018.json
@@ -21,7 +21,7 @@
     "date": "2018-03-17 00:00:00",
     "start": "2018-03-17T00:00:00.000Z",
     "end": "2018-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Sat"
@@ -30,7 +30,7 @@
     "date": "2018-03-19 00:00:00",
     "start": "2018-03-19T00:00:00.000Z",
     "end": "2018-03-20T00:00:00.000Z",
-    "name": "St Patrick's Day (substitute day)",
+    "name": "St Patrick’s Day (substitute day)",
     "type": "public",
     "substitute": true,
     "rule": "substitutes 03-17 if saturday then next monday",
@@ -94,7 +94,7 @@
     "date": "2018-07-12 00:00:00",
     "start": "2018-07-11T23:00:00.000Z",
     "end": "2018-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Thu"

--- a/test/fixtures/GB-NIR-2019.json
+++ b/test/fixtures/GB-NIR-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-03-17 00:00:00",
     "start": "2019-03-17T00:00:00.000Z",
     "end": "2019-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Sun"
@@ -21,7 +21,7 @@
     "date": "2019-03-18 00:00:00",
     "start": "2019-03-18T00:00:00.000Z",
     "end": "2019-03-19T00:00:00.000Z",
-    "name": "St Patrick's Day (substitute day)",
+    "name": "St Patrick’s Day (substitute day)",
     "type": "public",
     "substitute": true,
     "rule": "substitutes 03-17 if sunday then next monday",
@@ -94,7 +94,7 @@
     "date": "2019-07-12 00:00:00",
     "start": "2019-07-11T23:00:00.000Z",
     "end": "2019-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Fri"

--- a/test/fixtures/GB-NIR-2020.json
+++ b/test/fixtures/GB-NIR-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-03-17 00:00:00",
     "start": "2020-03-17T00:00:00.000Z",
     "end": "2020-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2020-07-12 00:00:00",
     "start": "2020-07-11T23:00:00.000Z",
     "end": "2020-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Sun"
@@ -93,7 +93,7 @@
     "date": "2020-07-13 00:00:00",
     "start": "2020-07-12T23:00:00.000Z",
     "end": "2020-07-13T23:00:00.000Z",
-    "name": "Battle of the Boyne (substitute day)",
+    "name": "Battle of the Boyne (Orangemen’s Day) (substitute day)",
     "type": "public",
     "substitute": true,
     "rule": "substitutes 07-12 if sunday then next monday",

--- a/test/fixtures/GB-NIR-2021.json
+++ b/test/fixtures/GB-NIR-2021.json
@@ -21,7 +21,7 @@
     "date": "2021-03-17 00:00:00",
     "start": "2021-03-17T00:00:00.000Z",
     "end": "2021-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2021-07-12 00:00:00",
     "start": "2021-07-11T23:00:00.000Z",
     "end": "2021-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Mon"

--- a/test/fixtures/GB-NIR-2022.json
+++ b/test/fixtures/GB-NIR-2022.json
@@ -22,7 +22,7 @@
     "date": "2022-03-17 00:00:00",
     "start": "2022-03-17T00:00:00.000Z",
     "end": "2022-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Thu"
@@ -103,7 +103,7 @@
     "date": "2022-07-12 00:00:00",
     "start": "2022-07-11T23:00:00.000Z",
     "end": "2022-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Tue"

--- a/test/fixtures/GB-NIR-2023.json
+++ b/test/fixtures/GB-NIR-2023.json
@@ -22,7 +22,7 @@
     "date": "2023-03-17 00:00:00",
     "start": "2023-03-17T00:00:00.000Z",
     "end": "2023-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Fri"
@@ -103,7 +103,7 @@
     "date": "2023-07-12 00:00:00",
     "start": "2023-07-11T23:00:00.000Z",
     "end": "2023-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Wed"

--- a/test/fixtures/GB-NIR-2024.json
+++ b/test/fixtures/GB-NIR-2024.json
@@ -21,7 +21,7 @@
     "date": "2024-03-17 00:00:00",
     "start": "2024-03-17T00:00:00.000Z",
     "end": "2024-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Sun"
@@ -30,7 +30,7 @@
     "date": "2024-03-18 00:00:00",
     "start": "2024-03-18T00:00:00.000Z",
     "end": "2024-03-19T00:00:00.000Z",
-    "name": "St Patrick's Day (substitute day)",
+    "name": "St Patrick’s Day (substitute day)",
     "type": "public",
     "substitute": true,
     "rule": "substitutes 03-17 if sunday then next monday",
@@ -94,7 +94,7 @@
     "date": "2024-07-12 00:00:00",
     "start": "2024-07-11T23:00:00.000Z",
     "end": "2024-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Fri"

--- a/test/fixtures/GB-NIR-2025.json
+++ b/test/fixtures/GB-NIR-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-03-17 00:00:00",
     "start": "2025-03-17T00:00:00.000Z",
     "end": "2025-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Mon"
@@ -84,7 +84,7 @@
     "date": "2025-07-12 00:00:00",
     "start": "2025-07-11T23:00:00.000Z",
     "end": "2025-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2025-07-14 00:00:00",
     "start": "2025-07-13T23:00:00.000Z",
     "end": "2025-07-14T23:00:00.000Z",
-    "name": "Battle of the Boyne (substitute day)",
+    "name": "Battle of the Boyne (Orangemen’s Day) (substitute day)",
     "type": "public",
     "substitute": true,
     "rule": "substitutes 07-12 if saturday then next monday",

--- a/test/fixtures/GB-NIR-2026.json
+++ b/test/fixtures/GB-NIR-2026.json
@@ -21,7 +21,7 @@
     "date": "2026-03-17 00:00:00",
     "start": "2026-03-17T00:00:00.000Z",
     "end": "2026-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2026-07-12 00:00:00",
     "start": "2026-07-11T23:00:00.000Z",
     "end": "2026-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Sun"
@@ -93,7 +93,7 @@
     "date": "2026-07-13 00:00:00",
     "start": "2026-07-12T23:00:00.000Z",
     "end": "2026-07-13T23:00:00.000Z",
-    "name": "Battle of the Boyne (substitute day)",
+    "name": "Battle of the Boyne (Orangemen’s Day) (substitute day)",
     "type": "public",
     "substitute": true,
     "rule": "substitutes 07-12 if sunday then next monday",

--- a/test/fixtures/GB-NIR-2027.json
+++ b/test/fixtures/GB-NIR-2027.json
@@ -21,7 +21,7 @@
     "date": "2027-03-17 00:00:00",
     "start": "2027-03-17T00:00:00.000Z",
     "end": "2027-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2027-07-12 00:00:00",
     "start": "2027-07-11T23:00:00.000Z",
     "end": "2027-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Mon"

--- a/test/fixtures/GB-NIR-2028.json
+++ b/test/fixtures/GB-NIR-2028.json
@@ -22,7 +22,7 @@
     "date": "2028-03-17 00:00:00",
     "start": "2028-03-17T00:00:00.000Z",
     "end": "2028-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Fri"
@@ -94,7 +94,7 @@
     "date": "2028-07-12 00:00:00",
     "start": "2028-07-11T23:00:00.000Z",
     "end": "2028-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Wed"

--- a/test/fixtures/GB-NIR-2029.json
+++ b/test/fixtures/GB-NIR-2029.json
@@ -21,7 +21,7 @@
     "date": "2029-03-17 00:00:00",
     "start": "2029-03-17T00:00:00.000Z",
     "end": "2029-03-18T00:00:00.000Z",
-    "name": "St Patrick's Day",
+    "name": "St Patrick’s Day",
     "type": "public",
     "rule": "03-17",
     "_weekday": "Sat"
@@ -30,7 +30,7 @@
     "date": "2029-03-19 00:00:00",
     "start": "2029-03-19T00:00:00.000Z",
     "end": "2029-03-20T00:00:00.000Z",
-    "name": "St Patrick's Day (substitute day)",
+    "name": "St Patrick’s Day (substitute day)",
     "type": "public",
     "substitute": true,
     "rule": "substitutes 03-17 if saturday then next monday",
@@ -94,7 +94,7 @@
     "date": "2029-07-12 00:00:00",
     "start": "2029-07-11T23:00:00.000Z",
     "end": "2029-07-12T23:00:00.000Z",
-    "name": "Battle of the Boyne, Orangemen’s Day",
+    "name": "Battle of the Boyne (Orangemen’s Day)",
     "type": "public",
     "rule": "07-12",
     "_weekday": "Thu"


### PR DESCRIPTION
I updated the GB holiday data by making the regions formatting more consistent and removing one dead source link.

Holiday names were aligned to official GOV.UK wording and standardized across related entries.
Note: this differs from Wikipedia-style apostrophe usage in some cases, because official GOV naming takes priority here.