### PR TITLE
feat(BR): add Espírito Santo and Goiás state holidays

### DIFF
--- a/data/countries/BR.yaml
+++ b/data/countries/BR.yaml
@@ -230,14 +230,45 @@ holidays:
             type: public
             active:
               - from: 1995-12-04
-      # ES:
-      #   name: Espírito Santo
-      #  zones:
-      #    - America/Sao_Paulo
-      # GO:
-      #   name: Goiás
-      #  zones:
-      #    - America/Sao_Paulo
+      ES:
+        name: Espírito Santo
+        # Data Magna do Estado: feriado estadual desde a Lei 11.010/2019.
+        # @attrib https://g1.globo.com/es/espirito-santo/noticia/2025/04/26/saiba-o-que-funciona-e-nao-funciona-no-feriado-de-nossa-senhora-da-penha-no-es.ghtml
+        zones:
+          - America/Sao_Paulo
+        days:
+          # "segunda-feira, oito dias depois do domingo de Páscoa"
+          easter 8:
+            name:
+              pt: Dia de Nossa Senhora da Penha
+            type: public
+            active:
+              - from: 2019-07-04
+      GO:
+        name: Goiás
+        sources:
+          - https://legisla.casacivil.go.gov.br/pesquisa_legislacao/100979/lei-20756
+        zones:
+          - America/Sao_Paulo
+        days:
+          07-26:
+            name:
+              pt: Fundação da Cidade de Goiás
+          10-24:
+            name:
+              pt: Lançamento da pedra fundamental de Goiânia
+        regions:
+          GOIANIA:
+            name: Goiânia
+            # Padroeira de Goiânia, feriado municipal pela Lei 701/1956.
+            # @source https://goias.gov.br/juceg/feriado-municipal-devido-ao-dia-de-nossa-senhora-auxiliadora-padroeira-do-municipio-de-goiania/
+            days:
+              05-24:
+                name:
+                  pt: Nossa Senhora Auxiliadora
+                type: public
+                active:
+                  - from: 1956-08-30
       MA:
         name: Maranhão
         zones:

--- a/test/fixtures/BR-ES-2015.json
+++ b/test/fixtures/BR-ES-2015.json
@@ -1,0 +1,182 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T02:00:00.000Z",
+    "end": "2015-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-14 00:00:00",
+    "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
+    "end": "2015-02-18T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T03:00:00.000Z",
+    "end": "2015-04-04T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-05 00:00:00",
+    "start": "2015-04-05T03:00:00.000Z",
+    "end": "2015-04-06T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-04-21 00:00:00",
+    "start": "2015-04-21T03:00:00.000Z",
+    "end": "2015-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T03:00:00.000Z",
+    "end": "2015-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-10T03:00:00.000Z",
+    "end": "2015-05-11T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T03:00:00.000Z",
+    "end": "2015-06-05T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-12 00:00:00",
+    "start": "2015-06-12T03:00:00.000Z",
+    "end": "2015-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-08-09 00:00:00",
+    "start": "2015-08-09T03:00:00.000Z",
+    "end": "2015-08-10T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-09-07 00:00:00",
+    "start": "2015-09-07T03:00:00.000Z",
+    "end": "2015-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-12 00:00:00",
+    "start": "2015-10-12T03:00:00.000Z",
+    "end": "2015-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T02:00:00.000Z",
+    "end": "2015-11-03T02:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-11-15 00:00:00",
+    "start": "2015-11-15T02:00:00.000Z",
+    "end": "2015-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-24 14:00:00",
+    "start": "2015-12-24T16:00:00.000Z",
+    "end": "2015-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T02:00:00.000Z",
+    "end": "2015-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-12-31 14:00:00",
+    "start": "2015-12-31T16:00:00.000Z",
+    "end": "2016-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BR-ES-2016.json
+++ b/test/fixtures/BR-ES-2016.json
@@ -1,0 +1,200 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T02:00:00.000Z",
+    "end": "2016-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
+    "end": "2016-02-10T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T03:00:00.000Z",
+    "end": "2016-03-26T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-03-27 00:00:00",
+    "start": "2016-03-27T03:00:00.000Z",
+    "end": "2016-03-28T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-04-21 00:00:00",
+    "start": "2016-04-21T03:00:00.000Z",
+    "end": "2016-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T03:00:00.000Z",
+    "end": "2016-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-08T03:00:00.000Z",
+    "end": "2016-05-09T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T03:00:00.000Z",
+    "end": "2016-05-27T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-06-12 00:00:00",
+    "start": "2016-06-12T03:00:00.000Z",
+    "end": "2016-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-08-14 00:00:00",
+    "start": "2016-08-14T03:00:00.000Z",
+    "end": "2016-08-15T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-09-07 00:00:00",
+    "start": "2016-09-07T03:00:00.000Z",
+    "end": "2016-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-02 00:00:00",
+    "start": "2016-10-02T03:00:00.000Z",
+    "end": "2016-10-03T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-10-12 00:00:00",
+    "start": "2016-10-12T03:00:00.000Z",
+    "end": "2016-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-30 00:00:00",
+    "start": "2016-10-30T02:00:00.000Z",
+    "end": "2016-10-31T02:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T02:00:00.000Z",
+    "end": "2016-11-03T02:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-11-15 00:00:00",
+    "start": "2016-11-15T02:00:00.000Z",
+    "end": "2016-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-12-24 14:00:00",
+    "start": "2016-12-24T16:00:00.000Z",
+    "end": "2016-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T02:00:00.000Z",
+    "end": "2016-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-31 14:00:00",
+    "start": "2016-12-31T16:00:00.000Z",
+    "end": "2017-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BR-ES-2017.json
+++ b/test/fixtures/BR-ES-2017.json
@@ -1,0 +1,182 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T02:00:00.000Z",
+    "end": "2017-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-02-25 00:00:00",
+    "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
+    "end": "2017-03-01T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T03:00:00.000Z",
+    "end": "2017-04-15T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-04-16 00:00:00",
+    "start": "2017-04-16T03:00:00.000Z",
+    "end": "2017-04-17T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-04-21 00:00:00",
+    "start": "2017-04-21T03:00:00.000Z",
+    "end": "2017-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T03:00:00.000Z",
+    "end": "2017-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-14T03:00:00.000Z",
+    "end": "2017-05-15T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-06-12 00:00:00",
+    "start": "2017-06-12T03:00:00.000Z",
+    "end": "2017-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T03:00:00.000Z",
+    "end": "2017-06-16T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-08-13 00:00:00",
+    "start": "2017-08-13T03:00:00.000Z",
+    "end": "2017-08-14T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-09-07 00:00:00",
+    "start": "2017-09-07T03:00:00.000Z",
+    "end": "2017-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-12 00:00:00",
+    "start": "2017-10-12T03:00:00.000Z",
+    "end": "2017-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T02:00:00.000Z",
+    "end": "2017-11-03T02:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-11-15 00:00:00",
+    "start": "2017-11-15T02:00:00.000Z",
+    "end": "2017-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-12-24 14:00:00",
+    "start": "2017-12-24T16:00:00.000Z",
+    "end": "2017-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T02:00:00.000Z",
+    "end": "2017-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-12-31 14:00:00",
+    "start": "2017-12-31T16:00:00.000Z",
+    "end": "2018-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/BR-ES-2018.json
+++ b/test/fixtures/BR-ES-2018.json
@@ -1,0 +1,200 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T02:00:00.000Z",
+    "end": "2018-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-10 00:00:00",
+    "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
+    "end": "2018-02-14T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T03:00:00.000Z",
+    "end": "2018-03-31T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-01 00:00:00",
+    "start": "2018-04-01T03:00:00.000Z",
+    "end": "2018-04-02T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-04-21 00:00:00",
+    "start": "2018-04-21T03:00:00.000Z",
+    "end": "2018-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T03:00:00.000Z",
+    "end": "2018-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-13T03:00:00.000Z",
+    "end": "2018-05-14T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T03:00:00.000Z",
+    "end": "2018-06-01T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-12 00:00:00",
+    "start": "2018-06-12T03:00:00.000Z",
+    "end": "2018-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-08-12 00:00:00",
+    "start": "2018-08-12T03:00:00.000Z",
+    "end": "2018-08-13T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-09-07 00:00:00",
+    "start": "2018-09-07T03:00:00.000Z",
+    "end": "2018-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-07 00:00:00",
+    "start": "2018-10-07T03:00:00.000Z",
+    "end": "2018-10-08T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-10-12 00:00:00",
+    "start": "2018-10-12T03:00:00.000Z",
+    "end": "2018-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-28 00:00:00",
+    "start": "2018-10-28T03:00:00.000Z",
+    "end": "2018-10-29T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T03:00:00.000Z",
+    "end": "2018-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-11-15 00:00:00",
+    "start": "2018-11-15T02:00:00.000Z",
+    "end": "2018-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-12-24 14:00:00",
+    "start": "2018-12-24T16:00:00.000Z",
+    "end": "2018-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T02:00:00.000Z",
+    "end": "2018-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-12-31 14:00:00",
+    "start": "2018-12-31T16:00:00.000Z",
+    "end": "2019-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BR-ES-2019.json
+++ b/test/fixtures/BR-ES-2019.json
@@ -1,0 +1,182 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T02:00:00.000Z",
+    "end": "2019-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-02 00:00:00",
+    "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
+    "end": "2019-03-06T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T03:00:00.000Z",
+    "end": "2019-04-20T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-21 00:00:00",
+    "start": "2019-04-21T03:00:00.000Z",
+    "end": "2019-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-04-21 00:00:00",
+    "start": "2019-04-21T03:00:00.000Z",
+    "end": "2019-04-22T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T03:00:00.000Z",
+    "end": "2019-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-12T03:00:00.000Z",
+    "end": "2019-05-13T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-06-12 00:00:00",
+    "start": "2019-06-12T03:00:00.000Z",
+    "end": "2019-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T03:00:00.000Z",
+    "end": "2019-06-21T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-08-11 00:00:00",
+    "start": "2019-08-11T03:00:00.000Z",
+    "end": "2019-08-12T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-09-07 00:00:00",
+    "start": "2019-09-07T03:00:00.000Z",
+    "end": "2019-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-12 00:00:00",
+    "start": "2019-10-12T03:00:00.000Z",
+    "end": "2019-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T03:00:00.000Z",
+    "end": "2019-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-11-15 00:00:00",
+    "start": "2019-11-15T03:00:00.000Z",
+    "end": "2019-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-12-24 14:00:00",
+    "start": "2019-12-24T17:00:00.000Z",
+    "end": "2019-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T03:00:00.000Z",
+    "end": "2019-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-12-31 14:00:00",
+    "start": "2019-12-31T17:00:00.000Z",
+    "end": "2020-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BR-ES-2020.json
+++ b/test/fixtures/BR-ES-2020.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T03:00:00.000Z",
+    "end": "2020-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-22 00:00:00",
+    "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
+    "end": "2020-02-26T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T03:00:00.000Z",
+    "end": "2020-04-11T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T03:00:00.000Z",
+    "end": "2020-04-13T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-04-20 00:00:00",
+    "start": "2020-04-20T03:00:00.000Z",
+    "end": "2020-04-21T03:00:00.000Z",
+    "name": "Dia de Nossa Senhora da Penha",
+    "type": "public",
+    "rule": "easter 8",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-21 00:00:00",
+    "start": "2020-04-21T03:00:00.000Z",
+    "end": "2020-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T03:00:00.000Z",
+    "end": "2020-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-10T03:00:00.000Z",
+    "end": "2020-05-11T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T03:00:00.000Z",
+    "end": "2020-06-12T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-12 00:00:00",
+    "start": "2020-06-12T03:00:00.000Z",
+    "end": "2020-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-08-09 00:00:00",
+    "start": "2020-08-09T03:00:00.000Z",
+    "end": "2020-08-10T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-09-07 00:00:00",
+    "start": "2020-09-07T03:00:00.000Z",
+    "end": "2020-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-04 00:00:00",
+    "start": "2020-10-04T03:00:00.000Z",
+    "end": "2020-10-05T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-10-12 00:00:00",
+    "start": "2020-10-12T03:00:00.000Z",
+    "end": "2020-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-25 00:00:00",
+    "start": "2020-10-25T03:00:00.000Z",
+    "end": "2020-10-26T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T03:00:00.000Z",
+    "end": "2020-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-11-15 00:00:00",
+    "start": "2020-11-15T03:00:00.000Z",
+    "end": "2020-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-24 14:00:00",
+    "start": "2020-12-24T17:00:00.000Z",
+    "end": "2020-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T03:00:00.000Z",
+    "end": "2020-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-12-31 14:00:00",
+    "start": "2020-12-31T17:00:00.000Z",
+    "end": "2021-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BR-ES-2021.json
+++ b/test/fixtures/BR-ES-2021.json
@@ -1,0 +1,191 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T03:00:00.000Z",
+    "end": "2021-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-13 00:00:00",
+    "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
+    "end": "2021-02-17T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T03:00:00.000Z",
+    "end": "2021-04-03T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-04 00:00:00",
+    "start": "2021-04-04T03:00:00.000Z",
+    "end": "2021-04-05T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-04-12 00:00:00",
+    "start": "2021-04-12T03:00:00.000Z",
+    "end": "2021-04-13T03:00:00.000Z",
+    "name": "Dia de Nossa Senhora da Penha",
+    "type": "public",
+    "rule": "easter 8",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-04-21 00:00:00",
+    "start": "2021-04-21T03:00:00.000Z",
+    "end": "2021-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T03:00:00.000Z",
+    "end": "2021-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-09T03:00:00.000Z",
+    "end": "2021-05-10T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T03:00:00.000Z",
+    "end": "2021-06-04T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-12 00:00:00",
+    "start": "2021-06-12T03:00:00.000Z",
+    "end": "2021-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-08-08 00:00:00",
+    "start": "2021-08-08T03:00:00.000Z",
+    "end": "2021-08-09T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-09-07 00:00:00",
+    "start": "2021-09-07T03:00:00.000Z",
+    "end": "2021-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-12 00:00:00",
+    "start": "2021-10-12T03:00:00.000Z",
+    "end": "2021-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T03:00:00.000Z",
+    "end": "2021-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-11-15 00:00:00",
+    "start": "2021-11-15T03:00:00.000Z",
+    "end": "2021-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-12-24 14:00:00",
+    "start": "2021-12-24T17:00:00.000Z",
+    "end": "2021-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T03:00:00.000Z",
+    "end": "2021-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-12-31 14:00:00",
+    "start": "2021-12-31T17:00:00.000Z",
+    "end": "2022-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BR-ES-2022.json
+++ b/test/fixtures/BR-ES-2022.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T03:00:00.000Z",
+    "end": "2022-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-26 00:00:00",
+    "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
+    "end": "2022-03-02T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T03:00:00.000Z",
+    "end": "2022-04-16T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-04-17 00:00:00",
+    "start": "2022-04-17T03:00:00.000Z",
+    "end": "2022-04-18T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-04-21 00:00:00",
+    "start": "2022-04-21T03:00:00.000Z",
+    "end": "2022-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-04-25 00:00:00",
+    "start": "2022-04-25T03:00:00.000Z",
+    "end": "2022-04-26T03:00:00.000Z",
+    "name": "Dia de Nossa Senhora da Penha",
+    "type": "public",
+    "rule": "easter 8",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T03:00:00.000Z",
+    "end": "2022-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-08T03:00:00.000Z",
+    "end": "2022-05-09T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-06-12 00:00:00",
+    "start": "2022-06-12T03:00:00.000Z",
+    "end": "2022-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T03:00:00.000Z",
+    "end": "2022-06-17T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-08-14 00:00:00",
+    "start": "2022-08-14T03:00:00.000Z",
+    "end": "2022-08-15T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-09-07 00:00:00",
+    "start": "2022-09-07T03:00:00.000Z",
+    "end": "2022-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-02 00:00:00",
+    "start": "2022-10-02T03:00:00.000Z",
+    "end": "2022-10-03T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-10-12 00:00:00",
+    "start": "2022-10-12T03:00:00.000Z",
+    "end": "2022-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-30 00:00:00",
+    "start": "2022-10-30T03:00:00.000Z",
+    "end": "2022-10-31T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T03:00:00.000Z",
+    "end": "2022-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-11-15 00:00:00",
+    "start": "2022-11-15T03:00:00.000Z",
+    "end": "2022-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-12-24 14:00:00",
+    "start": "2022-12-24T17:00:00.000Z",
+    "end": "2022-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T03:00:00.000Z",
+    "end": "2022-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-31 14:00:00",
+    "start": "2022-12-31T17:00:00.000Z",
+    "end": "2023-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BR-ES-2023.json
+++ b/test/fixtures/BR-ES-2023.json
@@ -1,0 +1,191 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T03:00:00.000Z",
+    "end": "2023-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-02-18 00:00:00",
+    "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
+    "end": "2023-02-22T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T03:00:00.000Z",
+    "end": "2023-04-08T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-09 00:00:00",
+    "start": "2023-04-09T03:00:00.000Z",
+    "end": "2023-04-10T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-04-17 00:00:00",
+    "start": "2023-04-17T03:00:00.000Z",
+    "end": "2023-04-18T03:00:00.000Z",
+    "name": "Dia de Nossa Senhora da Penha",
+    "type": "public",
+    "rule": "easter 8",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-04-21 00:00:00",
+    "start": "2023-04-21T03:00:00.000Z",
+    "end": "2023-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T03:00:00.000Z",
+    "end": "2023-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-14T03:00:00.000Z",
+    "end": "2023-05-15T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T03:00:00.000Z",
+    "end": "2023-06-09T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-12 00:00:00",
+    "start": "2023-06-12T03:00:00.000Z",
+    "end": "2023-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-08-13 00:00:00",
+    "start": "2023-08-13T03:00:00.000Z",
+    "end": "2023-08-14T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-09-07 00:00:00",
+    "start": "2023-09-07T03:00:00.000Z",
+    "end": "2023-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-12 00:00:00",
+    "start": "2023-10-12T03:00:00.000Z",
+    "end": "2023-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T03:00:00.000Z",
+    "end": "2023-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-11-15 00:00:00",
+    "start": "2023-11-15T03:00:00.000Z",
+    "end": "2023-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-12-24 14:00:00",
+    "start": "2023-12-24T17:00:00.000Z",
+    "end": "2023-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T03:00:00.000Z",
+    "end": "2023-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-12-31 14:00:00",
+    "start": "2023-12-31T17:00:00.000Z",
+    "end": "2024-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/BR-ES-2024.json
+++ b/test/fixtures/BR-ES-2024.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T03:00:00.000Z",
+    "end": "2024-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-10 00:00:00",
+    "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
+    "end": "2024-02-14T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T03:00:00.000Z",
+    "end": "2024-03-30T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-03-31 00:00:00",
+    "start": "2024-03-31T03:00:00.000Z",
+    "end": "2024-04-01T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-04-08 00:00:00",
+    "start": "2024-04-08T03:00:00.000Z",
+    "end": "2024-04-09T03:00:00.000Z",
+    "name": "Dia de Nossa Senhora da Penha",
+    "type": "public",
+    "rule": "easter 8",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-04-21 00:00:00",
+    "start": "2024-04-21T03:00:00.000Z",
+    "end": "2024-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T03:00:00.000Z",
+    "end": "2024-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-12T03:00:00.000Z",
+    "end": "2024-05-13T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T03:00:00.000Z",
+    "end": "2024-05-31T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-12 00:00:00",
+    "start": "2024-06-12T03:00:00.000Z",
+    "end": "2024-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-08-11 00:00:00",
+    "start": "2024-08-11T03:00:00.000Z",
+    "end": "2024-08-12T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-09-07 00:00:00",
+    "start": "2024-09-07T03:00:00.000Z",
+    "end": "2024-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-06 00:00:00",
+    "start": "2024-10-06T03:00:00.000Z",
+    "end": "2024-10-07T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-10-12 00:00:00",
+    "start": "2024-10-12T03:00:00.000Z",
+    "end": "2024-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-27 00:00:00",
+    "start": "2024-10-27T03:00:00.000Z",
+    "end": "2024-10-28T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T03:00:00.000Z",
+    "end": "2024-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-11-15 00:00:00",
+    "start": "2024-11-15T03:00:00.000Z",
+    "end": "2024-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-20 00:00:00",
+    "start": "2024-11-20T03:00:00.000Z",
+    "end": "2024-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-12-24 14:00:00",
+    "start": "2024-12-24T17:00:00.000Z",
+    "end": "2024-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T03:00:00.000Z",
+    "end": "2024-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-12-31 14:00:00",
+    "start": "2024-12-31T17:00:00.000Z",
+    "end": "2025-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BR-ES-2025.json
+++ b/test/fixtures/BR-ES-2025.json
@@ -1,0 +1,200 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T03:00:00.000Z",
+    "end": "2025-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-01 00:00:00",
+    "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
+    "end": "2025-03-05T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T03:00:00.000Z",
+    "end": "2025-04-19T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-04-20 00:00:00",
+    "start": "2025-04-20T03:00:00.000Z",
+    "end": "2025-04-21T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-21 00:00:00",
+    "start": "2025-04-21T03:00:00.000Z",
+    "end": "2025-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-04-28 00:00:00",
+    "start": "2025-04-28T03:00:00.000Z",
+    "end": "2025-04-29T03:00:00.000Z",
+    "name": "Dia de Nossa Senhora da Penha",
+    "type": "public",
+    "rule": "easter 8",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T03:00:00.000Z",
+    "end": "2025-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-11T03:00:00.000Z",
+    "end": "2025-05-12T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-06-12 00:00:00",
+    "start": "2025-06-12T03:00:00.000Z",
+    "end": "2025-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T03:00:00.000Z",
+    "end": "2025-06-20T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-08-10 00:00:00",
+    "start": "2025-08-10T03:00:00.000Z",
+    "end": "2025-08-11T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-07T03:00:00.000Z",
+    "end": "2025-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-12 00:00:00",
+    "start": "2025-10-12T03:00:00.000Z",
+    "end": "2025-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T03:00:00.000Z",
+    "end": "2025-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-11-15 00:00:00",
+    "start": "2025-11-15T03:00:00.000Z",
+    "end": "2025-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-20 00:00:00",
+    "start": "2025-11-20T03:00:00.000Z",
+    "end": "2025-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-12-24 14:00:00",
+    "start": "2025-12-24T17:00:00.000Z",
+    "end": "2025-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T03:00:00.000Z",
+    "end": "2025-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-12-31 14:00:00",
+    "start": "2025-12-31T17:00:00.000Z",
+    "end": "2026-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BR-ES-2026.json
+++ b/test/fixtures/BR-ES-2026.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T03:00:00.000Z",
+    "end": "2026-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-14 00:00:00",
+    "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
+    "end": "2026-02-18T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T03:00:00.000Z",
+    "end": "2026-04-04T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-05 00:00:00",
+    "start": "2026-04-05T03:00:00.000Z",
+    "end": "2026-04-06T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-04-13 00:00:00",
+    "start": "2026-04-13T03:00:00.000Z",
+    "end": "2026-04-14T03:00:00.000Z",
+    "name": "Dia de Nossa Senhora da Penha",
+    "type": "public",
+    "rule": "easter 8",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-21 00:00:00",
+    "start": "2026-04-21T03:00:00.000Z",
+    "end": "2026-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T03:00:00.000Z",
+    "end": "2026-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-10 00:00:00",
+    "start": "2026-05-10T03:00:00.000Z",
+    "end": "2026-05-11T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T03:00:00.000Z",
+    "end": "2026-06-05T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-12 00:00:00",
+    "start": "2026-06-12T03:00:00.000Z",
+    "end": "2026-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-08-09 00:00:00",
+    "start": "2026-08-09T03:00:00.000Z",
+    "end": "2026-08-10T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-09-07 00:00:00",
+    "start": "2026-09-07T03:00:00.000Z",
+    "end": "2026-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-04 00:00:00",
+    "start": "2026-10-04T03:00:00.000Z",
+    "end": "2026-10-05T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-10-12 00:00:00",
+    "start": "2026-10-12T03:00:00.000Z",
+    "end": "2026-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-25 00:00:00",
+    "start": "2026-10-25T03:00:00.000Z",
+    "end": "2026-10-26T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T03:00:00.000Z",
+    "end": "2026-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-11-15 00:00:00",
+    "start": "2026-11-15T03:00:00.000Z",
+    "end": "2026-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-20 00:00:00",
+    "start": "2026-11-20T03:00:00.000Z",
+    "end": "2026-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-12-24 14:00:00",
+    "start": "2026-12-24T17:00:00.000Z",
+    "end": "2026-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T03:00:00.000Z",
+    "end": "2026-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-12-31 14:00:00",
+    "start": "2026-12-31T17:00:00.000Z",
+    "end": "2027-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BR-ES-2027.json
+++ b/test/fixtures/BR-ES-2027.json
@@ -1,0 +1,200 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T03:00:00.000Z",
+    "end": "2027-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-06 00:00:00",
+    "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
+    "end": "2027-02-10T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T03:00:00.000Z",
+    "end": "2027-03-27T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-28 00:00:00",
+    "start": "2027-03-28T03:00:00.000Z",
+    "end": "2027-03-29T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-04-05 00:00:00",
+    "start": "2027-04-05T03:00:00.000Z",
+    "end": "2027-04-06T03:00:00.000Z",
+    "name": "Dia de Nossa Senhora da Penha",
+    "type": "public",
+    "rule": "easter 8",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-04-21 00:00:00",
+    "start": "2027-04-21T03:00:00.000Z",
+    "end": "2027-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T03:00:00.000Z",
+    "end": "2027-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-09 00:00:00",
+    "start": "2027-05-09T03:00:00.000Z",
+    "end": "2027-05-10T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T03:00:00.000Z",
+    "end": "2027-05-28T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-12 00:00:00",
+    "start": "2027-06-12T03:00:00.000Z",
+    "end": "2027-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-08-08 00:00:00",
+    "start": "2027-08-08T03:00:00.000Z",
+    "end": "2027-08-09T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-09-07 00:00:00",
+    "start": "2027-09-07T03:00:00.000Z",
+    "end": "2027-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-12 00:00:00",
+    "start": "2027-10-12T03:00:00.000Z",
+    "end": "2027-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T03:00:00.000Z",
+    "end": "2027-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-11-15 00:00:00",
+    "start": "2027-11-15T03:00:00.000Z",
+    "end": "2027-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-20 00:00:00",
+    "start": "2027-11-20T03:00:00.000Z",
+    "end": "2027-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-24 14:00:00",
+    "start": "2027-12-24T17:00:00.000Z",
+    "end": "2027-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T03:00:00.000Z",
+    "end": "2027-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-31 14:00:00",
+    "start": "2027-12-31T17:00:00.000Z",
+    "end": "2028-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BR-ES-2028.json
+++ b/test/fixtures/BR-ES-2028.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2028-01-01 00:00:00",
+    "start": "2028-01-01T03:00:00.000Z",
+    "end": "2028-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-26 00:00:00",
+    "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
+    "end": "2028-03-01T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-04-14 00:00:00",
+    "start": "2028-04-14T03:00:00.000Z",
+    "end": "2028-04-15T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2028-04-16 00:00:00",
+    "start": "2028-04-16T03:00:00.000Z",
+    "end": "2028-04-17T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-04-21 00:00:00",
+    "start": "2028-04-21T03:00:00.000Z",
+    "end": "2028-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2028-04-24 00:00:00",
+    "start": "2028-04-24T03:00:00.000Z",
+    "end": "2028-04-25T03:00:00.000Z",
+    "name": "Dia de Nossa Senhora da Penha",
+    "type": "public",
+    "rule": "easter 8",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-05-01 00:00:00",
+    "start": "2028-05-01T03:00:00.000Z",
+    "end": "2028-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-05-14 00:00:00",
+    "start": "2028-05-14T03:00:00.000Z",
+    "end": "2028-05-15T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-06-12 00:00:00",
+    "start": "2028-06-12T03:00:00.000Z",
+    "end": "2028-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-06-15 00:00:00",
+    "start": "2028-06-15T03:00:00.000Z",
+    "end": "2028-06-16T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-08-13 00:00:00",
+    "start": "2028-08-13T03:00:00.000Z",
+    "end": "2028-08-14T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-09-07 00:00:00",
+    "start": "2028-09-07T03:00:00.000Z",
+    "end": "2028-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-10-01 00:00:00",
+    "start": "2028-10-01T03:00:00.000Z",
+    "end": "2028-10-02T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-10-12 00:00:00",
+    "start": "2028-10-12T03:00:00.000Z",
+    "end": "2028-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-10-29 00:00:00",
+    "start": "2028-10-29T03:00:00.000Z",
+    "end": "2028-10-30T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-11-02 00:00:00",
+    "start": "2028-11-02T03:00:00.000Z",
+    "end": "2028-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-11-15 00:00:00",
+    "start": "2028-11-15T03:00:00.000Z",
+    "end": "2028-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-11-20 00:00:00",
+    "start": "2028-11-20T03:00:00.000Z",
+    "end": "2028-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-12-24 14:00:00",
+    "start": "2028-12-24T17:00:00.000Z",
+    "end": "2028-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-12-25 00:00:00",
+    "start": "2028-12-25T03:00:00.000Z",
+    "end": "2028-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-12-31 14:00:00",
+    "start": "2028-12-31T17:00:00.000Z",
+    "end": "2029-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/BR-ES-2029.json
+++ b/test/fixtures/BR-ES-2029.json
@@ -1,0 +1,200 @@
+[
+  {
+    "date": "2029-01-01 00:00:00",
+    "start": "2029-01-01T03:00:00.000Z",
+    "end": "2029-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-10 00:00:00",
+    "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
+    "end": "2029-02-14T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2029-03-30 00:00:00",
+    "start": "2029-03-30T03:00:00.000Z",
+    "end": "2029-03-31T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-04-01 00:00:00",
+    "start": "2029-04-01T03:00:00.000Z",
+    "end": "2029-04-02T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-04-09 00:00:00",
+    "start": "2029-04-09T03:00:00.000Z",
+    "end": "2029-04-10T03:00:00.000Z",
+    "name": "Dia de Nossa Senhora da Penha",
+    "type": "public",
+    "rule": "easter 8",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-04-21 00:00:00",
+    "start": "2029-04-21T03:00:00.000Z",
+    "end": "2029-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-05-01 00:00:00",
+    "start": "2029-05-01T03:00:00.000Z",
+    "end": "2029-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-05-13 00:00:00",
+    "start": "2029-05-13T03:00:00.000Z",
+    "end": "2029-05-14T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-05-31 00:00:00",
+    "start": "2029-05-31T03:00:00.000Z",
+    "end": "2029-06-01T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-06-12 00:00:00",
+    "start": "2029-06-12T03:00:00.000Z",
+    "end": "2029-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-08-12 00:00:00",
+    "start": "2029-08-12T03:00:00.000Z",
+    "end": "2029-08-13T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-09-07 00:00:00",
+    "start": "2029-09-07T03:00:00.000Z",
+    "end": "2029-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-10-12 00:00:00",
+    "start": "2029-10-12T03:00:00.000Z",
+    "end": "2029-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-11-02 00:00:00",
+    "start": "2029-11-02T03:00:00.000Z",
+    "end": "2029-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-11-15 00:00:00",
+    "start": "2029-11-15T03:00:00.000Z",
+    "end": "2029-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-11-20 00:00:00",
+    "start": "2029-11-20T03:00:00.000Z",
+    "end": "2029-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-12-24 14:00:00",
+    "start": "2029-12-24T17:00:00.000Z",
+    "end": "2029-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-12-25 00:00:00",
+    "start": "2029-12-25T03:00:00.000Z",
+    "end": "2029-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-12-31 14:00:00",
+    "start": "2029-12-31T17:00:00.000Z",
+    "end": "2030-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BR-GO-2015.json
+++ b/test/fixtures/BR-GO-2015.json
@@ -1,0 +1,200 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T02:00:00.000Z",
+    "end": "2015-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-14 00:00:00",
+    "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
+    "end": "2015-02-18T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T03:00:00.000Z",
+    "end": "2015-04-04T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-05 00:00:00",
+    "start": "2015-04-05T03:00:00.000Z",
+    "end": "2015-04-06T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-04-21 00:00:00",
+    "start": "2015-04-21T03:00:00.000Z",
+    "end": "2015-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T03:00:00.000Z",
+    "end": "2015-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-10T03:00:00.000Z",
+    "end": "2015-05-11T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T03:00:00.000Z",
+    "end": "2015-06-05T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-12 00:00:00",
+    "start": "2015-06-12T03:00:00.000Z",
+    "end": "2015-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-07-26 00:00:00",
+    "start": "2015-07-26T03:00:00.000Z",
+    "end": "2015-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-08-09 00:00:00",
+    "start": "2015-08-09T03:00:00.000Z",
+    "end": "2015-08-10T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-09-07 00:00:00",
+    "start": "2015-09-07T03:00:00.000Z",
+    "end": "2015-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-12 00:00:00",
+    "start": "2015-10-12T03:00:00.000Z",
+    "end": "2015-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-24 00:00:00",
+    "start": "2015-10-24T02:00:00.000Z",
+    "end": "2015-10-25T02:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T02:00:00.000Z",
+    "end": "2015-11-03T02:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-11-15 00:00:00",
+    "start": "2015-11-15T02:00:00.000Z",
+    "end": "2015-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-24 14:00:00",
+    "start": "2015-12-24T16:00:00.000Z",
+    "end": "2015-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T02:00:00.000Z",
+    "end": "2015-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-12-31 14:00:00",
+    "start": "2015-12-31T16:00:00.000Z",
+    "end": "2016-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BR-GO-2016.json
+++ b/test/fixtures/BR-GO-2016.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T02:00:00.000Z",
+    "end": "2016-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
+    "end": "2016-02-10T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T03:00:00.000Z",
+    "end": "2016-03-26T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-03-27 00:00:00",
+    "start": "2016-03-27T03:00:00.000Z",
+    "end": "2016-03-28T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-04-21 00:00:00",
+    "start": "2016-04-21T03:00:00.000Z",
+    "end": "2016-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T03:00:00.000Z",
+    "end": "2016-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-08T03:00:00.000Z",
+    "end": "2016-05-09T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T03:00:00.000Z",
+    "end": "2016-05-27T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-06-12 00:00:00",
+    "start": "2016-06-12T03:00:00.000Z",
+    "end": "2016-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-07-26 00:00:00",
+    "start": "2016-07-26T03:00:00.000Z",
+    "end": "2016-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-08-14 00:00:00",
+    "start": "2016-08-14T03:00:00.000Z",
+    "end": "2016-08-15T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-09-07 00:00:00",
+    "start": "2016-09-07T03:00:00.000Z",
+    "end": "2016-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-02 00:00:00",
+    "start": "2016-10-02T03:00:00.000Z",
+    "end": "2016-10-03T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-10-12 00:00:00",
+    "start": "2016-10-12T03:00:00.000Z",
+    "end": "2016-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-24 00:00:00",
+    "start": "2016-10-24T02:00:00.000Z",
+    "end": "2016-10-25T02:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-10-30 00:00:00",
+    "start": "2016-10-30T02:00:00.000Z",
+    "end": "2016-10-31T02:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T02:00:00.000Z",
+    "end": "2016-11-03T02:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-11-15 00:00:00",
+    "start": "2016-11-15T02:00:00.000Z",
+    "end": "2016-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-12-24 14:00:00",
+    "start": "2016-12-24T16:00:00.000Z",
+    "end": "2016-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T02:00:00.000Z",
+    "end": "2016-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-31 14:00:00",
+    "start": "2016-12-31T16:00:00.000Z",
+    "end": "2017-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BR-GO-2017.json
+++ b/test/fixtures/BR-GO-2017.json
@@ -1,0 +1,200 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T02:00:00.000Z",
+    "end": "2017-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-02-25 00:00:00",
+    "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
+    "end": "2017-03-01T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T03:00:00.000Z",
+    "end": "2017-04-15T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-04-16 00:00:00",
+    "start": "2017-04-16T03:00:00.000Z",
+    "end": "2017-04-17T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-04-21 00:00:00",
+    "start": "2017-04-21T03:00:00.000Z",
+    "end": "2017-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T03:00:00.000Z",
+    "end": "2017-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-14T03:00:00.000Z",
+    "end": "2017-05-15T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-06-12 00:00:00",
+    "start": "2017-06-12T03:00:00.000Z",
+    "end": "2017-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T03:00:00.000Z",
+    "end": "2017-06-16T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-07-26 00:00:00",
+    "start": "2017-07-26T03:00:00.000Z",
+    "end": "2017-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-08-13 00:00:00",
+    "start": "2017-08-13T03:00:00.000Z",
+    "end": "2017-08-14T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-09-07 00:00:00",
+    "start": "2017-09-07T03:00:00.000Z",
+    "end": "2017-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-12 00:00:00",
+    "start": "2017-10-12T03:00:00.000Z",
+    "end": "2017-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-24 00:00:00",
+    "start": "2017-10-24T02:00:00.000Z",
+    "end": "2017-10-25T02:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T02:00:00.000Z",
+    "end": "2017-11-03T02:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-11-15 00:00:00",
+    "start": "2017-11-15T02:00:00.000Z",
+    "end": "2017-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-12-24 14:00:00",
+    "start": "2017-12-24T16:00:00.000Z",
+    "end": "2017-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T02:00:00.000Z",
+    "end": "2017-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-12-31 14:00:00",
+    "start": "2017-12-31T16:00:00.000Z",
+    "end": "2018-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/BR-GO-2018.json
+++ b/test/fixtures/BR-GO-2018.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T02:00:00.000Z",
+    "end": "2018-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-10 00:00:00",
+    "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
+    "end": "2018-02-14T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T03:00:00.000Z",
+    "end": "2018-03-31T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-01 00:00:00",
+    "start": "2018-04-01T03:00:00.000Z",
+    "end": "2018-04-02T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-04-21 00:00:00",
+    "start": "2018-04-21T03:00:00.000Z",
+    "end": "2018-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T03:00:00.000Z",
+    "end": "2018-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-13T03:00:00.000Z",
+    "end": "2018-05-14T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T03:00:00.000Z",
+    "end": "2018-06-01T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-12 00:00:00",
+    "start": "2018-06-12T03:00:00.000Z",
+    "end": "2018-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-07-26 00:00:00",
+    "start": "2018-07-26T03:00:00.000Z",
+    "end": "2018-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-08-12 00:00:00",
+    "start": "2018-08-12T03:00:00.000Z",
+    "end": "2018-08-13T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-09-07 00:00:00",
+    "start": "2018-09-07T03:00:00.000Z",
+    "end": "2018-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-07 00:00:00",
+    "start": "2018-10-07T03:00:00.000Z",
+    "end": "2018-10-08T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-10-12 00:00:00",
+    "start": "2018-10-12T03:00:00.000Z",
+    "end": "2018-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-24 00:00:00",
+    "start": "2018-10-24T03:00:00.000Z",
+    "end": "2018-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-10-28 00:00:00",
+    "start": "2018-10-28T03:00:00.000Z",
+    "end": "2018-10-29T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T03:00:00.000Z",
+    "end": "2018-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-11-15 00:00:00",
+    "start": "2018-11-15T02:00:00.000Z",
+    "end": "2018-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-12-24 14:00:00",
+    "start": "2018-12-24T16:00:00.000Z",
+    "end": "2018-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T02:00:00.000Z",
+    "end": "2018-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-12-31 14:00:00",
+    "start": "2018-12-31T16:00:00.000Z",
+    "end": "2019-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BR-GO-2019.json
+++ b/test/fixtures/BR-GO-2019.json
@@ -1,0 +1,200 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T02:00:00.000Z",
+    "end": "2019-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-02 00:00:00",
+    "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
+    "end": "2019-03-06T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T03:00:00.000Z",
+    "end": "2019-04-20T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-21 00:00:00",
+    "start": "2019-04-21T03:00:00.000Z",
+    "end": "2019-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-04-21 00:00:00",
+    "start": "2019-04-21T03:00:00.000Z",
+    "end": "2019-04-22T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T03:00:00.000Z",
+    "end": "2019-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-12T03:00:00.000Z",
+    "end": "2019-05-13T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-06-12 00:00:00",
+    "start": "2019-06-12T03:00:00.000Z",
+    "end": "2019-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T03:00:00.000Z",
+    "end": "2019-06-21T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-07-26 00:00:00",
+    "start": "2019-07-26T03:00:00.000Z",
+    "end": "2019-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-08-11 00:00:00",
+    "start": "2019-08-11T03:00:00.000Z",
+    "end": "2019-08-12T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-09-07 00:00:00",
+    "start": "2019-09-07T03:00:00.000Z",
+    "end": "2019-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-12 00:00:00",
+    "start": "2019-10-12T03:00:00.000Z",
+    "end": "2019-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-24 00:00:00",
+    "start": "2019-10-24T03:00:00.000Z",
+    "end": "2019-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T03:00:00.000Z",
+    "end": "2019-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-11-15 00:00:00",
+    "start": "2019-11-15T03:00:00.000Z",
+    "end": "2019-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-12-24 14:00:00",
+    "start": "2019-12-24T17:00:00.000Z",
+    "end": "2019-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T03:00:00.000Z",
+    "end": "2019-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-12-31 14:00:00",
+    "start": "2019-12-31T17:00:00.000Z",
+    "end": "2020-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BR-GO-2020.json
+++ b/test/fixtures/BR-GO-2020.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T03:00:00.000Z",
+    "end": "2020-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-22 00:00:00",
+    "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
+    "end": "2020-02-26T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T03:00:00.000Z",
+    "end": "2020-04-11T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T03:00:00.000Z",
+    "end": "2020-04-13T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-04-21 00:00:00",
+    "start": "2020-04-21T03:00:00.000Z",
+    "end": "2020-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T03:00:00.000Z",
+    "end": "2020-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-10T03:00:00.000Z",
+    "end": "2020-05-11T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T03:00:00.000Z",
+    "end": "2020-06-12T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-12 00:00:00",
+    "start": "2020-06-12T03:00:00.000Z",
+    "end": "2020-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-07-26 00:00:00",
+    "start": "2020-07-26T03:00:00.000Z",
+    "end": "2020-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-08-09 00:00:00",
+    "start": "2020-08-09T03:00:00.000Z",
+    "end": "2020-08-10T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-09-07 00:00:00",
+    "start": "2020-09-07T03:00:00.000Z",
+    "end": "2020-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-04 00:00:00",
+    "start": "2020-10-04T03:00:00.000Z",
+    "end": "2020-10-05T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-10-12 00:00:00",
+    "start": "2020-10-12T03:00:00.000Z",
+    "end": "2020-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-24 00:00:00",
+    "start": "2020-10-24T03:00:00.000Z",
+    "end": "2020-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-10-25 00:00:00",
+    "start": "2020-10-25T03:00:00.000Z",
+    "end": "2020-10-26T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T03:00:00.000Z",
+    "end": "2020-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-11-15 00:00:00",
+    "start": "2020-11-15T03:00:00.000Z",
+    "end": "2020-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-24 14:00:00",
+    "start": "2020-12-24T17:00:00.000Z",
+    "end": "2020-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T03:00:00.000Z",
+    "end": "2020-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-12-31 14:00:00",
+    "start": "2020-12-31T17:00:00.000Z",
+    "end": "2021-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BR-GO-2021.json
+++ b/test/fixtures/BR-GO-2021.json
@@ -1,0 +1,200 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T03:00:00.000Z",
+    "end": "2021-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-13 00:00:00",
+    "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
+    "end": "2021-02-17T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T03:00:00.000Z",
+    "end": "2021-04-03T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-04 00:00:00",
+    "start": "2021-04-04T03:00:00.000Z",
+    "end": "2021-04-05T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-04-21 00:00:00",
+    "start": "2021-04-21T03:00:00.000Z",
+    "end": "2021-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T03:00:00.000Z",
+    "end": "2021-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-09T03:00:00.000Z",
+    "end": "2021-05-10T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T03:00:00.000Z",
+    "end": "2021-06-04T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-12 00:00:00",
+    "start": "2021-06-12T03:00:00.000Z",
+    "end": "2021-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-07-26 00:00:00",
+    "start": "2021-07-26T03:00:00.000Z",
+    "end": "2021-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-08 00:00:00",
+    "start": "2021-08-08T03:00:00.000Z",
+    "end": "2021-08-09T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-09-07 00:00:00",
+    "start": "2021-09-07T03:00:00.000Z",
+    "end": "2021-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-12 00:00:00",
+    "start": "2021-10-12T03:00:00.000Z",
+    "end": "2021-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-24 00:00:00",
+    "start": "2021-10-24T03:00:00.000Z",
+    "end": "2021-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T03:00:00.000Z",
+    "end": "2021-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-11-15 00:00:00",
+    "start": "2021-11-15T03:00:00.000Z",
+    "end": "2021-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-12-24 14:00:00",
+    "start": "2021-12-24T17:00:00.000Z",
+    "end": "2021-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T03:00:00.000Z",
+    "end": "2021-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-12-31 14:00:00",
+    "start": "2021-12-31T17:00:00.000Z",
+    "end": "2022-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BR-GO-2022.json
+++ b/test/fixtures/BR-GO-2022.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T03:00:00.000Z",
+    "end": "2022-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-26 00:00:00",
+    "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
+    "end": "2022-03-02T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T03:00:00.000Z",
+    "end": "2022-04-16T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-04-17 00:00:00",
+    "start": "2022-04-17T03:00:00.000Z",
+    "end": "2022-04-18T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-04-21 00:00:00",
+    "start": "2022-04-21T03:00:00.000Z",
+    "end": "2022-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T03:00:00.000Z",
+    "end": "2022-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-08T03:00:00.000Z",
+    "end": "2022-05-09T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-06-12 00:00:00",
+    "start": "2022-06-12T03:00:00.000Z",
+    "end": "2022-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T03:00:00.000Z",
+    "end": "2022-06-17T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-07-26 00:00:00",
+    "start": "2022-07-26T03:00:00.000Z",
+    "end": "2022-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-08-14 00:00:00",
+    "start": "2022-08-14T03:00:00.000Z",
+    "end": "2022-08-15T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-09-07 00:00:00",
+    "start": "2022-09-07T03:00:00.000Z",
+    "end": "2022-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-02 00:00:00",
+    "start": "2022-10-02T03:00:00.000Z",
+    "end": "2022-10-03T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-10-12 00:00:00",
+    "start": "2022-10-12T03:00:00.000Z",
+    "end": "2022-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-24 00:00:00",
+    "start": "2022-10-24T03:00:00.000Z",
+    "end": "2022-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-10-30 00:00:00",
+    "start": "2022-10-30T03:00:00.000Z",
+    "end": "2022-10-31T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T03:00:00.000Z",
+    "end": "2022-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-11-15 00:00:00",
+    "start": "2022-11-15T03:00:00.000Z",
+    "end": "2022-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-12-24 14:00:00",
+    "start": "2022-12-24T17:00:00.000Z",
+    "end": "2022-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T03:00:00.000Z",
+    "end": "2022-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-31 14:00:00",
+    "start": "2022-12-31T17:00:00.000Z",
+    "end": "2023-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BR-GO-2023.json
+++ b/test/fixtures/BR-GO-2023.json
@@ -1,0 +1,200 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T03:00:00.000Z",
+    "end": "2023-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-02-18 00:00:00",
+    "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
+    "end": "2023-02-22T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T03:00:00.000Z",
+    "end": "2023-04-08T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-09 00:00:00",
+    "start": "2023-04-09T03:00:00.000Z",
+    "end": "2023-04-10T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-04-21 00:00:00",
+    "start": "2023-04-21T03:00:00.000Z",
+    "end": "2023-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T03:00:00.000Z",
+    "end": "2023-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-14T03:00:00.000Z",
+    "end": "2023-05-15T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T03:00:00.000Z",
+    "end": "2023-06-09T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-12 00:00:00",
+    "start": "2023-06-12T03:00:00.000Z",
+    "end": "2023-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-07-26 00:00:00",
+    "start": "2023-07-26T03:00:00.000Z",
+    "end": "2023-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-08-13 00:00:00",
+    "start": "2023-08-13T03:00:00.000Z",
+    "end": "2023-08-14T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-09-07 00:00:00",
+    "start": "2023-09-07T03:00:00.000Z",
+    "end": "2023-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-12 00:00:00",
+    "start": "2023-10-12T03:00:00.000Z",
+    "end": "2023-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-24 00:00:00",
+    "start": "2023-10-24T03:00:00.000Z",
+    "end": "2023-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T03:00:00.000Z",
+    "end": "2023-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-11-15 00:00:00",
+    "start": "2023-11-15T03:00:00.000Z",
+    "end": "2023-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-12-24 14:00:00",
+    "start": "2023-12-24T17:00:00.000Z",
+    "end": "2023-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T03:00:00.000Z",
+    "end": "2023-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-12-31 14:00:00",
+    "start": "2023-12-31T17:00:00.000Z",
+    "end": "2024-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/BR-GO-2024.json
+++ b/test/fixtures/BR-GO-2024.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T03:00:00.000Z",
+    "end": "2024-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-10 00:00:00",
+    "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
+    "end": "2024-02-14T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T03:00:00.000Z",
+    "end": "2024-03-30T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-03-31 00:00:00",
+    "start": "2024-03-31T03:00:00.000Z",
+    "end": "2024-04-01T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-04-21 00:00:00",
+    "start": "2024-04-21T03:00:00.000Z",
+    "end": "2024-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T03:00:00.000Z",
+    "end": "2024-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-12T03:00:00.000Z",
+    "end": "2024-05-13T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T03:00:00.000Z",
+    "end": "2024-05-31T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-12 00:00:00",
+    "start": "2024-06-12T03:00:00.000Z",
+    "end": "2024-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-07-26 00:00:00",
+    "start": "2024-07-26T03:00:00.000Z",
+    "end": "2024-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-08-11 00:00:00",
+    "start": "2024-08-11T03:00:00.000Z",
+    "end": "2024-08-12T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-09-07 00:00:00",
+    "start": "2024-09-07T03:00:00.000Z",
+    "end": "2024-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-06 00:00:00",
+    "start": "2024-10-06T03:00:00.000Z",
+    "end": "2024-10-07T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-10-12 00:00:00",
+    "start": "2024-10-12T03:00:00.000Z",
+    "end": "2024-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-24 00:00:00",
+    "start": "2024-10-24T03:00:00.000Z",
+    "end": "2024-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-10-27 00:00:00",
+    "start": "2024-10-27T03:00:00.000Z",
+    "end": "2024-10-28T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T03:00:00.000Z",
+    "end": "2024-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-11-15 00:00:00",
+    "start": "2024-11-15T03:00:00.000Z",
+    "end": "2024-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-20 00:00:00",
+    "start": "2024-11-20T03:00:00.000Z",
+    "end": "2024-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-12-24 14:00:00",
+    "start": "2024-12-24T17:00:00.000Z",
+    "end": "2024-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T03:00:00.000Z",
+    "end": "2024-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-12-31 14:00:00",
+    "start": "2024-12-31T17:00:00.000Z",
+    "end": "2025-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BR-GO-2025.json
+++ b/test/fixtures/BR-GO-2025.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T03:00:00.000Z",
+    "end": "2025-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-01 00:00:00",
+    "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
+    "end": "2025-03-05T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T03:00:00.000Z",
+    "end": "2025-04-19T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-04-20 00:00:00",
+    "start": "2025-04-20T03:00:00.000Z",
+    "end": "2025-04-21T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-21 00:00:00",
+    "start": "2025-04-21T03:00:00.000Z",
+    "end": "2025-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T03:00:00.000Z",
+    "end": "2025-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-11T03:00:00.000Z",
+    "end": "2025-05-12T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-06-12 00:00:00",
+    "start": "2025-06-12T03:00:00.000Z",
+    "end": "2025-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T03:00:00.000Z",
+    "end": "2025-06-20T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-07-26 00:00:00",
+    "start": "2025-07-26T03:00:00.000Z",
+    "end": "2025-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-08-10 00:00:00",
+    "start": "2025-08-10T03:00:00.000Z",
+    "end": "2025-08-11T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-07T03:00:00.000Z",
+    "end": "2025-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-12 00:00:00",
+    "start": "2025-10-12T03:00:00.000Z",
+    "end": "2025-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-24 00:00:00",
+    "start": "2025-10-24T03:00:00.000Z",
+    "end": "2025-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T03:00:00.000Z",
+    "end": "2025-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-11-15 00:00:00",
+    "start": "2025-11-15T03:00:00.000Z",
+    "end": "2025-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-20 00:00:00",
+    "start": "2025-11-20T03:00:00.000Z",
+    "end": "2025-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-12-24 14:00:00",
+    "start": "2025-12-24T17:00:00.000Z",
+    "end": "2025-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T03:00:00.000Z",
+    "end": "2025-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-12-31 14:00:00",
+    "start": "2025-12-31T17:00:00.000Z",
+    "end": "2026-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BR-GO-2026.json
+++ b/test/fixtures/BR-GO-2026.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T03:00:00.000Z",
+    "end": "2026-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-14 00:00:00",
+    "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
+    "end": "2026-02-18T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T03:00:00.000Z",
+    "end": "2026-04-04T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-05 00:00:00",
+    "start": "2026-04-05T03:00:00.000Z",
+    "end": "2026-04-06T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-04-21 00:00:00",
+    "start": "2026-04-21T03:00:00.000Z",
+    "end": "2026-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T03:00:00.000Z",
+    "end": "2026-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-10 00:00:00",
+    "start": "2026-05-10T03:00:00.000Z",
+    "end": "2026-05-11T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T03:00:00.000Z",
+    "end": "2026-06-05T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-12 00:00:00",
+    "start": "2026-06-12T03:00:00.000Z",
+    "end": "2026-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-07-26 00:00:00",
+    "start": "2026-07-26T03:00:00.000Z",
+    "end": "2026-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-08-09 00:00:00",
+    "start": "2026-08-09T03:00:00.000Z",
+    "end": "2026-08-10T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-09-07 00:00:00",
+    "start": "2026-09-07T03:00:00.000Z",
+    "end": "2026-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-04 00:00:00",
+    "start": "2026-10-04T03:00:00.000Z",
+    "end": "2026-10-05T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-10-12 00:00:00",
+    "start": "2026-10-12T03:00:00.000Z",
+    "end": "2026-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-24 00:00:00",
+    "start": "2026-10-24T03:00:00.000Z",
+    "end": "2026-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-10-25 00:00:00",
+    "start": "2026-10-25T03:00:00.000Z",
+    "end": "2026-10-26T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T03:00:00.000Z",
+    "end": "2026-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-11-15 00:00:00",
+    "start": "2026-11-15T03:00:00.000Z",
+    "end": "2026-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-20 00:00:00",
+    "start": "2026-11-20T03:00:00.000Z",
+    "end": "2026-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-12-24 14:00:00",
+    "start": "2026-12-24T17:00:00.000Z",
+    "end": "2026-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T03:00:00.000Z",
+    "end": "2026-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-12-31 14:00:00",
+    "start": "2026-12-31T17:00:00.000Z",
+    "end": "2027-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BR-GO-2027.json
+++ b/test/fixtures/BR-GO-2027.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T03:00:00.000Z",
+    "end": "2027-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-06 00:00:00",
+    "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
+    "end": "2027-02-10T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T03:00:00.000Z",
+    "end": "2027-03-27T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-28 00:00:00",
+    "start": "2027-03-28T03:00:00.000Z",
+    "end": "2027-03-29T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-04-21 00:00:00",
+    "start": "2027-04-21T03:00:00.000Z",
+    "end": "2027-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T03:00:00.000Z",
+    "end": "2027-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-09 00:00:00",
+    "start": "2027-05-09T03:00:00.000Z",
+    "end": "2027-05-10T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T03:00:00.000Z",
+    "end": "2027-05-28T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-12 00:00:00",
+    "start": "2027-06-12T03:00:00.000Z",
+    "end": "2027-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-07-26 00:00:00",
+    "start": "2027-07-26T03:00:00.000Z",
+    "end": "2027-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-08 00:00:00",
+    "start": "2027-08-08T03:00:00.000Z",
+    "end": "2027-08-09T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-09-07 00:00:00",
+    "start": "2027-09-07T03:00:00.000Z",
+    "end": "2027-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-12 00:00:00",
+    "start": "2027-10-12T03:00:00.000Z",
+    "end": "2027-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-24 00:00:00",
+    "start": "2027-10-24T03:00:00.000Z",
+    "end": "2027-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T03:00:00.000Z",
+    "end": "2027-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-11-15 00:00:00",
+    "start": "2027-11-15T03:00:00.000Z",
+    "end": "2027-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-20 00:00:00",
+    "start": "2027-11-20T03:00:00.000Z",
+    "end": "2027-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-24 14:00:00",
+    "start": "2027-12-24T17:00:00.000Z",
+    "end": "2027-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T03:00:00.000Z",
+    "end": "2027-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-31 14:00:00",
+    "start": "2027-12-31T17:00:00.000Z",
+    "end": "2028-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BR-GO-2028.json
+++ b/test/fixtures/BR-GO-2028.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2028-01-01 00:00:00",
+    "start": "2028-01-01T03:00:00.000Z",
+    "end": "2028-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-26 00:00:00",
+    "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
+    "end": "2028-03-01T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-04-14 00:00:00",
+    "start": "2028-04-14T03:00:00.000Z",
+    "end": "2028-04-15T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2028-04-16 00:00:00",
+    "start": "2028-04-16T03:00:00.000Z",
+    "end": "2028-04-17T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-04-21 00:00:00",
+    "start": "2028-04-21T03:00:00.000Z",
+    "end": "2028-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2028-05-01 00:00:00",
+    "start": "2028-05-01T03:00:00.000Z",
+    "end": "2028-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-05-14 00:00:00",
+    "start": "2028-05-14T03:00:00.000Z",
+    "end": "2028-05-15T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-06-12 00:00:00",
+    "start": "2028-06-12T03:00:00.000Z",
+    "end": "2028-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-06-15 00:00:00",
+    "start": "2028-06-15T03:00:00.000Z",
+    "end": "2028-06-16T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-07-26 00:00:00",
+    "start": "2028-07-26T03:00:00.000Z",
+    "end": "2028-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-08-13 00:00:00",
+    "start": "2028-08-13T03:00:00.000Z",
+    "end": "2028-08-14T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-09-07 00:00:00",
+    "start": "2028-09-07T03:00:00.000Z",
+    "end": "2028-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-10-01 00:00:00",
+    "start": "2028-10-01T03:00:00.000Z",
+    "end": "2028-10-02T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-10-12 00:00:00",
+    "start": "2028-10-12T03:00:00.000Z",
+    "end": "2028-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-10-24 00:00:00",
+    "start": "2028-10-24T03:00:00.000Z",
+    "end": "2028-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-10-29 00:00:00",
+    "start": "2028-10-29T03:00:00.000Z",
+    "end": "2028-10-30T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-11-02 00:00:00",
+    "start": "2028-11-02T03:00:00.000Z",
+    "end": "2028-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-11-15 00:00:00",
+    "start": "2028-11-15T03:00:00.000Z",
+    "end": "2028-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-11-20 00:00:00",
+    "start": "2028-11-20T03:00:00.000Z",
+    "end": "2028-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-12-24 14:00:00",
+    "start": "2028-12-24T17:00:00.000Z",
+    "end": "2028-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-12-25 00:00:00",
+    "start": "2028-12-25T03:00:00.000Z",
+    "end": "2028-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-12-31 14:00:00",
+    "start": "2028-12-31T17:00:00.000Z",
+    "end": "2029-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/BR-GO-2029.json
+++ b/test/fixtures/BR-GO-2029.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2029-01-01 00:00:00",
+    "start": "2029-01-01T03:00:00.000Z",
+    "end": "2029-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-10 00:00:00",
+    "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
+    "end": "2029-02-14T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2029-03-30 00:00:00",
+    "start": "2029-03-30T03:00:00.000Z",
+    "end": "2029-03-31T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-04-01 00:00:00",
+    "start": "2029-04-01T03:00:00.000Z",
+    "end": "2029-04-02T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-04-21 00:00:00",
+    "start": "2029-04-21T03:00:00.000Z",
+    "end": "2029-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-05-01 00:00:00",
+    "start": "2029-05-01T03:00:00.000Z",
+    "end": "2029-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-05-13 00:00:00",
+    "start": "2029-05-13T03:00:00.000Z",
+    "end": "2029-05-14T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-05-31 00:00:00",
+    "start": "2029-05-31T03:00:00.000Z",
+    "end": "2029-06-01T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-06-12 00:00:00",
+    "start": "2029-06-12T03:00:00.000Z",
+    "end": "2029-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-07-26 00:00:00",
+    "start": "2029-07-26T03:00:00.000Z",
+    "end": "2029-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-08-12 00:00:00",
+    "start": "2029-08-12T03:00:00.000Z",
+    "end": "2029-08-13T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-09-07 00:00:00",
+    "start": "2029-09-07T03:00:00.000Z",
+    "end": "2029-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-10-12 00:00:00",
+    "start": "2029-10-12T03:00:00.000Z",
+    "end": "2029-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-10-24 00:00:00",
+    "start": "2029-10-24T03:00:00.000Z",
+    "end": "2029-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2029-11-02 00:00:00",
+    "start": "2029-11-02T03:00:00.000Z",
+    "end": "2029-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-11-15 00:00:00",
+    "start": "2029-11-15T03:00:00.000Z",
+    "end": "2029-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-11-20 00:00:00",
+    "start": "2029-11-20T03:00:00.000Z",
+    "end": "2029-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-12-24 14:00:00",
+    "start": "2029-12-24T17:00:00.000Z",
+    "end": "2029-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-12-25 00:00:00",
+    "start": "2029-12-25T03:00:00.000Z",
+    "end": "2029-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-12-31 14:00:00",
+    "start": "2029-12-31T17:00:00.000Z",
+    "end": "2030-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2015.json
+++ b/test/fixtures/BR-GO-GOIANIA-2015.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2015-01-01 00:00:00",
+    "start": "2015-01-01T02:00:00.000Z",
+    "end": "2015-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-02-14 00:00:00",
+    "start": "2015-02-14T02:00:00.000Z",
+    "end": "2015-02-16T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-02-16 00:00:00",
+    "start": "2015-02-16T02:00:00.000Z",
+    "end": "2015-02-17T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-02-17 00:00:00",
+    "start": "2015-02-17T02:00:00.000Z",
+    "end": "2015-02-18T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-02-18 00:00:00",
+    "start": "2015-02-18T02:00:00.000Z",
+    "end": "2015-02-18T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-04-03 00:00:00",
+    "start": "2015-04-03T03:00:00.000Z",
+    "end": "2015-04-04T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-04-05 00:00:00",
+    "start": "2015-04-05T03:00:00.000Z",
+    "end": "2015-04-06T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-04-21 00:00:00",
+    "start": "2015-04-21T03:00:00.000Z",
+    "end": "2015-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2015-05-01 00:00:00",
+    "start": "2015-05-01T03:00:00.000Z",
+    "end": "2015-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-05-10 00:00:00",
+    "start": "2015-05-10T03:00:00.000Z",
+    "end": "2015-05-11T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-05-24 00:00:00",
+    "start": "2015-05-24T03:00:00.000Z",
+    "end": "2015-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-06-04 00:00:00",
+    "start": "2015-06-04T03:00:00.000Z",
+    "end": "2015-06-05T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-06-12 00:00:00",
+    "start": "2015-06-12T03:00:00.000Z",
+    "end": "2015-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-07-26 00:00:00",
+    "start": "2015-07-26T03:00:00.000Z",
+    "end": "2015-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-08-09 00:00:00",
+    "start": "2015-08-09T03:00:00.000Z",
+    "end": "2015-08-10T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-09-07 00:00:00",
+    "start": "2015-09-07T03:00:00.000Z",
+    "end": "2015-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-12 00:00:00",
+    "start": "2015-10-12T03:00:00.000Z",
+    "end": "2015-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-10-24 00:00:00",
+    "start": "2015-10-24T02:00:00.000Z",
+    "end": "2015-10-25T02:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-02T02:00:00.000Z",
+    "end": "2015-11-03T02:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-11-15 00:00:00",
+    "start": "2015-11-15T02:00:00.000Z",
+    "end": "2015-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2015-12-24 14:00:00",
+    "start": "2015-12-24T16:00:00.000Z",
+    "end": "2015-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2015-12-25 00:00:00",
+    "start": "2015-12-25T02:00:00.000Z",
+    "end": "2015-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2015-12-31 14:00:00",
+    "start": "2015-12-31T16:00:00.000Z",
+    "end": "2016-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2016.json
+++ b/test/fixtures/BR-GO-GOIANIA-2016.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2016-01-01 00:00:00",
+    "start": "2016-01-01T02:00:00.000Z",
+    "end": "2016-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-02-06 00:00:00",
+    "start": "2016-02-06T02:00:00.000Z",
+    "end": "2016-02-08T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-02-08 00:00:00",
+    "start": "2016-02-08T02:00:00.000Z",
+    "end": "2016-02-09T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-02-09 00:00:00",
+    "start": "2016-02-09T02:00:00.000Z",
+    "end": "2016-02-10T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-10T02:00:00.000Z",
+    "end": "2016-02-10T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-03-25 00:00:00",
+    "start": "2016-03-25T03:00:00.000Z",
+    "end": "2016-03-26T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-03-27 00:00:00",
+    "start": "2016-03-27T03:00:00.000Z",
+    "end": "2016-03-28T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-04-21 00:00:00",
+    "start": "2016-04-21T03:00:00.000Z",
+    "end": "2016-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-05-01 00:00:00",
+    "start": "2016-05-01T03:00:00.000Z",
+    "end": "2016-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-08 00:00:00",
+    "start": "2016-05-08T03:00:00.000Z",
+    "end": "2016-05-09T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-05-24 00:00:00",
+    "start": "2016-05-24T03:00:00.000Z",
+    "end": "2016-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-05-26 00:00:00",
+    "start": "2016-05-26T03:00:00.000Z",
+    "end": "2016-05-27T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2016-06-12 00:00:00",
+    "start": "2016-06-12T03:00:00.000Z",
+    "end": "2016-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-07-26 00:00:00",
+    "start": "2016-07-26T03:00:00.000Z",
+    "end": "2016-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-08-14 00:00:00",
+    "start": "2016-08-14T03:00:00.000Z",
+    "end": "2016-08-15T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-09-07 00:00:00",
+    "start": "2016-09-07T03:00:00.000Z",
+    "end": "2016-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-02 00:00:00",
+    "start": "2016-10-02T03:00:00.000Z",
+    "end": "2016-10-03T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-10-12 00:00:00",
+    "start": "2016-10-12T03:00:00.000Z",
+    "end": "2016-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-10-24 00:00:00",
+    "start": "2016-10-24T02:00:00.000Z",
+    "end": "2016-10-25T02:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2016-10-30 00:00:00",
+    "start": "2016-10-30T02:00:00.000Z",
+    "end": "2016-10-31T02:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-11-02 00:00:00",
+    "start": "2016-11-02T02:00:00.000Z",
+    "end": "2016-11-03T02:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2016-11-15 00:00:00",
+    "start": "2016-11-15T02:00:00.000Z",
+    "end": "2016-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2016-12-24 14:00:00",
+    "start": "2016-12-24T16:00:00.000Z",
+    "end": "2016-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2016-12-25 00:00:00",
+    "start": "2016-12-25T02:00:00.000Z",
+    "end": "2016-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2016-12-31 14:00:00",
+    "start": "2016-12-31T16:00:00.000Z",
+    "end": "2017-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2017.json
+++ b/test/fixtures/BR-GO-GOIANIA-2017.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2017-01-01 00:00:00",
+    "start": "2017-01-01T02:00:00.000Z",
+    "end": "2017-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-02-25 00:00:00",
+    "start": "2017-02-25T03:00:00.000Z",
+    "end": "2017-02-27T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-02-27 00:00:00",
+    "start": "2017-02-27T03:00:00.000Z",
+    "end": "2017-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-02-28 00:00:00",
+    "start": "2017-02-28T03:00:00.000Z",
+    "end": "2017-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-03-01 00:00:00",
+    "start": "2017-03-01T03:00:00.000Z",
+    "end": "2017-03-01T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-04-14 00:00:00",
+    "start": "2017-04-14T03:00:00.000Z",
+    "end": "2017-04-15T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-04-16 00:00:00",
+    "start": "2017-04-16T03:00:00.000Z",
+    "end": "2017-04-17T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-04-21 00:00:00",
+    "start": "2017-04-21T03:00:00.000Z",
+    "end": "2017-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2017-05-01 00:00:00",
+    "start": "2017-05-01T03:00:00.000Z",
+    "end": "2017-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-05-14 00:00:00",
+    "start": "2017-05-14T03:00:00.000Z",
+    "end": "2017-05-15T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-05-24 00:00:00",
+    "start": "2017-05-24T03:00:00.000Z",
+    "end": "2017-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-06-12 00:00:00",
+    "start": "2017-06-12T03:00:00.000Z",
+    "end": "2017-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-06-15 00:00:00",
+    "start": "2017-06-15T03:00:00.000Z",
+    "end": "2017-06-16T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-07-26 00:00:00",
+    "start": "2017-07-26T03:00:00.000Z",
+    "end": "2017-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-08-13 00:00:00",
+    "start": "2017-08-13T03:00:00.000Z",
+    "end": "2017-08-14T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-09-07 00:00:00",
+    "start": "2017-09-07T03:00:00.000Z",
+    "end": "2017-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-12 00:00:00",
+    "start": "2017-10-12T03:00:00.000Z",
+    "end": "2017-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-10-24 00:00:00",
+    "start": "2017-10-24T02:00:00.000Z",
+    "end": "2017-10-25T02:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2017-11-02 00:00:00",
+    "start": "2017-11-02T02:00:00.000Z",
+    "end": "2017-11-03T02:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2017-11-15 00:00:00",
+    "start": "2017-11-15T02:00:00.000Z",
+    "end": "2017-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2017-12-24 14:00:00",
+    "start": "2017-12-24T16:00:00.000Z",
+    "end": "2017-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-12-25 00:00:00",
+    "start": "2017-12-25T02:00:00.000Z",
+    "end": "2017-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2017-12-31 14:00:00",
+    "start": "2017-12-31T16:00:00.000Z",
+    "end": "2018-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2018.json
+++ b/test/fixtures/BR-GO-GOIANIA-2018.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2018-01-01 00:00:00",
+    "start": "2018-01-01T02:00:00.000Z",
+    "end": "2018-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-10 00:00:00",
+    "start": "2018-02-10T02:00:00.000Z",
+    "end": "2018-02-12T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-02-12 00:00:00",
+    "start": "2018-02-12T02:00:00.000Z",
+    "end": "2018-02-13T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-02-13 00:00:00",
+    "start": "2018-02-13T02:00:00.000Z",
+    "end": "2018-02-14T02:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-02-14 00:00:00",
+    "start": "2018-02-14T02:00:00.000Z",
+    "end": "2018-02-14T16:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-03-30 00:00:00",
+    "start": "2018-03-30T03:00:00.000Z",
+    "end": "2018-03-31T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-04-01 00:00:00",
+    "start": "2018-04-01T03:00:00.000Z",
+    "end": "2018-04-02T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-04-21 00:00:00",
+    "start": "2018-04-21T03:00:00.000Z",
+    "end": "2018-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2018-05-01 00:00:00",
+    "start": "2018-05-01T03:00:00.000Z",
+    "end": "2018-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-05-13 00:00:00",
+    "start": "2018-05-13T03:00:00.000Z",
+    "end": "2018-05-14T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-05-24 00:00:00",
+    "start": "2018-05-24T03:00:00.000Z",
+    "end": "2018-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-05-31 00:00:00",
+    "start": "2018-05-31T03:00:00.000Z",
+    "end": "2018-06-01T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-06-12 00:00:00",
+    "start": "2018-06-12T03:00:00.000Z",
+    "end": "2018-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-07-26 00:00:00",
+    "start": "2018-07-26T03:00:00.000Z",
+    "end": "2018-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-08-12 00:00:00",
+    "start": "2018-08-12T03:00:00.000Z",
+    "end": "2018-08-13T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-09-07 00:00:00",
+    "start": "2018-09-07T03:00:00.000Z",
+    "end": "2018-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-07 00:00:00",
+    "start": "2018-10-07T03:00:00.000Z",
+    "end": "2018-10-08T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-10-12 00:00:00",
+    "start": "2018-10-12T03:00:00.000Z",
+    "end": "2018-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-10-24 00:00:00",
+    "start": "2018-10-24T03:00:00.000Z",
+    "end": "2018-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2018-10-28 00:00:00",
+    "start": "2018-10-28T03:00:00.000Z",
+    "end": "2018-10-29T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-11-02 00:00:00",
+    "start": "2018-11-02T03:00:00.000Z",
+    "end": "2018-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2018-11-15 00:00:00",
+    "start": "2018-11-15T02:00:00.000Z",
+    "end": "2018-11-16T02:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2018-12-24 14:00:00",
+    "start": "2018-12-24T16:00:00.000Z",
+    "end": "2018-12-25T02:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2018-12-25 00:00:00",
+    "start": "2018-12-25T02:00:00.000Z",
+    "end": "2018-12-26T02:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2018-12-31 14:00:00",
+    "start": "2018-12-31T16:00:00.000Z",
+    "end": "2019-01-01T02:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Mon"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2019.json
+++ b/test/fixtures/BR-GO-GOIANIA-2019.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2019-01-01 00:00:00",
+    "start": "2019-01-01T02:00:00.000Z",
+    "end": "2019-01-02T02:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-02 00:00:00",
+    "start": "2019-03-02T03:00:00.000Z",
+    "end": "2019-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-03-04 00:00:00",
+    "start": "2019-03-04T03:00:00.000Z",
+    "end": "2019-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-03-05 00:00:00",
+    "start": "2019-03-05T03:00:00.000Z",
+    "end": "2019-03-06T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-03-06 00:00:00",
+    "start": "2019-03-06T03:00:00.000Z",
+    "end": "2019-03-06T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-04-19 00:00:00",
+    "start": "2019-04-19T03:00:00.000Z",
+    "end": "2019-04-20T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-04-21 00:00:00",
+    "start": "2019-04-21T03:00:00.000Z",
+    "end": "2019-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-04-21 00:00:00",
+    "start": "2019-04-21T03:00:00.000Z",
+    "end": "2019-04-22T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-05-01 00:00:00",
+    "start": "2019-05-01T03:00:00.000Z",
+    "end": "2019-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-05-12 00:00:00",
+    "start": "2019-05-12T03:00:00.000Z",
+    "end": "2019-05-13T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-05-24 00:00:00",
+    "start": "2019-05-24T03:00:00.000Z",
+    "end": "2019-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-06-12 00:00:00",
+    "start": "2019-06-12T03:00:00.000Z",
+    "end": "2019-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-06-20 00:00:00",
+    "start": "2019-06-20T03:00:00.000Z",
+    "end": "2019-06-21T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-07-26 00:00:00",
+    "start": "2019-07-26T03:00:00.000Z",
+    "end": "2019-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-08-11 00:00:00",
+    "start": "2019-08-11T03:00:00.000Z",
+    "end": "2019-08-12T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2019-09-07 00:00:00",
+    "start": "2019-09-07T03:00:00.000Z",
+    "end": "2019-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-12 00:00:00",
+    "start": "2019-10-12T03:00:00.000Z",
+    "end": "2019-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-24 00:00:00",
+    "start": "2019-10-24T03:00:00.000Z",
+    "end": "2019-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2019-11-02 00:00:00",
+    "start": "2019-11-02T03:00:00.000Z",
+    "end": "2019-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2019-11-15 00:00:00",
+    "start": "2019-11-15T03:00:00.000Z",
+    "end": "2019-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2019-12-24 14:00:00",
+    "start": "2019-12-24T17:00:00.000Z",
+    "end": "2019-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2019-12-25 00:00:00",
+    "start": "2019-12-25T03:00:00.000Z",
+    "end": "2019-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2019-12-31 14:00:00",
+    "start": "2019-12-31T17:00:00.000Z",
+    "end": "2020-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2020.json
+++ b/test/fixtures/BR-GO-GOIANIA-2020.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2020-01-01 00:00:00",
+    "start": "2020-01-01T03:00:00.000Z",
+    "end": "2020-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-02-22 00:00:00",
+    "start": "2020-02-22T03:00:00.000Z",
+    "end": "2020-02-24T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-02-24 00:00:00",
+    "start": "2020-02-24T03:00:00.000Z",
+    "end": "2020-02-25T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-02-25 00:00:00",
+    "start": "2020-02-25T03:00:00.000Z",
+    "end": "2020-02-26T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-02-26 00:00:00",
+    "start": "2020-02-26T03:00:00.000Z",
+    "end": "2020-02-26T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-04-10 00:00:00",
+    "start": "2020-04-10T03:00:00.000Z",
+    "end": "2020-04-11T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-04-12 00:00:00",
+    "start": "2020-04-12T03:00:00.000Z",
+    "end": "2020-04-13T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-04-21 00:00:00",
+    "start": "2020-04-21T03:00:00.000Z",
+    "end": "2020-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2020-05-01 00:00:00",
+    "start": "2020-05-01T03:00:00.000Z",
+    "end": "2020-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-05-10 00:00:00",
+    "start": "2020-05-10T03:00:00.000Z",
+    "end": "2020-05-11T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-05-24 00:00:00",
+    "start": "2020-05-24T03:00:00.000Z",
+    "end": "2020-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-06-11 00:00:00",
+    "start": "2020-06-11T03:00:00.000Z",
+    "end": "2020-06-12T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-06-12 00:00:00",
+    "start": "2020-06-12T03:00:00.000Z",
+    "end": "2020-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-07-26 00:00:00",
+    "start": "2020-07-26T03:00:00.000Z",
+    "end": "2020-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-08-09 00:00:00",
+    "start": "2020-08-09T03:00:00.000Z",
+    "end": "2020-08-10T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-09-07 00:00:00",
+    "start": "2020-09-07T03:00:00.000Z",
+    "end": "2020-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-04 00:00:00",
+    "start": "2020-10-04T03:00:00.000Z",
+    "end": "2020-10-05T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-10-12 00:00:00",
+    "start": "2020-10-12T03:00:00.000Z",
+    "end": "2020-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-10-24 00:00:00",
+    "start": "2020-10-24T03:00:00.000Z",
+    "end": "2020-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2020-10-25 00:00:00",
+    "start": "2020-10-25T03:00:00.000Z",
+    "end": "2020-10-26T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-02T03:00:00.000Z",
+    "end": "2020-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-11-15 00:00:00",
+    "start": "2020-11-15T03:00:00.000Z",
+    "end": "2020-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2020-12-24 14:00:00",
+    "start": "2020-12-24T17:00:00.000Z",
+    "end": "2020-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2020-12-25 00:00:00",
+    "start": "2020-12-25T03:00:00.000Z",
+    "end": "2020-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2020-12-31 14:00:00",
+    "start": "2020-12-31T17:00:00.000Z",
+    "end": "2021-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2021.json
+++ b/test/fixtures/BR-GO-GOIANIA-2021.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2021-01-01 00:00:00",
+    "start": "2021-01-01T03:00:00.000Z",
+    "end": "2021-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-02-13 00:00:00",
+    "start": "2021-02-13T03:00:00.000Z",
+    "end": "2021-02-15T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-02-15 00:00:00",
+    "start": "2021-02-15T03:00:00.000Z",
+    "end": "2021-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-02-16 00:00:00",
+    "start": "2021-02-16T03:00:00.000Z",
+    "end": "2021-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-02-17 00:00:00",
+    "start": "2021-02-17T03:00:00.000Z",
+    "end": "2021-02-17T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-04-02 00:00:00",
+    "start": "2021-04-02T03:00:00.000Z",
+    "end": "2021-04-03T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-04-04 00:00:00",
+    "start": "2021-04-04T03:00:00.000Z",
+    "end": "2021-04-05T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-04-21 00:00:00",
+    "start": "2021-04-21T03:00:00.000Z",
+    "end": "2021-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2021-05-01 00:00:00",
+    "start": "2021-05-01T03:00:00.000Z",
+    "end": "2021-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-05-09 00:00:00",
+    "start": "2021-05-09T03:00:00.000Z",
+    "end": "2021-05-10T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-05-24 00:00:00",
+    "start": "2021-05-24T03:00:00.000Z",
+    "end": "2021-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-06-03 00:00:00",
+    "start": "2021-06-03T03:00:00.000Z",
+    "end": "2021-06-04T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-06-12 00:00:00",
+    "start": "2021-06-12T03:00:00.000Z",
+    "end": "2021-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-07-26 00:00:00",
+    "start": "2021-07-26T03:00:00.000Z",
+    "end": "2021-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-08-08 00:00:00",
+    "start": "2021-08-08T03:00:00.000Z",
+    "end": "2021-08-09T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-09-07 00:00:00",
+    "start": "2021-09-07T03:00:00.000Z",
+    "end": "2021-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-12 00:00:00",
+    "start": "2021-10-12T03:00:00.000Z",
+    "end": "2021-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-10-24 00:00:00",
+    "start": "2021-10-24T03:00:00.000Z",
+    "end": "2021-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2021-11-02 00:00:00",
+    "start": "2021-11-02T03:00:00.000Z",
+    "end": "2021-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2021-11-15 00:00:00",
+    "start": "2021-11-15T03:00:00.000Z",
+    "end": "2021-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2021-12-24 14:00:00",
+    "start": "2021-12-24T17:00:00.000Z",
+    "end": "2021-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2021-12-25 00:00:00",
+    "start": "2021-12-25T03:00:00.000Z",
+    "end": "2021-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2021-12-31 14:00:00",
+    "start": "2021-12-31T17:00:00.000Z",
+    "end": "2022-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2022.json
+++ b/test/fixtures/BR-GO-GOIANIA-2022.json
@@ -1,0 +1,227 @@
+[
+  {
+    "date": "2022-01-01 00:00:00",
+    "start": "2022-01-01T03:00:00.000Z",
+    "end": "2022-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-26 00:00:00",
+    "start": "2022-02-26T03:00:00.000Z",
+    "end": "2022-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-02-28 00:00:00",
+    "start": "2022-02-28T03:00:00.000Z",
+    "end": "2022-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-03-01 00:00:00",
+    "start": "2022-03-01T03:00:00.000Z",
+    "end": "2022-03-02T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-03-02 00:00:00",
+    "start": "2022-03-02T03:00:00.000Z",
+    "end": "2022-03-02T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-04-15 00:00:00",
+    "start": "2022-04-15T03:00:00.000Z",
+    "end": "2022-04-16T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-04-17 00:00:00",
+    "start": "2022-04-17T03:00:00.000Z",
+    "end": "2022-04-18T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-04-21 00:00:00",
+    "start": "2022-04-21T03:00:00.000Z",
+    "end": "2022-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-05-01 00:00:00",
+    "start": "2022-05-01T03:00:00.000Z",
+    "end": "2022-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-08 00:00:00",
+    "start": "2022-05-08T03:00:00.000Z",
+    "end": "2022-05-09T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-05-24 00:00:00",
+    "start": "2022-05-24T03:00:00.000Z",
+    "end": "2022-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-06-12 00:00:00",
+    "start": "2022-06-12T03:00:00.000Z",
+    "end": "2022-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-06-16 00:00:00",
+    "start": "2022-06-16T03:00:00.000Z",
+    "end": "2022-06-17T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2022-07-26 00:00:00",
+    "start": "2022-07-26T03:00:00.000Z",
+    "end": "2022-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-08-14 00:00:00",
+    "start": "2022-08-14T03:00:00.000Z",
+    "end": "2022-08-15T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-09-07 00:00:00",
+    "start": "2022-09-07T03:00:00.000Z",
+    "end": "2022-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-02 00:00:00",
+    "start": "2022-10-02T03:00:00.000Z",
+    "end": "2022-10-03T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-10-12 00:00:00",
+    "start": "2022-10-12T03:00:00.000Z",
+    "end": "2022-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-10-24 00:00:00",
+    "start": "2022-10-24T03:00:00.000Z",
+    "end": "2022-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-10-30 00:00:00",
+    "start": "2022-10-30T03:00:00.000Z",
+    "end": "2022-10-31T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-11-02 00:00:00",
+    "start": "2022-11-02T03:00:00.000Z",
+    "end": "2022-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2022-11-15 00:00:00",
+    "start": "2022-11-15T03:00:00.000Z",
+    "end": "2022-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2022-12-24 14:00:00",
+    "start": "2022-12-24T17:00:00.000Z",
+    "end": "2022-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2022-12-25 00:00:00",
+    "start": "2022-12-25T03:00:00.000Z",
+    "end": "2022-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2022-12-31 14:00:00",
+    "start": "2022-12-31T17:00:00.000Z",
+    "end": "2023-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sat"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2023.json
+++ b/test/fixtures/BR-GO-GOIANIA-2023.json
@@ -1,0 +1,209 @@
+[
+  {
+    "date": "2023-01-01 00:00:00",
+    "start": "2023-01-01T03:00:00.000Z",
+    "end": "2023-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-02-18 00:00:00",
+    "start": "2023-02-18T03:00:00.000Z",
+    "end": "2023-02-20T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-02-20 00:00:00",
+    "start": "2023-02-20T03:00:00.000Z",
+    "end": "2023-02-21T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-02-21 00:00:00",
+    "start": "2023-02-21T03:00:00.000Z",
+    "end": "2023-02-22T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-02-22 00:00:00",
+    "start": "2023-02-22T03:00:00.000Z",
+    "end": "2023-02-22T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-04-07 00:00:00",
+    "start": "2023-04-07T03:00:00.000Z",
+    "end": "2023-04-08T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-04-09 00:00:00",
+    "start": "2023-04-09T03:00:00.000Z",
+    "end": "2023-04-10T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-04-21 00:00:00",
+    "start": "2023-04-21T03:00:00.000Z",
+    "end": "2023-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2023-05-01 00:00:00",
+    "start": "2023-05-01T03:00:00.000Z",
+    "end": "2023-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-05-14 00:00:00",
+    "start": "2023-05-14T03:00:00.000Z",
+    "end": "2023-05-15T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-05-24 00:00:00",
+    "start": "2023-05-24T03:00:00.000Z",
+    "end": "2023-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-06-08 00:00:00",
+    "start": "2023-06-08T03:00:00.000Z",
+    "end": "2023-06-09T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-06-12 00:00:00",
+    "start": "2023-06-12T03:00:00.000Z",
+    "end": "2023-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-07-26 00:00:00",
+    "start": "2023-07-26T03:00:00.000Z",
+    "end": "2023-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-08-13 00:00:00",
+    "start": "2023-08-13T03:00:00.000Z",
+    "end": "2023-08-14T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-09-07 00:00:00",
+    "start": "2023-09-07T03:00:00.000Z",
+    "end": "2023-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-12 00:00:00",
+    "start": "2023-10-12T03:00:00.000Z",
+    "end": "2023-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-10-24 00:00:00",
+    "start": "2023-10-24T03:00:00.000Z",
+    "end": "2023-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2023-11-02 00:00:00",
+    "start": "2023-11-02T03:00:00.000Z",
+    "end": "2023-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2023-11-15 00:00:00",
+    "start": "2023-11-15T03:00:00.000Z",
+    "end": "2023-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2023-12-24 14:00:00",
+    "start": "2023-12-24T17:00:00.000Z",
+    "end": "2023-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-12-25 00:00:00",
+    "start": "2023-12-25T03:00:00.000Z",
+    "end": "2023-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2023-12-31 14:00:00",
+    "start": "2023-12-31T17:00:00.000Z",
+    "end": "2024-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2024.json
+++ b/test/fixtures/BR-GO-GOIANIA-2024.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2024-01-01 00:00:00",
+    "start": "2024-01-01T03:00:00.000Z",
+    "end": "2024-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-10 00:00:00",
+    "start": "2024-02-10T03:00:00.000Z",
+    "end": "2024-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-12T03:00:00.000Z",
+    "end": "2024-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-02-13 00:00:00",
+    "start": "2024-02-13T03:00:00.000Z",
+    "end": "2024-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-02-14 00:00:00",
+    "start": "2024-02-14T03:00:00.000Z",
+    "end": "2024-02-14T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-03-29 00:00:00",
+    "start": "2024-03-29T03:00:00.000Z",
+    "end": "2024-03-30T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-03-31 00:00:00",
+    "start": "2024-03-31T03:00:00.000Z",
+    "end": "2024-04-01T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-04-21 00:00:00",
+    "start": "2024-04-21T03:00:00.000Z",
+    "end": "2024-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-05-01 00:00:00",
+    "start": "2024-05-01T03:00:00.000Z",
+    "end": "2024-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-05-12 00:00:00",
+    "start": "2024-05-12T03:00:00.000Z",
+    "end": "2024-05-13T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-05-24 00:00:00",
+    "start": "2024-05-24T03:00:00.000Z",
+    "end": "2024-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-05-30 00:00:00",
+    "start": "2024-05-30T03:00:00.000Z",
+    "end": "2024-05-31T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-06-12 00:00:00",
+    "start": "2024-06-12T03:00:00.000Z",
+    "end": "2024-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-07-26 00:00:00",
+    "start": "2024-07-26T03:00:00.000Z",
+    "end": "2024-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-08-11 00:00:00",
+    "start": "2024-08-11T03:00:00.000Z",
+    "end": "2024-08-12T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-09-07 00:00:00",
+    "start": "2024-09-07T03:00:00.000Z",
+    "end": "2024-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-06 00:00:00",
+    "start": "2024-10-06T03:00:00.000Z",
+    "end": "2024-10-07T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-10-12 00:00:00",
+    "start": "2024-10-12T03:00:00.000Z",
+    "end": "2024-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-24 00:00:00",
+    "start": "2024-10-24T03:00:00.000Z",
+    "end": "2024-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2024-10-27 00:00:00",
+    "start": "2024-10-27T03:00:00.000Z",
+    "end": "2024-10-28T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2024-11-02 00:00:00",
+    "start": "2024-11-02T03:00:00.000Z",
+    "end": "2024-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2024-11-15 00:00:00",
+    "start": "2024-11-15T03:00:00.000Z",
+    "end": "2024-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2024-11-20 00:00:00",
+    "start": "2024-11-20T03:00:00.000Z",
+    "end": "2024-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-12-24 14:00:00",
+    "start": "2024-12-24T17:00:00.000Z",
+    "end": "2024-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2024-12-25 00:00:00",
+    "start": "2024-12-25T03:00:00.000Z",
+    "end": "2024-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2024-12-31 14:00:00",
+    "start": "2024-12-31T17:00:00.000Z",
+    "end": "2025-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Tue"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2025.json
+++ b/test/fixtures/BR-GO-GOIANIA-2025.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2025-01-01 00:00:00",
+    "start": "2025-01-01T03:00:00.000Z",
+    "end": "2025-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-03-01 00:00:00",
+    "start": "2025-03-01T03:00:00.000Z",
+    "end": "2025-03-03T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-03T03:00:00.000Z",
+    "end": "2025-03-04T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-03-04 00:00:00",
+    "start": "2025-03-04T03:00:00.000Z",
+    "end": "2025-03-05T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-03-05 00:00:00",
+    "start": "2025-03-05T03:00:00.000Z",
+    "end": "2025-03-05T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-04-18 00:00:00",
+    "start": "2025-04-18T03:00:00.000Z",
+    "end": "2025-04-19T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-04-20 00:00:00",
+    "start": "2025-04-20T03:00:00.000Z",
+    "end": "2025-04-21T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-04-21 00:00:00",
+    "start": "2025-04-21T03:00:00.000Z",
+    "end": "2025-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2025-05-01 00:00:00",
+    "start": "2025-05-01T03:00:00.000Z",
+    "end": "2025-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-05-11 00:00:00",
+    "start": "2025-05-11T03:00:00.000Z",
+    "end": "2025-05-12T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-05-24 00:00:00",
+    "start": "2025-05-24T03:00:00.000Z",
+    "end": "2025-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-06-12 00:00:00",
+    "start": "2025-06-12T03:00:00.000Z",
+    "end": "2025-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-06-19 00:00:00",
+    "start": "2025-06-19T03:00:00.000Z",
+    "end": "2025-06-20T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-07-26 00:00:00",
+    "start": "2025-07-26T03:00:00.000Z",
+    "end": "2025-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-08-10 00:00:00",
+    "start": "2025-08-10T03:00:00.000Z",
+    "end": "2025-08-11T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-09-07 00:00:00",
+    "start": "2025-09-07T03:00:00.000Z",
+    "end": "2025-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-12 00:00:00",
+    "start": "2025-10-12T03:00:00.000Z",
+    "end": "2025-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-24 00:00:00",
+    "start": "2025-10-24T03:00:00.000Z",
+    "end": "2025-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2025-11-02 00:00:00",
+    "start": "2025-11-02T03:00:00.000Z",
+    "end": "2025-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2025-11-15 00:00:00",
+    "start": "2025-11-15T03:00:00.000Z",
+    "end": "2025-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2025-11-20 00:00:00",
+    "start": "2025-11-20T03:00:00.000Z",
+    "end": "2025-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-12-24 14:00:00",
+    "start": "2025-12-24T17:00:00.000Z",
+    "end": "2025-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2025-12-25 00:00:00",
+    "start": "2025-12-25T03:00:00.000Z",
+    "end": "2025-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2025-12-31 14:00:00",
+    "start": "2025-12-31T17:00:00.000Z",
+    "end": "2026-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Wed"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2026.json
+++ b/test/fixtures/BR-GO-GOIANIA-2026.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2026-01-01 00:00:00",
+    "start": "2026-01-01T03:00:00.000Z",
+    "end": "2026-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-02-14 00:00:00",
+    "start": "2026-02-14T03:00:00.000Z",
+    "end": "2026-02-16T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-02-16 00:00:00",
+    "start": "2026-02-16T03:00:00.000Z",
+    "end": "2026-02-17T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-02-17 00:00:00",
+    "start": "2026-02-17T03:00:00.000Z",
+    "end": "2026-02-18T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-02-18 00:00:00",
+    "start": "2026-02-18T03:00:00.000Z",
+    "end": "2026-02-18T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-03T03:00:00.000Z",
+    "end": "2026-04-04T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-04-05 00:00:00",
+    "start": "2026-04-05T03:00:00.000Z",
+    "end": "2026-04-06T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-04-21 00:00:00",
+    "start": "2026-04-21T03:00:00.000Z",
+    "end": "2026-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2026-05-01 00:00:00",
+    "start": "2026-05-01T03:00:00.000Z",
+    "end": "2026-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-05-10 00:00:00",
+    "start": "2026-05-10T03:00:00.000Z",
+    "end": "2026-05-11T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-24 00:00:00",
+    "start": "2026-05-24T03:00:00.000Z",
+    "end": "2026-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-06-04 00:00:00",
+    "start": "2026-06-04T03:00:00.000Z",
+    "end": "2026-06-05T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-06-12 00:00:00",
+    "start": "2026-06-12T03:00:00.000Z",
+    "end": "2026-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-07-26 00:00:00",
+    "start": "2026-07-26T03:00:00.000Z",
+    "end": "2026-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-08-09 00:00:00",
+    "start": "2026-08-09T03:00:00.000Z",
+    "end": "2026-08-10T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-09-07 00:00:00",
+    "start": "2026-09-07T03:00:00.000Z",
+    "end": "2026-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-04 00:00:00",
+    "start": "2026-10-04T03:00:00.000Z",
+    "end": "2026-10-05T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-10-12 00:00:00",
+    "start": "2026-10-12T03:00:00.000Z",
+    "end": "2026-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-10-24 00:00:00",
+    "start": "2026-10-24T03:00:00.000Z",
+    "end": "2026-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2026-10-25 00:00:00",
+    "start": "2026-10-25T03:00:00.000Z",
+    "end": "2026-10-26T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-02T03:00:00.000Z",
+    "end": "2026-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-11-15 00:00:00",
+    "start": "2026-11-15T03:00:00.000Z",
+    "end": "2026-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-11-20 00:00:00",
+    "start": "2026-11-20T03:00:00.000Z",
+    "end": "2026-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-12-24 14:00:00",
+    "start": "2026-12-24T17:00:00.000Z",
+    "end": "2026-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2026-12-25 00:00:00",
+    "start": "2026-12-25T03:00:00.000Z",
+    "end": "2026-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2026-12-31 14:00:00",
+    "start": "2026-12-31T17:00:00.000Z",
+    "end": "2027-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Thu"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2027.json
+++ b/test/fixtures/BR-GO-GOIANIA-2027.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2027-01-01 00:00:00",
+    "start": "2027-01-01T03:00:00.000Z",
+    "end": "2027-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-02-06 00:00:00",
+    "start": "2027-02-06T03:00:00.000Z",
+    "end": "2027-02-08T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-02-08 00:00:00",
+    "start": "2027-02-08T03:00:00.000Z",
+    "end": "2027-02-09T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-09T03:00:00.000Z",
+    "end": "2027-02-10T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-02-10 00:00:00",
+    "start": "2027-02-10T03:00:00.000Z",
+    "end": "2027-02-10T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-03-26 00:00:00",
+    "start": "2027-03-26T03:00:00.000Z",
+    "end": "2027-03-27T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-03-28 00:00:00",
+    "start": "2027-03-28T03:00:00.000Z",
+    "end": "2027-03-29T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-04-21 00:00:00",
+    "start": "2027-04-21T03:00:00.000Z",
+    "end": "2027-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2027-05-01 00:00:00",
+    "start": "2027-05-01T03:00:00.000Z",
+    "end": "2027-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-05-09 00:00:00",
+    "start": "2027-05-09T03:00:00.000Z",
+    "end": "2027-05-10T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-05-24 00:00:00",
+    "start": "2027-05-24T03:00:00.000Z",
+    "end": "2027-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-05-27 00:00:00",
+    "start": "2027-05-27T03:00:00.000Z",
+    "end": "2027-05-28T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-06-12 00:00:00",
+    "start": "2027-06-12T03:00:00.000Z",
+    "end": "2027-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-07-26 00:00:00",
+    "start": "2027-07-26T03:00:00.000Z",
+    "end": "2027-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-08-08 00:00:00",
+    "start": "2027-08-08T03:00:00.000Z",
+    "end": "2027-08-09T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-09-07 00:00:00",
+    "start": "2027-09-07T03:00:00.000Z",
+    "end": "2027-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-12 00:00:00",
+    "start": "2027-10-12T03:00:00.000Z",
+    "end": "2027-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-10-24 00:00:00",
+    "start": "2027-10-24T03:00:00.000Z",
+    "end": "2027-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2027-11-02 00:00:00",
+    "start": "2027-11-02T03:00:00.000Z",
+    "end": "2027-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2027-11-15 00:00:00",
+    "start": "2027-11-15T03:00:00.000Z",
+    "end": "2027-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2027-11-20 00:00:00",
+    "start": "2027-11-20T03:00:00.000Z",
+    "end": "2027-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-24 14:00:00",
+    "start": "2027-12-24T17:00:00.000Z",
+    "end": "2027-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2027-12-25 00:00:00",
+    "start": "2027-12-25T03:00:00.000Z",
+    "end": "2027-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-31 14:00:00",
+    "start": "2027-12-31T17:00:00.000Z",
+    "end": "2028-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Fri"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2028.json
+++ b/test/fixtures/BR-GO-GOIANIA-2028.json
@@ -1,0 +1,236 @@
+[
+  {
+    "date": "2028-01-01 00:00:00",
+    "start": "2028-01-01T03:00:00.000Z",
+    "end": "2028-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-26 00:00:00",
+    "start": "2028-02-26T03:00:00.000Z",
+    "end": "2028-02-28T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-02-28 00:00:00",
+    "start": "2028-02-28T03:00:00.000Z",
+    "end": "2028-02-29T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-02-29 00:00:00",
+    "start": "2028-02-29T03:00:00.000Z",
+    "end": "2028-03-01T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-03-01 00:00:00",
+    "start": "2028-03-01T03:00:00.000Z",
+    "end": "2028-03-01T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-04-14 00:00:00",
+    "start": "2028-04-14T03:00:00.000Z",
+    "end": "2028-04-15T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2028-04-16 00:00:00",
+    "start": "2028-04-16T03:00:00.000Z",
+    "end": "2028-04-17T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-04-21 00:00:00",
+    "start": "2028-04-21T03:00:00.000Z",
+    "end": "2028-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2028-05-01 00:00:00",
+    "start": "2028-05-01T03:00:00.000Z",
+    "end": "2028-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-05-14 00:00:00",
+    "start": "2028-05-14T03:00:00.000Z",
+    "end": "2028-05-15T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-05-24 00:00:00",
+    "start": "2028-05-24T03:00:00.000Z",
+    "end": "2028-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-06-12 00:00:00",
+    "start": "2028-06-12T03:00:00.000Z",
+    "end": "2028-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-06-15 00:00:00",
+    "start": "2028-06-15T03:00:00.000Z",
+    "end": "2028-06-16T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-07-26 00:00:00",
+    "start": "2028-07-26T03:00:00.000Z",
+    "end": "2028-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-08-13 00:00:00",
+    "start": "2028-08-13T03:00:00.000Z",
+    "end": "2028-08-14T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-09-07 00:00:00",
+    "start": "2028-09-07T03:00:00.000Z",
+    "end": "2028-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-10-01 00:00:00",
+    "start": "2028-10-01T03:00:00.000Z",
+    "end": "2028-10-02T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday in October in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-10-12 00:00:00",
+    "start": "2028-10-12T03:00:00.000Z",
+    "end": "2028-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-10-24 00:00:00",
+    "start": "2028-10-24T03:00:00.000Z",
+    "end": "2028-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2028-10-29 00:00:00",
+    "start": "2028-10-29T03:00:00.000Z",
+    "end": "2028-10-30T03:00:00.000Z",
+    "name": "Dia de Eleição",
+    "type": "public",
+    "rule": "1st sunday before 11-01 in even years",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-11-02 00:00:00",
+    "start": "2028-11-02T03:00:00.000Z",
+    "end": "2028-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-11-15 00:00:00",
+    "start": "2028-11-15T03:00:00.000Z",
+    "end": "2028-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2028-11-20 00:00:00",
+    "start": "2028-11-20T03:00:00.000Z",
+    "end": "2028-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-12-24 14:00:00",
+    "start": "2028-12-24T17:00:00.000Z",
+    "end": "2028-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-12-25 00:00:00",
+    "start": "2028-12-25T03:00:00.000Z",
+    "end": "2028-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-12-31 14:00:00",
+    "start": "2028-12-31T17:00:00.000Z",
+    "end": "2029-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Sun"
+  }
+]

--- a/test/fixtures/BR-GO-GOIANIA-2029.json
+++ b/test/fixtures/BR-GO-GOIANIA-2029.json
@@ -1,0 +1,218 @@
+[
+  {
+    "date": "2029-01-01 00:00:00",
+    "start": "2029-01-01T03:00:00.000Z",
+    "end": "2029-01-02T03:00:00.000Z",
+    "name": "Ano Novo",
+    "type": "public",
+    "rule": "01-01",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-10 00:00:00",
+    "start": "2029-02-10T03:00:00.000Z",
+    "end": "2029-02-12T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -50 PT48H",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-02-12 00:00:00",
+    "start": "2029-02-12T03:00:00.000Z",
+    "end": "2029-02-13T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -48",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-02-13 00:00:00",
+    "start": "2029-02-13T03:00:00.000Z",
+    "end": "2029-02-14T03:00:00.000Z",
+    "name": "Carnaval",
+    "type": "bank",
+    "rule": "easter -47",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-02-14 00:00:00",
+    "start": "2029-02-14T03:00:00.000Z",
+    "end": "2029-02-14T17:00:00.000Z",
+    "name": "Carnaval",
+    "type": "optional",
+    "rule": "easter -46 PT14H",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2029-03-30 00:00:00",
+    "start": "2029-03-30T03:00:00.000Z",
+    "end": "2029-03-31T03:00:00.000Z",
+    "name": "Sexta-Feira Santa",
+    "type": "public",
+    "rule": "easter -2",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-04-01 00:00:00",
+    "start": "2029-04-01T03:00:00.000Z",
+    "end": "2029-04-02T03:00:00.000Z",
+    "name": "Páscoa",
+    "type": "observance",
+    "rule": "easter",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-04-21 00:00:00",
+    "start": "2029-04-21T03:00:00.000Z",
+    "end": "2029-04-22T03:00:00.000Z",
+    "name": "Dia de Tiradentes",
+    "type": "public",
+    "rule": "04-21",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2029-05-01 00:00:00",
+    "start": "2029-05-01T03:00:00.000Z",
+    "end": "2029-05-02T03:00:00.000Z",
+    "name": "Dia do trabalhador",
+    "type": "public",
+    "rule": "05-01",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-05-13 00:00:00",
+    "start": "2029-05-13T03:00:00.000Z",
+    "end": "2029-05-14T03:00:00.000Z",
+    "name": "Dia das Mães",
+    "type": "observance",
+    "rule": "2nd sunday in May",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-05-24 00:00:00",
+    "start": "2029-05-24T03:00:00.000Z",
+    "end": "2029-05-25T03:00:00.000Z",
+    "name": "Nossa Senhora Auxiliadora",
+    "type": "public",
+    "rule": "05-24",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-05-31 00:00:00",
+    "start": "2029-05-31T03:00:00.000Z",
+    "end": "2029-06-01T03:00:00.000Z",
+    "name": "Corpo de Deus",
+    "type": "bank",
+    "rule": "easter 60",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-06-12 00:00:00",
+    "start": "2029-06-12T03:00:00.000Z",
+    "end": "2029-06-13T03:00:00.000Z",
+    "name": "Dia dos Namorados",
+    "type": "observance",
+    "rule": "06-12",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-07-26 00:00:00",
+    "start": "2029-07-26T03:00:00.000Z",
+    "end": "2029-07-27T03:00:00.000Z",
+    "name": "Fundação da Cidade de Goiás",
+    "type": "public",
+    "rule": "07-26",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-08-12 00:00:00",
+    "start": "2029-08-12T03:00:00.000Z",
+    "end": "2029-08-13T03:00:00.000Z",
+    "name": "Dia dos Pais",
+    "type": "observance",
+    "rule": "2nd sunday in August",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-09-07 00:00:00",
+    "start": "2029-09-07T03:00:00.000Z",
+    "end": "2029-09-08T03:00:00.000Z",
+    "name": "Dia da Independência",
+    "type": "public",
+    "rule": "09-07",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-10-12 00:00:00",
+    "start": "2029-10-12T03:00:00.000Z",
+    "end": "2029-10-13T03:00:00.000Z",
+    "name": "Nossa Senhora Aparecida",
+    "type": "public",
+    "rule": "10-12",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-10-24 00:00:00",
+    "start": "2029-10-24T03:00:00.000Z",
+    "end": "2029-10-25T03:00:00.000Z",
+    "name": "Lançamento da pedra fundamental de Goiânia",
+    "type": "public",
+    "rule": "10-24",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2029-11-02 00:00:00",
+    "start": "2029-11-02T03:00:00.000Z",
+    "end": "2029-11-03T03:00:00.000Z",
+    "name": "Dia de Finados",
+    "type": "public",
+    "rule": "11-02",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2029-11-15 00:00:00",
+    "start": "2029-11-15T03:00:00.000Z",
+    "end": "2029-11-16T03:00:00.000Z",
+    "name": "Proclamação da República",
+    "type": "public",
+    "rule": "11-15",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2029-11-20 00:00:00",
+    "start": "2029-11-20T03:00:00.000Z",
+    "end": "2029-11-21T03:00:00.000Z",
+    "name": "Dia da Consciência Negra",
+    "type": "public",
+    "rule": "11-20",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-12-24 14:00:00",
+    "start": "2029-12-24T17:00:00.000Z",
+    "end": "2029-12-25T03:00:00.000Z",
+    "name": "Noite de Natal",
+    "type": "optional",
+    "rule": "12-24 14:00",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2029-12-25 00:00:00",
+    "start": "2029-12-25T03:00:00.000Z",
+    "end": "2029-12-26T03:00:00.000Z",
+    "name": "Natal",
+    "type": "public",
+    "rule": "12-25",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2029-12-31 14:00:00",
+    "start": "2029-12-31T17:00:00.000Z",
+    "end": "2030-01-01T03:00:00.000Z",
+    "name": "Véspera de Ano Novo",
+    "type": "optional",
+    "rule": "12-31 14:00",
+    "_weekday": "Mon"
+  }
+]


### PR DESCRIPTION
While comparing `opening_hours.js` with `date-holidays` data, I noticed that Espírito Santo and Goiás were still missing in `BR.yaml` and only existed as commented placeholders. I researched and added the missing entries.