### PR TITLE
feat(PY): Add a new holiday for Paraguay in 2026 to recognize the his…

### DIFF
--- a/data/countries/PY.yaml
+++ b/data/countries/PY.yaml
@@ -72,3 +72,8 @@ holidays:
       12-31:
         _name: 12-31
         type: bank
+      # @source https://as.com/futbol/mundial/festivo-nacional-en-paraguay-tras-eliminar-a-alemania-f202606-n/
+      2026-06-30:
+        name:
+          en: Recognition of the historic victory of the Paraguayan national football team over Germany
+          es: Reconocimiento al histórico triunfo de la Selección Paraguaya de Fútbol frente a Alemania

--- a/test/fixtures/PY-2026.json
+++ b/test/fixtures/PY-2026.json
@@ -82,6 +82,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2026-06-30 00:00:00",
+    "start": "2026-06-30T03:00:00.000Z",
+    "end": "2026-07-01T03:00:00.000Z",
+    "name": "Reconocimiento al histórico triunfo de la Selección Paraguaya de Fútbol frente a Alemania",
+    "type": "public",
+    "rule": "2026-06-30",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-15T03:00:00.000Z",
     "end": "2026-08-16T03:00:00.000Z",


### PR DESCRIPTION
…toric victory of the Paraguayan national football team over Germany.

Source: https://as.com/futbol/mundial/festivo-nacional-en-paraguay-tras-eliminar-a-alemania-f202606-n/