### PR TITLE
feat: Add new colombian holiday monday after 07-09

### DIFF
--- a/data/countries/CO.yaml
+++ b/data/countries/CO.yaml
@@ -37,6 +37,11 @@ holidays:
           en: Sacred Heart
       monday after 06-29:
         _name: 06-29
+      # @source https://lector.ramajudicial.gov.co/SIDN/NORMATIVA/TEXTOS_COMPLETOS/7_LEYES/LEYES%202026/Ley%202578%20de%202026.pdf
+      monday after 07-09 since 2026:
+        name:
+          es: La virgen de Chiquinquirá
+          en: Virgin of Chiquinquirá  
       07-20:
         _name: Independence Day
       08-07:

--- a/test/fixtures/CO-2026.json
+++ b/test/fixtures/CO-2026.json
@@ -108,6 +108,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2026-07-13 00:00:00",
+    "start": "2026-07-13T05:00:00.000Z",
+    "end": "2026-07-14T05:00:00.000Z",
+    "name": "La virgen de Chiquinquirá",
+    "type": "public",
+    "rule": "monday after 07-09 since 2026",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-07-20 00:00:00",
     "start": "2026-07-20T05:00:00.000Z",
     "end": "2026-07-21T05:00:00.000Z",

--- a/test/fixtures/CO-2027.json
+++ b/test/fixtures/CO-2027.json
@@ -108,6 +108,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2027-07-12 00:00:00",
+    "start": "2027-07-12T05:00:00.000Z",
+    "end": "2027-07-13T05:00:00.000Z",
+    "name": "La virgen de Chiquinquirá",
+    "type": "public",
+    "rule": "monday after 07-09 since 2026",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-07-20 00:00:00",
     "start": "2027-07-20T05:00:00.000Z",
     "end": "2027-07-21T05:00:00.000Z",

--- a/test/fixtures/CO-2028.json
+++ b/test/fixtures/CO-2028.json
@@ -108,6 +108,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2028-07-10 00:00:00",
+    "start": "2028-07-10T05:00:00.000Z",
+    "end": "2028-07-11T05:00:00.000Z",
+    "name": "La virgen de Chiquinquirá",
+    "type": "public",
+    "rule": "monday after 07-09 since 2026",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2028-07-20 00:00:00",
     "start": "2028-07-20T05:00:00.000Z",
     "end": "2028-07-21T05:00:00.000Z",

--- a/test/fixtures/CO-2029.json
+++ b/test/fixtures/CO-2029.json
@@ -108,6 +108,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2029-07-09 00:00:00",
+    "start": "2029-07-09T05:00:00.000Z",
+    "end": "2029-07-10T05:00:00.000Z",
+    "name": "La virgen de Chiquinquirá",
+    "type": "public",
+    "rule": "monday after 07-09 since 2026",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2029-07-20 00:00:00",
     "start": "2029-07-20T05:00:00.000Z",
     "end": "2029-07-21T05:00:00.000Z",


### PR DESCRIPTION
On June 1st, as per law 2578 of 2026. The government has declared a new holiday in honor to "La virgen de Chiquinquirá" (Virgin of Chiquinquirá) and is mandatory in all the country.

Sources:

[Official Goverment Law](https://lector.ramajudicial.gov.co/SIDN/NORMATIVA/TEXTOS_COMPLETOS/7_LEYES/LEYES%202026/Ley%202578%20de%202026.pdf)

[Portafolio newspaper](https://www.portafolio.co/economia/gobierno/se-nos-aparecio-la-virgen-colombia-tendra-nuevo-festivo-nacional-el-9-de-julio-en-honor-a-chiquinquira-495500)

[El tiempo newspaper](https://www.eltiempo.com/politica/gobierno/colombia-tendra-nuevo-festivo-en-julio-por-dia-de-la-virgen-de-chiquinquira-esto-dice-la-ley-que-sanciono-el-gobierno-3562087)

[El País newspaper](https://elpais.com/america-colombia/2026-06-04/colombia-declara-festivo-el-9-de-julio-en-homenaje-a-la-virgen-de-chiquinquira.html)

[Semana magazine](https://www.semana.com/nacion/articulo/desde-cuando-se-aplicara-el-nuevo-festivo-del-dia-de-la-virgen-de-chiquinquira-en-colombia/202631/)