### PR TITLE
fix(DK): use formal Danish holiday names and optimize observance notes

### DIFF
--- a/data/countries/DK.yaml
+++ b/data/countries/DK.yaml
@@ -34,14 +34,16 @@ holidays:
       05-01:
         _name: 05-01
         type: observance
-        note: Full holiday for blue collar workers
+        note: Not a public holiday; full day off for blue collar workers only
+        # @source https://cphpost.dk/2025-05-01/life-in-denmark/what-happens-on-the-1st-of-may/
       2nd sunday in May:
         _name: Mothers Day
         type: observance
       06-05:
         _name: Constitution Day
         type: observance
-        note: Shops are closed
+        note: Not a public holiday; shops closed by law
+        # @source https://www.retsinformation.dk/eli/lta/2019/515
       easter 49:
         _name: easter 49
       easter 50:
@@ -49,7 +51,8 @@ holidays:
       12-24:
         _name: 12-24
         type: observance
-        note: Shops are closed
+        note: Not a public holiday; shops closed by law
+        # @source https://www.retsinformation.dk/eli/lta/2019/515
       12-25:
         _name: 12-25
       12-26:

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -19,7 +19,7 @@ names:
       bs: Novogodisnji dan
       ca: Any nou
       cz: Nový rok
-      da: Nytår
+      da: Nytårsdag
       de: Neujahr
       el: Πρωτοχρονιά
       es: Año Nuevo
@@ -351,7 +351,7 @@ names:
       bg: Бъдни вечер
       bs: Badnji dan
       cz: Štědrý den
-      da: Juleaften
+      da: Juleaftensdag
       de: Heiliger Abend
       es: Nochebuena
       et: jõululaupäev
@@ -627,7 +627,7 @@ names:
       bg: Великден
       bs: Vaskrs
       cz: Velikonoční neděle
-      da: Påskesøndag
+      da: Påskedag
       de: Ostersonntag
       el: Πάσχα
       es: Pascua

--- a/test/fixtures/DK-2015.json
+++ b/test/fixtures/DK-2015.json
@@ -3,7 +3,7 @@
     "date": "2015-01-01 00:00:00",
     "start": "2014-12-31T23:00:00.000Z",
     "end": "2015-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2015-04-05 00:00:00",
     "start": "2015-04-04T22:00:00.000Z",
     "end": "2015-04-05T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2015-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Fri"
   },
@@ -114,7 +114,7 @@
     "end": "2015-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Fri"
   },
@@ -122,9 +122,9 @@
     "date": "2015-12-24 00:00:00",
     "start": "2015-12-23T23:00:00.000Z",
     "end": "2015-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Thu"
   },

--- a/test/fixtures/DK-2016.json
+++ b/test/fixtures/DK-2016.json
@@ -3,7 +3,7 @@
     "date": "2016-01-01 00:00:00",
     "start": "2015-12-31T23:00:00.000Z",
     "end": "2016-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2016-03-27 00:00:00",
     "start": "2016-03-26T23:00:00.000Z",
     "end": "2016-03-27T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -68,7 +68,7 @@
     "end": "2016-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Sun"
   },
@@ -114,7 +114,7 @@
     "end": "2016-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Sun"
   },
@@ -122,9 +122,9 @@
     "date": "2016-12-24 00:00:00",
     "start": "2016-12-23T23:00:00.000Z",
     "end": "2016-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Sat"
   },

--- a/test/fixtures/DK-2017.json
+++ b/test/fixtures/DK-2017.json
@@ -3,7 +3,7 @@
     "date": "2017-01-01 00:00:00",
     "start": "2016-12-31T23:00:00.000Z",
     "end": "2017-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2017-04-16 00:00:00",
     "start": "2017-04-15T22:00:00.000Z",
     "end": "2017-04-16T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2017-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Mon"
   },
@@ -114,7 +114,7 @@
     "end": "2017-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Mon"
   },
@@ -122,9 +122,9 @@
     "date": "2017-12-24 00:00:00",
     "start": "2017-12-23T23:00:00.000Z",
     "end": "2017-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DK-2018.json
+++ b/test/fixtures/DK-2018.json
@@ -3,7 +3,7 @@
     "date": "2018-01-01 00:00:00",
     "start": "2017-12-31T23:00:00.000Z",
     "end": "2018-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2018-04-01 00:00:00",
     "start": "2018-03-31T22:00:00.000Z",
     "end": "2018-04-01T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -68,7 +68,7 @@
     "end": "2018-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Tue"
   },
@@ -114,7 +114,7 @@
     "end": "2018-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Tue"
   },
@@ -122,9 +122,9 @@
     "date": "2018-12-24 00:00:00",
     "start": "2018-12-23T23:00:00.000Z",
     "end": "2018-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Mon"
   },

--- a/test/fixtures/DK-2019.json
+++ b/test/fixtures/DK-2019.json
@@ -3,7 +3,7 @@
     "date": "2019-01-01 00:00:00",
     "start": "2018-12-31T23:00:00.000Z",
     "end": "2019-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2019-04-21 00:00:00",
     "start": "2019-04-20T22:00:00.000Z",
     "end": "2019-04-21T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2019-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Wed"
   },
@@ -96,7 +96,7 @@
     "end": "2019-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Wed"
   },
@@ -122,9 +122,9 @@
     "date": "2019-12-24 00:00:00",
     "start": "2019-12-23T23:00:00.000Z",
     "end": "2019-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Tue"
   },

--- a/test/fixtures/DK-2020.json
+++ b/test/fixtures/DK-2020.json
@@ -3,7 +3,7 @@
     "date": "2020-01-01 00:00:00",
     "start": "2019-12-31T23:00:00.000Z",
     "end": "2020-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2020-04-12 00:00:00",
     "start": "2020-04-11T22:00:00.000Z",
     "end": "2020-04-12T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2020-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Fri"
   },
@@ -114,7 +114,7 @@
     "end": "2020-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Fri"
   },
@@ -122,9 +122,9 @@
     "date": "2020-12-24 00:00:00",
     "start": "2020-12-23T23:00:00.000Z",
     "end": "2020-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Thu"
   },

--- a/test/fixtures/DK-2021.json
+++ b/test/fixtures/DK-2021.json
@@ -3,7 +3,7 @@
     "date": "2021-01-01 00:00:00",
     "start": "2020-12-31T23:00:00.000Z",
     "end": "2021-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2021-04-04 00:00:00",
     "start": "2021-04-03T22:00:00.000Z",
     "end": "2021-04-04T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -68,7 +68,7 @@
     "end": "2021-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Sat"
   },
@@ -114,7 +114,7 @@
     "end": "2021-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Sat"
   },
@@ -122,9 +122,9 @@
     "date": "2021-12-24 00:00:00",
     "start": "2021-12-23T23:00:00.000Z",
     "end": "2021-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Fri"
   },

--- a/test/fixtures/DK-2022.json
+++ b/test/fixtures/DK-2022.json
@@ -3,7 +3,7 @@
     "date": "2022-01-01 00:00:00",
     "start": "2021-12-31T23:00:00.000Z",
     "end": "2022-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2022-04-17 00:00:00",
     "start": "2022-04-16T22:00:00.000Z",
     "end": "2022-04-17T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2022-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Sun"
   },
@@ -96,7 +96,7 @@
     "end": "2022-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Sun"
   },
@@ -122,9 +122,9 @@
     "date": "2022-12-24 00:00:00",
     "start": "2022-12-23T23:00:00.000Z",
     "end": "2022-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Sat"
   },

--- a/test/fixtures/DK-2023.json
+++ b/test/fixtures/DK-2023.json
@@ -3,7 +3,7 @@
     "date": "2023-01-01 00:00:00",
     "start": "2022-12-31T23:00:00.000Z",
     "end": "2023-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2023-04-09 00:00:00",
     "start": "2023-04-08T22:00:00.000Z",
     "end": "2023-04-09T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2023-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Mon"
   },
@@ -114,7 +114,7 @@
     "end": "2023-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Mon"
   },
@@ -122,9 +122,9 @@
     "date": "2023-12-24 00:00:00",
     "start": "2023-12-23T23:00:00.000Z",
     "end": "2023-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DK-2024.json
+++ b/test/fixtures/DK-2024.json
@@ -3,7 +3,7 @@
     "date": "2024-01-01 00:00:00",
     "start": "2023-12-31T23:00:00.000Z",
     "end": "2024-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2024-03-31 00:00:00",
     "start": "2024-03-30T23:00:00.000Z",
     "end": "2024-03-31T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2024-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Wed"
   },
@@ -105,7 +105,7 @@
     "end": "2024-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Wed"
   },
@@ -113,9 +113,9 @@
     "date": "2024-12-24 00:00:00",
     "start": "2024-12-23T23:00:00.000Z",
     "end": "2024-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Tue"
   },

--- a/test/fixtures/DK-2025.json
+++ b/test/fixtures/DK-2025.json
@@ -3,7 +3,7 @@
     "date": "2025-01-01 00:00:00",
     "start": "2024-12-31T23:00:00.000Z",
     "end": "2025-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2025-04-20 00:00:00",
     "start": "2025-04-19T22:00:00.000Z",
     "end": "2025-04-20T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2025-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Thu"
   },
@@ -87,7 +87,7 @@
     "end": "2025-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Thu"
   },
@@ -113,9 +113,9 @@
     "date": "2025-12-24 00:00:00",
     "start": "2025-12-23T23:00:00.000Z",
     "end": "2025-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Wed"
   },

--- a/test/fixtures/DK-2026.json
+++ b/test/fixtures/DK-2026.json
@@ -3,7 +3,7 @@
     "date": "2026-01-01 00:00:00",
     "start": "2025-12-31T23:00:00.000Z",
     "end": "2026-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2026-04-05 00:00:00",
     "start": "2026-04-04T22:00:00.000Z",
     "end": "2026-04-05T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2026-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Fri"
   },
@@ -105,7 +105,7 @@
     "end": "2026-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Fri"
   },
@@ -113,9 +113,9 @@
     "date": "2026-12-24 00:00:00",
     "start": "2026-12-23T23:00:00.000Z",
     "end": "2026-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Thu"
   },

--- a/test/fixtures/DK-2027.json
+++ b/test/fixtures/DK-2027.json
@@ -3,7 +3,7 @@
     "date": "2027-01-01 00:00:00",
     "start": "2026-12-31T23:00:00.000Z",
     "end": "2027-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2027-03-28 00:00:00",
     "start": "2027-03-27T23:00:00.000Z",
     "end": "2027-03-28T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2027-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Sat"
   },
@@ -105,7 +105,7 @@
     "end": "2027-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Sat"
   },
@@ -113,9 +113,9 @@
     "date": "2027-12-24 00:00:00",
     "start": "2027-12-23T23:00:00.000Z",
     "end": "2027-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Fri"
   },

--- a/test/fixtures/DK-2028.json
+++ b/test/fixtures/DK-2028.json
@@ -3,7 +3,7 @@
     "date": "2028-01-01 00:00:00",
     "start": "2027-12-31T23:00:00.000Z",
     "end": "2028-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2028-04-16 00:00:00",
     "start": "2028-04-15T22:00:00.000Z",
     "end": "2028-04-16T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2028-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Mon"
   },
@@ -105,7 +105,7 @@
     "end": "2028-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Mon"
   },
@@ -113,9 +113,9 @@
     "date": "2028-12-24 00:00:00",
     "start": "2028-12-23T23:00:00.000Z",
     "end": "2028-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DK-2029.json
+++ b/test/fixtures/DK-2029.json
@@ -3,7 +3,7 @@
     "date": "2029-01-01 00:00:00",
     "start": "2028-12-31T23:00:00.000Z",
     "end": "2029-01-01T23:00:00.000Z",
-    "name": "Nytår",
+    "name": "Nytårsdag",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2029-04-01 00:00:00",
     "start": "2029-03-31T22:00:00.000Z",
     "end": "2029-04-01T22:00:00.000Z",
-    "name": "Påskesøndag",
+    "name": "Påskedag",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -59,7 +59,7 @@
     "end": "2029-05-01T22:00:00.000Z",
     "name": "1. maj",
     "type": "observance",
-    "note": "Full holiday for blue collar workers",
+    "note": "Not a public holiday; full day off for blue collar workers only",
     "rule": "05-01",
     "_weekday": "Tue"
   },
@@ -105,7 +105,7 @@
     "end": "2029-06-05T22:00:00.000Z",
     "name": "Grundlovsdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "06-05",
     "_weekday": "Tue"
   },
@@ -113,9 +113,9 @@
     "date": "2029-12-24 00:00:00",
     "start": "2029-12-23T23:00:00.000Z",
     "end": "2029-12-24T23:00:00.000Z",
-    "name": "Juleaften",
+    "name": "Juleaftensdag",
     "type": "observance",
-    "note": "Shops are closed",
+    "note": "Not a public holiday; shops closed by law",
     "rule": "12-24",
     "_weekday": "Mon"
   },


### PR DESCRIPTION
While comparing `opening_hours.js` with `date-holidays`, I noticed a few inconsistencies in the Danish holiday data. I checked the official naming and observance details, updated the entries, added sources, and regenerated the fixtures.