### PR TITLE
fix(ca): improve Canadian provincial holiday rules

### DIFF
--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -60,10 +60,6 @@ holidays:
       2nd sunday after 05-01:
         _name: Mothers Day
         type: observance
-      monday before 05-25:
-        name:
-          en: Victoria Day
-          fr: Fête de la Reine
       3rd sunday after 06-01:
         _name: Fathers Day
         type: observance
@@ -102,6 +98,10 @@ holidays:
             name:
               en: Family Day
               fr: Fête de la famille
+          monday before 05-25:
+            name:
+              en: Victoria Day
+              fr: Fête de la Reine
           easter 1:
             _name: easter 1
             type: optional
@@ -123,6 +123,10 @@ holidays:
           - America/Creston
           - America/Dawson_Creek
         days:
+          monday before 05-25:
+            name:
+              en: Victoria Day
+              fr: Fête de la Reine
           1st monday in August:
             name:
               en: British Columbia Day
@@ -153,6 +157,10 @@ holidays:
             name:
               en: Louis Riel Day
               fr: Journée Louis Riel
+          monday before 05-25:
+            name:
+              en: Victoria Day
+              fr: Fête de la Reine
           1st monday in August:
             name:
               en: Terry Fox Day
@@ -249,6 +257,10 @@ holidays:
             name:
               en: Civic Holiday
               fr: Premier lundi d’août
+          monday before 05-25:
+            name:
+              en: Victoria Day
+              fr: Fête de la Reine
           11-11:
             name:
               en: Remembrance Day
@@ -275,6 +287,10 @@ holidays:
           - America/Atikokan
           - America/Cambridge_Bay
         days:
+          monday before 05-25:
+            name:
+              en: Victoria Day
+              fr: Fête de la Reine
           1st monday in August:
             name:
               en: Civic Holiday
@@ -302,6 +318,10 @@ holidays:
             name:
               en: Family Day
               fr: Fête de la famille
+          monday before 05-25:
+            name:
+              en: Victoria Day
+              fr: Fête de la Reine
           easter 1:
             _name: easter 1
           1st monday in August:
@@ -353,6 +373,7 @@ holidays:
             _name: easter 1
             type: optional
             note: Either Good Friday or Easter Monday, at the employer’s option
+          # @source https://www.cnesst.gouv.qc.ca/en/working-conditions/leave/statutory-holidays/statutory-holidays
           monday before 05-25:
             name:
               en: National Patriots' Day
@@ -377,6 +398,10 @@ holidays:
             name:
               en: Family Day
               fr: Fête de la famille
+          monday before 05-25:
+            name:
+              en: Victoria Day
+              fr: Fête de la Reine
           1st monday in August:
             name:
               en: Saskatchewan Day
@@ -393,6 +418,10 @@ holidays:
         days:
           easter 1:
             _name: easter 1
+          monday before 05-25:
+            name:
+              en: Victoria Day
+              fr: Fête de la Reine
           11-11:
             name:
               en: Remembrance Day

--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -102,8 +102,6 @@ holidays:
           fr: Jour du Souvenir
       12-25:
         _name: 12-25
-      12-26:
-        _name: 12-26
     states:
       AB:
         name: Alberta
@@ -240,6 +238,9 @@ holidays:
             name:
               en: National Indigenous Peoples Day
               fr: Journée nationale des Autochthones
+          # @source https://my.hr.gov.nt.ca/employees/leave-time/statutory-holidays
+          12-26:
+            _name: 12-26
       NU:
         name: Nunavut
         zones:
@@ -271,6 +272,9 @@ holidays:
               fr: Fête de la famille
           easter 1:
             _name: easter 1
+          # @source https://www.ontario.ca/document/your-guide-employment-standards-act-0/public-holidays
+          12-26:
+            _name: 12-26
           09-30 since 2021: false
       PE:
         name: Prince Edward Island

--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -57,8 +57,6 @@ holidays:
         type: observance
       easter -2:
         _name: easter -2
-      easter:
-        _name: easter
       2nd sunday after 05-01:
         _name: Mothers Day
         type: observance

--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -92,10 +92,6 @@ holidays:
           en: Halloween
           fr: l'Halloween
         type: observance
-      11-11:
-        name:
-          en: Remembrance Day
-          fr: Jour du Souvenir
       12-25:
         _name: 12-25
     states:
@@ -116,6 +112,10 @@ holidays:
               en: Heritage Day
               fr: Fête du patrimoine
             type: optional
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
           09-30 since 2021: false
       BC:
         name: British Columbia
@@ -128,6 +128,10 @@ holidays:
           1st monday in August:
             name:
               en: British Columbia Day
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
           2nd monday after 02-01:
             name:
               en: Family Day
@@ -156,6 +160,11 @@ holidays:
               en: Terry Fox Day
               fr: Journée Terry Fox
             type: optional
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
+            type: optional
       NB:
         name: New Brunswick
         zones:
@@ -165,6 +174,10 @@ holidays:
             name:
               en: New Brunswick Day
               fr: Jour de Nouveau Brunswick
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
           # @attrib https://en.wikipedia.org/wiki/Family_Day_(Canada)
           3rd monday after 02-01:
             name:
@@ -224,6 +237,10 @@ holidays:
               en: Natal Day
               fr: Jour de la Fondation
             type: optional
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
       NT:
         name: Northwest Territories
         zones:
@@ -234,6 +251,10 @@ holidays:
             name:
               en: Civic Holiday
               fr: Premier lundi d’août
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
           # @source https://my.hr.gov.nt.ca/employees/leave-time/statutory-holidays
           easter: false
           # @source https://my.hr.gov.nt.ca/employees/leave-time/statutory-holidays
@@ -264,6 +285,10 @@ holidays:
             name:
               en: Nunavut Day
             type: bank
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
           09-30 since 2021: false
       "ON":
         name: Ontario
@@ -286,6 +311,11 @@ holidays:
               en: Civic Holiday
               fr: Premier lundi d’août
             type: optional
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
+            type: optional
           # @source https://www.ontario.ca/document/your-guide-employment-standards-act-0/public-holidays
           12-26:
             _name: 12-26
@@ -304,6 +334,10 @@ holidays:
             name:
               en: Gold Cup Parade Day
               fr: "Défilé de la Coupe d'or"
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
           09-30 since 2021: false
       # @source https://www.cnesst.gouv.qc.ca/en/working-conditions/leave/statutory-holidays/statutory-holidays
       QC:
@@ -348,6 +382,10 @@ holidays:
           1st monday in August:
             name:
               en: Saskatchewan Day
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
           09-30 since 2021: false
       YT:
         name: Yukon
@@ -357,6 +395,10 @@ holidays:
         days:
           easter 1:
             _name: easter 1
+          11-11:
+            name:
+              en: Remembrance Day
+              fr: Jour du Souvenir
           3rd monday in August:
             name:
               en: Discovery Day

--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -181,6 +181,10 @@ holidays:
           - America/St_Johns
           - America/Goose_Bay
         days:
+          # @source https://www.assembly.nl.ca/legislation/sr/annualstatutes/RSN1990/S15.c90.htm
+          07-01:
+            name:
+              en: Memorial Day
           03-17:
             name:
               en: Saint Patrick's Day
@@ -201,6 +205,8 @@ holidays:
               en: Orangemen's Day
               fr: Fête des orangistes
             type: optional
+          # @source https://www.assembly.nl.ca/legislation/sr/annualstatutes/RSN1990/S15.c90.htm
+          1st monday in August: false
           11-11:
             name:
               en: Armistice Day
@@ -225,6 +231,11 @@ holidays:
           - America/Yellowknife
           - America/Inuvik
         days:
+          # @source https://my.hr.gov.nt.ca/employees/leave-time/statutory-holidays
+          easter: false
+          # @source https://my.hr.gov.nt.ca/employees/leave-time/statutory-holidays
+          easter 1:
+            _name: easter 1
           06-21 since 2001:
             name:
               en: National Indigenous Peoples Day
@@ -287,8 +298,10 @@ holidays:
           easter -2:
             _name: easter -2
             note: Either Good Friday or Easter Monday, at the employer’s option
+          # @source https://www.cnesst.gouv.qc.ca/en/working-conditions/leave/statutory-holidays/statutory-holidays
           easter 1:
             _name: easter 1
+            type: optional
             note: Either Good Friday or Easter Monday, at the employer’s option
           monday before 05-25:
             name:
@@ -299,6 +312,10 @@ holidays:
               en: National Holiday
               fr: Fête nationale du Québec
           monday after 08-01: false
+          # @source https://www.cnesst.gouv.qc.ca/en/working-conditions/leave/statutory-holidays/statutory-holidays
+          11-11: false
+          # @source https://www.cnesst.gouv.qc.ca/en/working-conditions/leave/statutory-holidays/statutory-holidays
+          12-26: false
           09-30 since 2021: false
       SK:
         name: Saskatchewan

--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -73,10 +73,6 @@ holidays:
         name:
           en: Canada Day
           fr: Fête du Canada
-      1st monday in August:
-        name:
-          en: Civic Holiday
-          fr: Premier lundi d’août
       1st monday in September:
         _name: 05-01
       # @source https://www.canada.ca/en/canadian-heritage/campaigns/national-day-truth-reconciliation.html
@@ -129,6 +125,9 @@ holidays:
           - America/Creston
           - America/Dawson_Creek
         days:
+          1st monday in August:
+            name:
+              en: British Columbia Day
           2nd monday after 02-01:
             name:
               en: Family Day
@@ -156,6 +155,7 @@ holidays:
             name:
               en: Terry Fox Day
               fr: Journée Terry Fox
+            type: optional
       NB:
         name: New Brunswick
         zones:
@@ -223,12 +223,17 @@ holidays:
             name:
               en: Natal Day
               fr: Jour de la Fondation
+            type: optional
       NT:
         name: Northwest Territories
         zones:
           - America/Yellowknife
           - America/Inuvik
         days:
+          1st monday in August:
+            name:
+              en: Civic Holiday
+              fr: Premier lundi d’août
           # @source https://my.hr.gov.nt.ca/employees/leave-time/statutory-holidays
           easter: false
           # @source https://my.hr.gov.nt.ca/employees/leave-time/statutory-holidays
@@ -251,6 +256,10 @@ holidays:
           - America/Atikokan
           - America/Cambridge_Bay
         days:
+          1st monday in August:
+            name:
+              en: Civic Holiday
+              fr: Premier lundi d’août
           07-09:
             name:
               en: Nunavut Day
@@ -272,6 +281,11 @@ holidays:
               fr: Fête de la famille
           easter 1:
             _name: easter 1
+          1st monday in August:
+            name:
+              en: Civic Holiday
+              fr: Premier lundi d’août
+            type: optional
           # @source https://www.ontario.ca/document/your-guide-employment-standards-act-0/public-holidays
           12-26:
             _name: 12-26
@@ -315,7 +329,6 @@ holidays:
             name:
               en: National Holiday
               fr: Fête nationale du Québec
-          monday after 08-01: false
           # @source https://www.cnesst.gouv.qc.ca/en/working-conditions/leave/statutory-holidays/statutory-holidays
           11-11: false
           # @source https://www.cnesst.gouv.qc.ca/en/working-conditions/leave/statutory-holidays/statutory-holidays

--- a/data/countries/CA.yaml
+++ b/data/countries/CA.yaml
@@ -77,10 +77,6 @@ holidays:
           fr: Journée nationale de la vérité et de la réconciliation
         type: observance
         note: Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work
-      2nd monday after 10-01:
-        name:
-          en: Thanksgiving
-          fr: Action de grâce
       10-31 18:00:
         name:
           en: Halloween
@@ -110,6 +106,10 @@ holidays:
               en: Heritage Day
               fr: Fête du patrimoine
             type: optional
+          2nd monday after 10-01:
+            name:
+              en: Thanksgiving
+              fr: Action de grâce
           11-11:
             name:
               en: Remembrance Day
@@ -130,6 +130,10 @@ holidays:
           1st monday in August:
             name:
               en: British Columbia Day
+          2nd monday after 10-01:
+            name:
+              en: Thanksgiving
+              fr: Action de grâce
           11-11:
             name:
               en: Remembrance Day
@@ -166,6 +170,10 @@ holidays:
               en: Terry Fox Day
               fr: Journée Terry Fox
             type: optional
+          2nd monday after 10-01:
+            name:
+              en: Thanksgiving
+              fr: Action de grâce
           11-11:
             name:
               en: Remembrance Day
@@ -274,6 +282,10 @@ holidays:
             name:
               en: National Indigenous Peoples Day
               fr: Journée nationale des Autochthones
+          2nd monday after 10-01:
+            name:
+              en: Thanksgiving
+              fr: Action de grâce
           # @source https://my.hr.gov.nt.ca/employees/leave-time/statutory-holidays
           12-26:
             _name: 12-26
@@ -299,6 +311,10 @@ holidays:
             name:
               en: Nunavut Day
             type: bank
+          2nd monday after 10-01:
+            name:
+              en: Thanksgiving
+              fr: Action de grâce
           11-11:
             name:
               en: Remembrance Day
@@ -329,6 +345,10 @@ holidays:
               en: Civic Holiday
               fr: Premier lundi d’août
             type: optional
+          2nd monday after 10-01:
+            name:
+              en: Thanksgiving
+              fr: Action de grâce
           11-11:
             name:
               en: Remembrance Day
@@ -382,6 +402,10 @@ holidays:
             name:
               en: National Holiday
               fr: Fête nationale du Québec
+          2nd monday after 10-01:
+            name:
+              en: Thanksgiving
+              fr: Action de grâce
           # @source https://www.cnesst.gouv.qc.ca/en/working-conditions/leave/statutory-holidays/statutory-holidays
           11-11: false
           # @source https://www.cnesst.gouv.qc.ca/en/working-conditions/leave/statutory-holidays/statutory-holidays
@@ -405,6 +429,10 @@ holidays:
           1st monday in August:
             name:
               en: Saskatchewan Day
+          2nd monday after 10-01:
+            name:
+              en: Thanksgiving
+              fr: Action de grâce
           11-11:
             name:
               en: Remembrance Day
@@ -430,6 +458,10 @@ holidays:
             name:
               en: Discovery Day
               fr: Jour de la Découverte
+          2nd monday after 10-01:
+            name:
+              en: Thanksgiving
+              fr: Action de grâce
           06-21 since 2017:
             name:
               en: National Indigenous Peoples Day

--- a/test/fixtures/CA-2015.json
+++ b/test/fixtures/CA-2015.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T04:00:00.000Z",
-    "end": "2015-04-06T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-05-10 00:00:00",
     "start": "2015-05-10T04:00:00.000Z",
     "end": "2015-05-11T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2015-05-18 00:00:00",
-    "start": "2015-05-18T04:00:00.000Z",
-    "end": "2015-05-19T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2015-06-21 00:00:00",
@@ -90,30 +72,12 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2015-08-03 00:00:00",
-    "start": "2015-08-03T04:00:00.000Z",
-    "end": "2015-08-04T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2015-09-07 00:00:00",
     "start": "2015-09-07T04:00:00.000Z",
     "end": "2015-09-08T04:00:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2015-10-12 00:00:00",
-    "start": "2015-10-12T04:00:00.000Z",
-    "end": "2015-10-13T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -126,15 +90,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2015-11-11 00:00:00",
-    "start": "2015-11-11T05:00:00.000Z",
-    "end": "2015-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Wed"
-  },
-  {
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-25T05:00:00.000Z",
     "end": "2015-12-26T05:00:00.000Z",
@@ -142,14 +97,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T05:00:00.000Z",
-    "end": "2015-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-2016.json
+++ b/test/fixtures/CA-2016.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T04:00:00.000Z",
-    "end": "2016-03-28T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-05-08 00:00:00",
     "start": "2016-05-08T04:00:00.000Z",
     "end": "2016-05-09T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-05-23 00:00:00",
-    "start": "2016-05-23T04:00:00.000Z",
-    "end": "2016-05-24T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2016-06-19 00:00:00",
@@ -90,30 +72,12 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-08-01 00:00:00",
-    "start": "2016-08-01T04:00:00.000Z",
-    "end": "2016-08-02T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2016-09-05 00:00:00",
     "start": "2016-09-05T04:00:00.000Z",
     "end": "2016-09-06T04:00:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2016-10-10 00:00:00",
-    "start": "2016-10-10T04:00:00.000Z",
-    "end": "2016-10-11T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -126,15 +90,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2016-11-11 00:00:00",
-    "start": "2016-11-11T05:00:00.000Z",
-    "end": "2016-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-25T05:00:00.000Z",
     "end": "2016-12-26T05:00:00.000Z",
@@ -142,14 +97,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T05:00:00.000Z",
-    "end": "2016-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-2017.json
+++ b/test/fixtures/CA-2017.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T04:00:00.000Z",
-    "end": "2017-04-17T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-05-14 00:00:00",
     "start": "2017-05-14T04:00:00.000Z",
     "end": "2017-05-15T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2017-05-22 00:00:00",
-    "start": "2017-05-22T04:00:00.000Z",
-    "end": "2017-05-23T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2017-06-18 00:00:00",
@@ -90,30 +72,12 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2017-08-07 00:00:00",
-    "start": "2017-08-07T04:00:00.000Z",
-    "end": "2017-08-08T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2017-09-04 00:00:00",
     "start": "2017-09-04T04:00:00.000Z",
     "end": "2017-09-05T04:00:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2017-10-09 00:00:00",
-    "start": "2017-10-09T04:00:00.000Z",
-    "end": "2017-10-10T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -126,15 +90,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2017-11-11 00:00:00",
-    "start": "2017-11-11T05:00:00.000Z",
-    "end": "2017-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Sat"
-  },
-  {
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-25T05:00:00.000Z",
     "end": "2017-12-26T05:00:00.000Z",
@@ -142,14 +97,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T05:00:00.000Z",
-    "end": "2017-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-2018.json
+++ b/test/fixtures/CA-2018.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T04:00:00.000Z",
-    "end": "2018-04-02T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-05-13 00:00:00",
     "start": "2018-05-13T04:00:00.000Z",
     "end": "2018-05-14T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2018-05-21 00:00:00",
-    "start": "2018-05-21T04:00:00.000Z",
-    "end": "2018-05-22T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2018-06-17 00:00:00",
@@ -90,30 +72,12 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2018-08-06 00:00:00",
-    "start": "2018-08-06T04:00:00.000Z",
-    "end": "2018-08-07T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2018-09-03 00:00:00",
     "start": "2018-09-03T04:00:00.000Z",
     "end": "2018-09-04T04:00:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2018-10-08 00:00:00",
-    "start": "2018-10-08T04:00:00.000Z",
-    "end": "2018-10-09T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -126,15 +90,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2018-11-11 00:00:00",
-    "start": "2018-11-11T05:00:00.000Z",
-    "end": "2018-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-25T05:00:00.000Z",
     "end": "2018-12-26T05:00:00.000Z",
@@ -142,14 +97,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T05:00:00.000Z",
-    "end": "2018-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-2019.json
+++ b/test/fixtures/CA-2019.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T04:00:00.000Z",
-    "end": "2019-04-22T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-05-12 00:00:00",
     "start": "2019-05-12T04:00:00.000Z",
     "end": "2019-05-13T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2019-05-20 00:00:00",
-    "start": "2019-05-20T04:00:00.000Z",
-    "end": "2019-05-21T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2019-06-16 00:00:00",
@@ -90,30 +72,12 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2019-08-05 00:00:00",
-    "start": "2019-08-05T04:00:00.000Z",
-    "end": "2019-08-06T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2019-09-02 00:00:00",
     "start": "2019-09-02T04:00:00.000Z",
     "end": "2019-09-03T04:00:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2019-10-14 00:00:00",
-    "start": "2019-10-14T04:00:00.000Z",
-    "end": "2019-10-15T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -126,15 +90,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2019-11-11 00:00:00",
-    "start": "2019-11-11T05:00:00.000Z",
-    "end": "2019-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-25T05:00:00.000Z",
     "end": "2019-12-26T05:00:00.000Z",
@@ -142,14 +97,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T05:00:00.000Z",
-    "end": "2019-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-2020.json
+++ b/test/fixtures/CA-2020.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T04:00:00.000Z",
-    "end": "2020-04-13T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-05-10 00:00:00",
     "start": "2020-05-10T04:00:00.000Z",
     "end": "2020-05-11T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2020-05-18 00:00:00",
-    "start": "2020-05-18T04:00:00.000Z",
-    "end": "2020-05-19T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2020-06-21 00:00:00",
@@ -90,30 +72,12 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2020-08-03 00:00:00",
-    "start": "2020-08-03T04:00:00.000Z",
-    "end": "2020-08-04T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2020-09-07 00:00:00",
     "start": "2020-09-07T04:00:00.000Z",
     "end": "2020-09-08T04:00:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2020-10-12 00:00:00",
-    "start": "2020-10-12T04:00:00.000Z",
-    "end": "2020-10-13T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -126,15 +90,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2020-11-11 00:00:00",
-    "start": "2020-11-11T05:00:00.000Z",
-    "end": "2020-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Wed"
-  },
-  {
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-25T05:00:00.000Z",
     "end": "2020-12-26T05:00:00.000Z",
@@ -142,14 +97,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T05:00:00.000Z",
-    "end": "2020-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-2021.json
+++ b/test/fixtures/CA-2021.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T04:00:00.000Z",
-    "end": "2021-04-05T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-05-09 00:00:00",
     "start": "2021-05-09T04:00:00.000Z",
     "end": "2021-05-10T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2021-05-24 00:00:00",
-    "start": "2021-05-24T04:00:00.000Z",
-    "end": "2021-05-25T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-06-20 00:00:00",
@@ -88,15 +70,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2021-08-02 00:00:00",
-    "start": "2021-08-02T04:00:00.000Z",
-    "end": "2021-08-03T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-09-06 00:00:00",
@@ -118,15 +91,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2021-10-11 00:00:00",
-    "start": "2021-10-11T04:00:00.000Z",
-    "end": "2021-10-12T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2021-10-31 18:00:00",
     "start": "2021-10-31T22:00:00.000Z",
     "end": "2021-11-01T04:00:00.000Z",
@@ -136,15 +100,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2021-11-11 00:00:00",
-    "start": "2021-11-11T05:00:00.000Z",
-    "end": "2021-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Thu"
-  },
-  {
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-25T05:00:00.000Z",
     "end": "2021-12-26T05:00:00.000Z",
@@ -152,14 +107,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T05:00:00.000Z",
-    "end": "2021-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-2022.json
+++ b/test/fixtures/CA-2022.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T04:00:00.000Z",
-    "end": "2022-04-18T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-05-08 00:00:00",
     "start": "2022-05-08T04:00:00.000Z",
     "end": "2022-05-09T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-05-23 00:00:00",
-    "start": "2022-05-23T04:00:00.000Z",
-    "end": "2022-05-24T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-06-19 00:00:00",
@@ -88,15 +70,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2022-08-01 00:00:00",
-    "start": "2022-08-01T04:00:00.000Z",
-    "end": "2022-08-02T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-09-05 00:00:00",
@@ -118,15 +91,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-10-10 00:00:00",
-    "start": "2022-10-10T04:00:00.000Z",
-    "end": "2022-10-11T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2022-10-31 18:00:00",
     "start": "2022-10-31T22:00:00.000Z",
     "end": "2022-11-01T04:00:00.000Z",
@@ -136,15 +100,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-11-11 00:00:00",
-    "start": "2022-11-11T05:00:00.000Z",
-    "end": "2022-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-25T05:00:00.000Z",
     "end": "2022-12-26T05:00:00.000Z",
@@ -152,14 +107,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T05:00:00.000Z",
-    "end": "2022-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-2023.json
+++ b/test/fixtures/CA-2023.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T04:00:00.000Z",
-    "end": "2023-04-10T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-05-14 00:00:00",
     "start": "2023-05-14T04:00:00.000Z",
     "end": "2023-05-15T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2023-05-22 00:00:00",
-    "start": "2023-05-22T04:00:00.000Z",
-    "end": "2023-05-23T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-06-18 00:00:00",
@@ -88,15 +70,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2023-08-07 00:00:00",
-    "start": "2023-08-07T04:00:00.000Z",
-    "end": "2023-08-08T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-09-04 00:00:00",
@@ -118,15 +91,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2023-10-09 00:00:00",
-    "start": "2023-10-09T04:00:00.000Z",
-    "end": "2023-10-10T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2023-10-31 18:00:00",
     "start": "2023-10-31T22:00:00.000Z",
     "end": "2023-11-01T04:00:00.000Z",
@@ -136,15 +100,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2023-11-11 00:00:00",
-    "start": "2023-11-11T05:00:00.000Z",
-    "end": "2023-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Sat"
-  },
-  {
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-25T05:00:00.000Z",
     "end": "2023-12-26T05:00:00.000Z",
@@ -152,14 +107,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T05:00:00.000Z",
-    "end": "2023-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-2024.json
+++ b/test/fixtures/CA-2024.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T04:00:00.000Z",
-    "end": "2024-04-01T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-05-12 00:00:00",
     "start": "2024-05-12T04:00:00.000Z",
     "end": "2024-05-13T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2024-05-20 00:00:00",
-    "start": "2024-05-20T04:00:00.000Z",
-    "end": "2024-05-21T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2024-06-16 00:00:00",
@@ -87,15 +69,6 @@
     "name": "Canada Day",
     "type": "public",
     "rule": "07-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2024-08-05 00:00:00",
-    "start": "2024-08-05T04:00:00.000Z",
-    "end": "2024-08-06T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {
@@ -118,15 +91,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2024-10-14 00:00:00",
-    "start": "2024-10-14T04:00:00.000Z",
-    "end": "2024-10-15T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2024-10-31 18:00:00",
     "start": "2024-10-31T22:00:00.000Z",
     "end": "2024-11-01T04:00:00.000Z",
@@ -136,15 +100,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2024-11-11 00:00:00",
-    "start": "2024-11-11T05:00:00.000Z",
-    "end": "2024-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-25T05:00:00.000Z",
     "end": "2024-12-26T05:00:00.000Z",
@@ -152,14 +107,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T05:00:00.000Z",
-    "end": "2024-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-2025.json
+++ b/test/fixtures/CA-2025.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T04:00:00.000Z",
-    "end": "2025-04-21T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-05-11 00:00:00",
     "start": "2025-05-11T04:00:00.000Z",
     "end": "2025-05-12T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2025-05-19 00:00:00",
-    "start": "2025-05-19T04:00:00.000Z",
-    "end": "2025-05-20T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2025-06-15 00:00:00",
@@ -88,15 +70,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2025-08-04 00:00:00",
-    "start": "2025-08-04T04:00:00.000Z",
-    "end": "2025-08-05T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2025-09-01 00:00:00",
@@ -118,15 +91,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2025-10-13 00:00:00",
-    "start": "2025-10-13T04:00:00.000Z",
-    "end": "2025-10-14T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2025-10-31 18:00:00",
     "start": "2025-10-31T22:00:00.000Z",
     "end": "2025-11-01T04:00:00.000Z",
@@ -136,15 +100,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-11-11 00:00:00",
-    "start": "2025-11-11T05:00:00.000Z",
-    "end": "2025-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Tue"
-  },
-  {
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-25T05:00:00.000Z",
     "end": "2025-12-26T05:00:00.000Z",
@@ -152,14 +107,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T05:00:00.000Z",
-    "end": "2025-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-2026.json
+++ b/test/fixtures/CA-2026.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T04:00:00.000Z",
-    "end": "2026-04-06T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-05-10 00:00:00",
     "start": "2026-05-10T04:00:00.000Z",
     "end": "2026-05-11T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2026-05-18 00:00:00",
-    "start": "2026-05-18T04:00:00.000Z",
-    "end": "2026-05-19T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-06-21 00:00:00",
@@ -88,15 +70,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2026-08-03 00:00:00",
-    "start": "2026-08-03T04:00:00.000Z",
-    "end": "2026-08-04T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-09-07 00:00:00",
@@ -118,15 +91,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2026-10-12 00:00:00",
-    "start": "2026-10-12T04:00:00.000Z",
-    "end": "2026-10-13T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2026-10-31 18:00:00",
     "start": "2026-10-31T22:00:00.000Z",
     "end": "2026-11-01T04:00:00.000Z",
@@ -136,15 +100,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2026-11-11 00:00:00",
-    "start": "2026-11-11T05:00:00.000Z",
-    "end": "2026-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Wed"
-  },
-  {
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-25T05:00:00.000Z",
     "end": "2026-12-26T05:00:00.000Z",
@@ -152,14 +107,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T05:00:00.000Z",
-    "end": "2026-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-2027.json
+++ b/test/fixtures/CA-2027.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T04:00:00.000Z",
-    "end": "2027-03-29T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-05-09 00:00:00",
     "start": "2027-05-09T04:00:00.000Z",
     "end": "2027-05-10T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2027-05-24 00:00:00",
-    "start": "2027-05-24T04:00:00.000Z",
-    "end": "2027-05-25T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2027-06-20 00:00:00",
@@ -88,15 +70,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2027-08-02 00:00:00",
-    "start": "2027-08-02T04:00:00.000Z",
-    "end": "2027-08-03T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2027-09-06 00:00:00",
@@ -118,15 +91,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2027-10-11 00:00:00",
-    "start": "2027-10-11T04:00:00.000Z",
-    "end": "2027-10-12T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2027-10-31 18:00:00",
     "start": "2027-10-31T22:00:00.000Z",
     "end": "2027-11-01T04:00:00.000Z",
@@ -136,15 +100,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2027-11-11 00:00:00",
-    "start": "2027-11-11T05:00:00.000Z",
-    "end": "2027-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Thu"
-  },
-  {
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-25T05:00:00.000Z",
     "end": "2027-12-26T05:00:00.000Z",
@@ -152,14 +107,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T05:00:00.000Z",
-    "end": "2027-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-2028.json
+++ b/test/fixtures/CA-2028.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T04:00:00.000Z",
-    "end": "2028-04-17T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-05-14 00:00:00",
     "start": "2028-05-14T04:00:00.000Z",
     "end": "2028-05-15T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2028-05-22 00:00:00",
-    "start": "2028-05-22T04:00:00.000Z",
-    "end": "2028-05-23T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2028-06-18 00:00:00",
@@ -88,15 +70,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2028-08-07 00:00:00",
-    "start": "2028-08-07T04:00:00.000Z",
-    "end": "2028-08-08T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2028-09-04 00:00:00",
@@ -118,15 +91,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2028-10-09 00:00:00",
-    "start": "2028-10-09T04:00:00.000Z",
-    "end": "2028-10-10T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2028-10-31 18:00:00",
     "start": "2028-10-31T22:00:00.000Z",
     "end": "2028-11-01T04:00:00.000Z",
@@ -136,15 +100,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2028-11-11 00:00:00",
-    "start": "2028-11-11T05:00:00.000Z",
-    "end": "2028-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Sat"
-  },
-  {
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-25T05:00:00.000Z",
     "end": "2028-12-26T05:00:00.000Z",
@@ -152,14 +107,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T05:00:00.000Z",
-    "end": "2028-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-2029.json
+++ b/test/fixtures/CA-2029.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T04:00:00.000Z",
-    "end": "2029-04-02T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-05-13 00:00:00",
     "start": "2029-05-13T04:00:00.000Z",
     "end": "2029-05-14T04:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2029-05-21 00:00:00",
-    "start": "2029-05-21T04:00:00.000Z",
-    "end": "2029-05-22T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-06-17 00:00:00",
@@ -88,15 +70,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2029-08-06 00:00:00",
-    "start": "2029-08-06T04:00:00.000Z",
-    "end": "2029-08-07T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-09-03 00:00:00",
@@ -118,15 +91,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2029-10-08 00:00:00",
-    "start": "2029-10-08T04:00:00.000Z",
-    "end": "2029-10-09T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2029-10-31 18:00:00",
     "start": "2029-10-31T22:00:00.000Z",
     "end": "2029-11-01T04:00:00.000Z",
@@ -136,15 +100,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2029-11-11 00:00:00",
-    "start": "2029-11-11T05:00:00.000Z",
-    "end": "2029-11-12T05:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-25T05:00:00.000Z",
     "end": "2029-12-26T05:00:00.000Z",
@@ -152,14 +107,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T05:00:00.000Z",
-    "end": "2029-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-AB-2015.json
+++ b/test/fixtures/CA-AB-2015.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T06:00:00.000Z",
-    "end": "2015-04-06T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-06T06:00:00.000Z",
     "end": "2015-04-07T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T07:00:00.000Z",
-    "end": "2015-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-AB-2016.json
+++ b/test/fixtures/CA-AB-2016.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T06:00:00.000Z",
-    "end": "2016-03-28T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-28T06:00:00.000Z",
     "end": "2016-03-29T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T07:00:00.000Z",
-    "end": "2016-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-AB-2017.json
+++ b/test/fixtures/CA-AB-2017.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T06:00:00.000Z",
-    "end": "2017-04-17T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-17T06:00:00.000Z",
     "end": "2017-04-18T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T07:00:00.000Z",
-    "end": "2017-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-AB-2018.json
+++ b/test/fixtures/CA-AB-2018.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T06:00:00.000Z",
-    "end": "2018-04-02T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-02T06:00:00.000Z",
     "end": "2018-04-03T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T07:00:00.000Z",
-    "end": "2018-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-AB-2019.json
+++ b/test/fixtures/CA-AB-2019.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T06:00:00.000Z",
-    "end": "2019-04-22T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-22T06:00:00.000Z",
     "end": "2019-04-23T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T07:00:00.000Z",
-    "end": "2019-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-AB-2020.json
+++ b/test/fixtures/CA-AB-2020.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T06:00:00.000Z",
-    "end": "2020-04-13T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-13T06:00:00.000Z",
     "end": "2020-04-14T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T07:00:00.000Z",
-    "end": "2020-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-AB-2021.json
+++ b/test/fixtures/CA-AB-2021.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T06:00:00.000Z",
-    "end": "2021-04-05T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-05T06:00:00.000Z",
     "end": "2021-04-06T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T07:00:00.000Z",
-    "end": "2021-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-AB-2022.json
+++ b/test/fixtures/CA-AB-2022.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T06:00:00.000Z",
-    "end": "2022-04-18T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-18T06:00:00.000Z",
     "end": "2022-04-19T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T07:00:00.000Z",
-    "end": "2022-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-AB-2023.json
+++ b/test/fixtures/CA-AB-2023.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T06:00:00.000Z",
-    "end": "2023-04-10T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-10T06:00:00.000Z",
     "end": "2023-04-11T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T07:00:00.000Z",
-    "end": "2023-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-AB-2024.json
+++ b/test/fixtures/CA-AB-2024.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T06:00:00.000Z",
-    "end": "2024-04-01T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-04-01 00:00:00",
     "start": "2024-04-01T06:00:00.000Z",
     "end": "2024-04-02T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T07:00:00.000Z",
-    "end": "2024-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-AB-2025.json
+++ b/test/fixtures/CA-AB-2025.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T06:00:00.000Z",
-    "end": "2025-04-21T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-21T06:00:00.000Z",
     "end": "2025-04-22T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T07:00:00.000Z",
-    "end": "2025-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-AB-2026.json
+++ b/test/fixtures/CA-AB-2026.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T06:00:00.000Z",
-    "end": "2026-04-06T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-06T06:00:00.000Z",
     "end": "2026-04-07T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T07:00:00.000Z",
-    "end": "2026-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-AB-2027.json
+++ b/test/fixtures/CA-AB-2027.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T06:00:00.000Z",
-    "end": "2027-03-29T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-29T06:00:00.000Z",
     "end": "2027-03-30T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T07:00:00.000Z",
-    "end": "2027-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-AB-2028.json
+++ b/test/fixtures/CA-AB-2028.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T06:00:00.000Z",
-    "end": "2028-04-17T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-17T06:00:00.000Z",
     "end": "2028-04-18T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T07:00:00.000Z",
-    "end": "2028-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-AB-2029.json
+++ b/test/fixtures/CA-AB-2029.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T06:00:00.000Z",
-    "end": "2029-04-02T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-02T06:00:00.000Z",
     "end": "2029-04-03T06:00:00.000Z",
@@ -160,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T07:00:00.000Z",
-    "end": "2029-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-BC-2015.json
+++ b/test/fixtures/CA-BC-2015.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T07:00:00.000Z",
-    "end": "2015-04-06T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-05-10 00:00:00",
     "start": "2015-05-10T07:00:00.000Z",
     "end": "2015-05-11T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2015-08-03 00:00:00",
     "start": "2015-08-03T07:00:00.000Z",
     "end": "2015-08-04T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T08:00:00.000Z",
-    "end": "2015-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-BC-2016.json
+++ b/test/fixtures/CA-BC-2016.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T07:00:00.000Z",
-    "end": "2016-03-28T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-05-08 00:00:00",
     "start": "2016-05-08T07:00:00.000Z",
     "end": "2016-05-09T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2016-08-01 00:00:00",
     "start": "2016-08-01T07:00:00.000Z",
     "end": "2016-08-02T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T08:00:00.000Z",
-    "end": "2016-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-BC-2017.json
+++ b/test/fixtures/CA-BC-2017.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T07:00:00.000Z",
-    "end": "2017-04-17T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-05-14 00:00:00",
     "start": "2017-05-14T07:00:00.000Z",
     "end": "2017-05-15T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2017-08-07 00:00:00",
     "start": "2017-08-07T07:00:00.000Z",
     "end": "2017-08-08T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T08:00:00.000Z",
-    "end": "2017-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-BC-2018.json
+++ b/test/fixtures/CA-BC-2018.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T07:00:00.000Z",
-    "end": "2018-04-02T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-05-13 00:00:00",
     "start": "2018-05-13T07:00:00.000Z",
     "end": "2018-05-14T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2018-08-06 00:00:00",
     "start": "2018-08-06T07:00:00.000Z",
     "end": "2018-08-07T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T08:00:00.000Z",
-    "end": "2018-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-BC-2019.json
+++ b/test/fixtures/CA-BC-2019.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T07:00:00.000Z",
-    "end": "2019-04-22T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-05-12 00:00:00",
     "start": "2019-05-12T07:00:00.000Z",
     "end": "2019-05-13T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2019-08-05 00:00:00",
     "start": "2019-08-05T07:00:00.000Z",
     "end": "2019-08-06T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T08:00:00.000Z",
-    "end": "2019-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-BC-2020.json
+++ b/test/fixtures/CA-BC-2020.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T07:00:00.000Z",
-    "end": "2020-04-13T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-05-10 00:00:00",
     "start": "2020-05-10T07:00:00.000Z",
     "end": "2020-05-11T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2020-08-03 00:00:00",
     "start": "2020-08-03T07:00:00.000Z",
     "end": "2020-08-04T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T08:00:00.000Z",
-    "end": "2020-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-BC-2021.json
+++ b/test/fixtures/CA-BC-2021.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T07:00:00.000Z",
-    "end": "2021-04-05T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-05-09 00:00:00",
     "start": "2021-05-09T07:00:00.000Z",
     "end": "2021-05-10T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2021-08-02 00:00:00",
     "start": "2021-08-02T07:00:00.000Z",
     "end": "2021-08-03T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T08:00:00.000Z",
-    "end": "2021-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-BC-2022.json
+++ b/test/fixtures/CA-BC-2022.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T07:00:00.000Z",
-    "end": "2022-04-18T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-05-08 00:00:00",
     "start": "2022-05-08T07:00:00.000Z",
     "end": "2022-05-09T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2022-08-01 00:00:00",
     "start": "2022-08-01T07:00:00.000Z",
     "end": "2022-08-02T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T08:00:00.000Z",
-    "end": "2022-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-BC-2023.json
+++ b/test/fixtures/CA-BC-2023.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T07:00:00.000Z",
-    "end": "2023-04-10T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-05-14 00:00:00",
     "start": "2023-05-14T07:00:00.000Z",
     "end": "2023-05-15T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2023-08-07 00:00:00",
     "start": "2023-08-07T07:00:00.000Z",
     "end": "2023-08-08T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T08:00:00.000Z",
-    "end": "2023-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-BC-2024.json
+++ b/test/fixtures/CA-BC-2024.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T07:00:00.000Z",
-    "end": "2024-04-01T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-05-12 00:00:00",
     "start": "2024-05-12T07:00:00.000Z",
     "end": "2024-05-13T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2024-08-05 00:00:00",
     "start": "2024-08-05T07:00:00.000Z",
     "end": "2024-08-06T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T08:00:00.000Z",
-    "end": "2024-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-BC-2025.json
+++ b/test/fixtures/CA-BC-2025.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T07:00:00.000Z",
-    "end": "2025-04-21T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-05-11 00:00:00",
     "start": "2025-05-11T07:00:00.000Z",
     "end": "2025-05-12T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2025-08-04 00:00:00",
     "start": "2025-08-04T07:00:00.000Z",
     "end": "2025-08-05T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T08:00:00.000Z",
-    "end": "2025-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-BC-2026.json
+++ b/test/fixtures/CA-BC-2026.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T07:00:00.000Z",
-    "end": "2026-04-06T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-05-10 00:00:00",
     "start": "2026-05-10T07:00:00.000Z",
     "end": "2026-05-11T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2026-08-03 00:00:00",
     "start": "2026-08-03T07:00:00.000Z",
     "end": "2026-08-04T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T08:00:00.000Z",
-    "end": "2026-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-BC-2027.json
+++ b/test/fixtures/CA-BC-2027.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T07:00:00.000Z",
-    "end": "2027-03-29T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-05-09 00:00:00",
     "start": "2027-05-09T07:00:00.000Z",
     "end": "2027-05-10T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2027-08-02 00:00:00",
     "start": "2027-08-02T07:00:00.000Z",
     "end": "2027-08-03T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T08:00:00.000Z",
-    "end": "2027-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-BC-2028.json
+++ b/test/fixtures/CA-BC-2028.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T07:00:00.000Z",
-    "end": "2028-04-17T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-05-14 00:00:00",
     "start": "2028-05-14T07:00:00.000Z",
     "end": "2028-05-15T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2028-08-07 00:00:00",
     "start": "2028-08-07T07:00:00.000Z",
     "end": "2028-08-08T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T08:00:00.000Z",
-    "end": "2028-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-BC-2029.json
+++ b/test/fixtures/CA-BC-2029.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T07:00:00.000Z",
-    "end": "2029-04-02T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-05-13 00:00:00",
     "start": "2029-05-13T07:00:00.000Z",
     "end": "2029-05-14T07:00:00.000Z",
@@ -102,7 +93,7 @@
     "date": "2029-08-06 00:00:00",
     "start": "2029-08-06T07:00:00.000Z",
     "end": "2029-08-07T07:00:00.000Z",
-    "name": "Civic Holiday",
+    "name": "British Columbia Day",
     "type": "public",
     "rule": "1st monday in August",
     "_weekday": "Mon"
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T08:00:00.000Z",
-    "end": "2029-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-MB-2015.json
+++ b/test/fixtures/CA-MB-2015.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T05:00:00.000Z",
-    "end": "2015-04-06T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-05-10 00:00:00",
     "start": "2015-05-10T05:00:00.000Z",
     "end": "2015-05-11T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2015-08-03T05:00:00.000Z",
     "end": "2015-08-04T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -139,7 +130,7 @@
     "start": "2015-11-11T06:00:00.000Z",
     "end": "2015-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Wed"
   },
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T06:00:00.000Z",
-    "end": "2015-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-MB-2016.json
+++ b/test/fixtures/CA-MB-2016.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T05:00:00.000Z",
-    "end": "2016-03-28T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-05-08 00:00:00",
     "start": "2016-05-08T05:00:00.000Z",
     "end": "2016-05-09T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2016-08-01T05:00:00.000Z",
     "end": "2016-08-02T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -139,7 +130,7 @@
     "start": "2016-11-11T06:00:00.000Z",
     "end": "2016-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Fri"
   },
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T06:00:00.000Z",
-    "end": "2016-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-MB-2017.json
+++ b/test/fixtures/CA-MB-2017.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T05:00:00.000Z",
-    "end": "2017-04-17T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-05-14 00:00:00",
     "start": "2017-05-14T05:00:00.000Z",
     "end": "2017-05-15T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2017-08-07T05:00:00.000Z",
     "end": "2017-08-08T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -139,7 +130,7 @@
     "start": "2017-11-11T06:00:00.000Z",
     "end": "2017-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Sat"
   },
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T06:00:00.000Z",
-    "end": "2017-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-MB-2018.json
+++ b/test/fixtures/CA-MB-2018.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T05:00:00.000Z",
-    "end": "2018-04-02T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-05-13 00:00:00",
     "start": "2018-05-13T05:00:00.000Z",
     "end": "2018-05-14T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2018-08-06T05:00:00.000Z",
     "end": "2018-08-07T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -139,7 +130,7 @@
     "start": "2018-11-11T06:00:00.000Z",
     "end": "2018-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Sun"
   },
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T06:00:00.000Z",
-    "end": "2018-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-MB-2019.json
+++ b/test/fixtures/CA-MB-2019.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T05:00:00.000Z",
-    "end": "2019-04-22T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-05-12 00:00:00",
     "start": "2019-05-12T05:00:00.000Z",
     "end": "2019-05-13T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2019-08-05T05:00:00.000Z",
     "end": "2019-08-06T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -139,7 +130,7 @@
     "start": "2019-11-11T06:00:00.000Z",
     "end": "2019-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Mon"
   },
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T06:00:00.000Z",
-    "end": "2019-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-MB-2020.json
+++ b/test/fixtures/CA-MB-2020.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T05:00:00.000Z",
-    "end": "2020-04-13T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-05-10 00:00:00",
     "start": "2020-05-10T05:00:00.000Z",
     "end": "2020-05-11T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2020-08-03T05:00:00.000Z",
     "end": "2020-08-04T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -139,7 +130,7 @@
     "start": "2020-11-11T06:00:00.000Z",
     "end": "2020-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Wed"
   },
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T06:00:00.000Z",
-    "end": "2020-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-MB-2021.json
+++ b/test/fixtures/CA-MB-2021.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T05:00:00.000Z",
-    "end": "2021-04-05T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-05-09 00:00:00",
     "start": "2021-05-09T05:00:00.000Z",
     "end": "2021-05-10T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2021-08-02T05:00:00.000Z",
     "end": "2021-08-03T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -149,7 +140,7 @@
     "start": "2021-11-11T06:00:00.000Z",
     "end": "2021-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Thu"
   },
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T06:00:00.000Z",
-    "end": "2021-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-MB-2022.json
+++ b/test/fixtures/CA-MB-2022.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T05:00:00.000Z",
-    "end": "2022-04-18T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-05-08 00:00:00",
     "start": "2022-05-08T05:00:00.000Z",
     "end": "2022-05-09T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2022-08-01T05:00:00.000Z",
     "end": "2022-08-02T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -149,7 +140,7 @@
     "start": "2022-11-11T06:00:00.000Z",
     "end": "2022-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Fri"
   },
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T06:00:00.000Z",
-    "end": "2022-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-MB-2023.json
+++ b/test/fixtures/CA-MB-2023.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T05:00:00.000Z",
-    "end": "2023-04-10T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-05-14 00:00:00",
     "start": "2023-05-14T05:00:00.000Z",
     "end": "2023-05-15T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2023-08-07T05:00:00.000Z",
     "end": "2023-08-08T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -149,7 +140,7 @@
     "start": "2023-11-11T06:00:00.000Z",
     "end": "2023-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Sat"
   },
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T06:00:00.000Z",
-    "end": "2023-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-MB-2024.json
+++ b/test/fixtures/CA-MB-2024.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T05:00:00.000Z",
-    "end": "2024-04-01T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-05-12 00:00:00",
     "start": "2024-05-12T05:00:00.000Z",
     "end": "2024-05-13T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2024-08-05T05:00:00.000Z",
     "end": "2024-08-06T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -149,7 +140,7 @@
     "start": "2024-11-11T06:00:00.000Z",
     "end": "2024-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Mon"
   },
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T06:00:00.000Z",
-    "end": "2024-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-MB-2025.json
+++ b/test/fixtures/CA-MB-2025.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T05:00:00.000Z",
-    "end": "2025-04-21T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-05-11 00:00:00",
     "start": "2025-05-11T05:00:00.000Z",
     "end": "2025-05-12T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2025-08-04T05:00:00.000Z",
     "end": "2025-08-05T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -149,7 +140,7 @@
     "start": "2025-11-11T06:00:00.000Z",
     "end": "2025-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Tue"
   },
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T06:00:00.000Z",
-    "end": "2025-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-MB-2026.json
+++ b/test/fixtures/CA-MB-2026.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T05:00:00.000Z",
-    "end": "2026-04-06T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-05-10 00:00:00",
     "start": "2026-05-10T05:00:00.000Z",
     "end": "2026-05-11T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2026-08-03T05:00:00.000Z",
     "end": "2026-08-04T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -149,7 +140,7 @@
     "start": "2026-11-11T06:00:00.000Z",
     "end": "2026-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Wed"
   },
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T06:00:00.000Z",
-    "end": "2026-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-MB-2027.json
+++ b/test/fixtures/CA-MB-2027.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T05:00:00.000Z",
-    "end": "2027-03-29T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-05-09 00:00:00",
     "start": "2027-05-09T05:00:00.000Z",
     "end": "2027-05-10T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2027-08-02T05:00:00.000Z",
     "end": "2027-08-03T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -149,7 +140,7 @@
     "start": "2027-11-11T06:00:00.000Z",
     "end": "2027-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Thu"
   },
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T06:00:00.000Z",
-    "end": "2027-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-MB-2028.json
+++ b/test/fixtures/CA-MB-2028.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T05:00:00.000Z",
-    "end": "2028-04-17T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-05-14 00:00:00",
     "start": "2028-05-14T05:00:00.000Z",
     "end": "2028-05-15T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2028-08-07T05:00:00.000Z",
     "end": "2028-08-08T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -149,7 +140,7 @@
     "start": "2028-11-11T06:00:00.000Z",
     "end": "2028-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Sat"
   },
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T06:00:00.000Z",
-    "end": "2028-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-MB-2029.json
+++ b/test/fixtures/CA-MB-2029.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T05:00:00.000Z",
-    "end": "2029-04-02T05:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-05-13 00:00:00",
     "start": "2029-05-13T05:00:00.000Z",
     "end": "2029-05-14T05:00:00.000Z",
@@ -103,7 +94,7 @@
     "start": "2029-08-06T05:00:00.000Z",
     "end": "2029-08-07T05:00:00.000Z",
     "name": "Terry Fox Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -149,7 +140,7 @@
     "start": "2029-11-11T06:00:00.000Z",
     "end": "2029-11-12T06:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Sun"
   },
@@ -161,14 +152,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T06:00:00.000Z",
-    "end": "2029-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-NB-2015.json
+++ b/test/fixtures/CA-NB-2015.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T03:00:00.000Z",
-    "end": "2015-04-06T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-05-10 00:00:00",
     "start": "2015-05-10T03:00:00.000Z",
     "end": "2015-05-11T03:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2015-05-18 00:00:00",
-    "start": "2015-05-18T03:00:00.000Z",
-    "end": "2015-05-19T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2015-06-21 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2015-10-12 00:00:00",
-    "start": "2015-10-12T03:00:00.000Z",
-    "end": "2015-10-13T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2015-10-31 18:00:00",
     "start": "2015-10-31T21:00:00.000Z",
     "end": "2015-11-01T03:00:00.000Z",
@@ -142,14 +115,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T04:00:00.000Z",
-    "end": "2015-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NB-2016.json
+++ b/test/fixtures/CA-NB-2016.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T03:00:00.000Z",
-    "end": "2016-03-28T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-05-08 00:00:00",
     "start": "2016-05-08T03:00:00.000Z",
     "end": "2016-05-09T03:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-05-23 00:00:00",
-    "start": "2016-05-23T03:00:00.000Z",
-    "end": "2016-05-24T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2016-06-19 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2016-10-10 00:00:00",
-    "start": "2016-10-10T03:00:00.000Z",
-    "end": "2016-10-11T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2016-10-31 18:00:00",
     "start": "2016-10-31T21:00:00.000Z",
     "end": "2016-11-01T03:00:00.000Z",
@@ -142,14 +115,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T04:00:00.000Z",
-    "end": "2016-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-NB-2017.json
+++ b/test/fixtures/CA-NB-2017.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T03:00:00.000Z",
-    "end": "2017-04-17T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-05-14 00:00:00",
     "start": "2017-05-14T03:00:00.000Z",
     "end": "2017-05-15T03:00:00.000Z",
@@ -61,15 +52,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2017-05-22 00:00:00",
-    "start": "2017-05-22T03:00:00.000Z",
-    "end": "2017-05-23T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2017-06-18 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2017-10-09 00:00:00",
-    "start": "2017-10-09T03:00:00.000Z",
-    "end": "2017-10-10T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2017-10-31 18:00:00",
     "start": "2017-10-31T21:00:00.000Z",
     "end": "2017-11-01T03:00:00.000Z",
@@ -142,14 +115,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T04:00:00.000Z",
-    "end": "2017-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NB-2018.json
+++ b/test/fixtures/CA-NB-2018.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T03:00:00.000Z",
-    "end": "2018-04-02T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-05-13 00:00:00",
     "start": "2018-05-13T03:00:00.000Z",
     "end": "2018-05-14T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2018-05-21 00:00:00",
-    "start": "2018-05-21T03:00:00.000Z",
-    "end": "2018-05-22T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2018-06-17 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2018-10-08 00:00:00",
-    "start": "2018-10-08T03:00:00.000Z",
-    "end": "2018-10-09T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2018-10-31 18:00:00",
     "start": "2018-10-31T21:00:00.000Z",
     "end": "2018-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T04:00:00.000Z",
-    "end": "2018-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-NB-2019.json
+++ b/test/fixtures/CA-NB-2019.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T03:00:00.000Z",
-    "end": "2019-04-22T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-05-12 00:00:00",
     "start": "2019-05-12T03:00:00.000Z",
     "end": "2019-05-13T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2019-05-20 00:00:00",
-    "start": "2019-05-20T03:00:00.000Z",
-    "end": "2019-05-21T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2019-06-16 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2019-10-14 00:00:00",
-    "start": "2019-10-14T03:00:00.000Z",
-    "end": "2019-10-15T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2019-10-31 18:00:00",
     "start": "2019-10-31T21:00:00.000Z",
     "end": "2019-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T04:00:00.000Z",
-    "end": "2019-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-NB-2020.json
+++ b/test/fixtures/CA-NB-2020.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T03:00:00.000Z",
-    "end": "2020-04-13T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-05-10 00:00:00",
     "start": "2020-05-10T03:00:00.000Z",
     "end": "2020-05-11T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2020-05-18 00:00:00",
-    "start": "2020-05-18T03:00:00.000Z",
-    "end": "2020-05-19T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2020-06-21 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2020-10-12 00:00:00",
-    "start": "2020-10-12T03:00:00.000Z",
-    "end": "2020-10-13T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2020-10-31 18:00:00",
     "start": "2020-10-31T21:00:00.000Z",
     "end": "2020-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T04:00:00.000Z",
-    "end": "2020-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NB-2021.json
+++ b/test/fixtures/CA-NB-2021.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T03:00:00.000Z",
-    "end": "2021-04-05T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-05-09 00:00:00",
     "start": "2021-05-09T03:00:00.000Z",
     "end": "2021-05-10T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2021-05-24 00:00:00",
-    "start": "2021-05-24T03:00:00.000Z",
-    "end": "2021-05-25T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-06-20 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2021-10-11 00:00:00",
-    "start": "2021-10-11T03:00:00.000Z",
-    "end": "2021-10-12T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2021-10-31 18:00:00",
     "start": "2021-10-31T21:00:00.000Z",
     "end": "2021-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T04:00:00.000Z",
-    "end": "2021-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-NB-2022.json
+++ b/test/fixtures/CA-NB-2022.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T03:00:00.000Z",
-    "end": "2022-04-18T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-05-08 00:00:00",
     "start": "2022-05-08T03:00:00.000Z",
     "end": "2022-05-09T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-05-23 00:00:00",
-    "start": "2022-05-23T03:00:00.000Z",
-    "end": "2022-05-24T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-06-19 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-10-10 00:00:00",
-    "start": "2022-10-10T03:00:00.000Z",
-    "end": "2022-10-11T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2022-10-31 18:00:00",
     "start": "2022-10-31T21:00:00.000Z",
     "end": "2022-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T04:00:00.000Z",
-    "end": "2022-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-NB-2023.json
+++ b/test/fixtures/CA-NB-2023.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T03:00:00.000Z",
-    "end": "2023-04-10T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-05-14 00:00:00",
     "start": "2023-05-14T03:00:00.000Z",
     "end": "2023-05-15T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2023-05-22 00:00:00",
-    "start": "2023-05-22T03:00:00.000Z",
-    "end": "2023-05-23T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-06-18 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2023-10-09 00:00:00",
-    "start": "2023-10-09T03:00:00.000Z",
-    "end": "2023-10-10T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2023-10-31 18:00:00",
     "start": "2023-10-31T21:00:00.000Z",
     "end": "2023-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T04:00:00.000Z",
-    "end": "2023-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NB-2024.json
+++ b/test/fixtures/CA-NB-2024.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T03:00:00.000Z",
-    "end": "2024-04-01T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-05-12 00:00:00",
     "start": "2024-05-12T03:00:00.000Z",
     "end": "2024-05-13T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2024-05-20 00:00:00",
-    "start": "2024-05-20T03:00:00.000Z",
-    "end": "2024-05-21T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2024-06-16 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2024-10-14 00:00:00",
-    "start": "2024-10-14T03:00:00.000Z",
-    "end": "2024-10-15T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2024-10-31 18:00:00",
     "start": "2024-10-31T21:00:00.000Z",
     "end": "2024-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T04:00:00.000Z",
-    "end": "2024-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-NB-2025.json
+++ b/test/fixtures/CA-NB-2025.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T03:00:00.000Z",
-    "end": "2025-04-21T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-05-11 00:00:00",
     "start": "2025-05-11T03:00:00.000Z",
     "end": "2025-05-12T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2025-05-19 00:00:00",
-    "start": "2025-05-19T03:00:00.000Z",
-    "end": "2025-05-20T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2025-06-15 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2025-10-13 00:00:00",
-    "start": "2025-10-13T03:00:00.000Z",
-    "end": "2025-10-14T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2025-10-31 18:00:00",
     "start": "2025-10-31T21:00:00.000Z",
     "end": "2025-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T04:00:00.000Z",
-    "end": "2025-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-NB-2026.json
+++ b/test/fixtures/CA-NB-2026.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T03:00:00.000Z",
-    "end": "2026-04-06T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-05-10 00:00:00",
     "start": "2026-05-10T03:00:00.000Z",
     "end": "2026-05-11T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2026-05-18 00:00:00",
-    "start": "2026-05-18T03:00:00.000Z",
-    "end": "2026-05-19T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-06-21 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2026-10-12 00:00:00",
-    "start": "2026-10-12T03:00:00.000Z",
-    "end": "2026-10-13T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2026-10-31 18:00:00",
     "start": "2026-10-31T21:00:00.000Z",
     "end": "2026-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T04:00:00.000Z",
-    "end": "2026-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NB-2027.json
+++ b/test/fixtures/CA-NB-2027.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T03:00:00.000Z",
-    "end": "2027-03-29T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-05-09 00:00:00",
     "start": "2027-05-09T03:00:00.000Z",
     "end": "2027-05-10T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2027-05-24 00:00:00",
-    "start": "2027-05-24T03:00:00.000Z",
-    "end": "2027-05-25T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2027-06-20 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2027-10-11 00:00:00",
-    "start": "2027-10-11T03:00:00.000Z",
-    "end": "2027-10-12T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2027-10-31 18:00:00",
     "start": "2027-10-31T21:00:00.000Z",
     "end": "2027-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T04:00:00.000Z",
-    "end": "2027-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-NB-2028.json
+++ b/test/fixtures/CA-NB-2028.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T03:00:00.000Z",
-    "end": "2028-04-17T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-05-14 00:00:00",
     "start": "2028-05-14T03:00:00.000Z",
     "end": "2028-05-15T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2028-05-22 00:00:00",
-    "start": "2028-05-22T03:00:00.000Z",
-    "end": "2028-05-23T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2028-06-18 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2028-10-09 00:00:00",
-    "start": "2028-10-09T03:00:00.000Z",
-    "end": "2028-10-10T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2028-10-31 18:00:00",
     "start": "2028-10-31T21:00:00.000Z",
     "end": "2028-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T04:00:00.000Z",
-    "end": "2028-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NB-2029.json
+++ b/test/fixtures/CA-NB-2029.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T03:00:00.000Z",
-    "end": "2029-04-02T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-05-13 00:00:00",
     "start": "2029-05-13T03:00:00.000Z",
     "end": "2029-05-14T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2029-05-21 00:00:00",
-    "start": "2029-05-21T03:00:00.000Z",
-    "end": "2029-05-22T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-06-17 00:00:00",
@@ -117,15 +99,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2029-10-08 00:00:00",
-    "start": "2029-10-08T03:00:00.000Z",
-    "end": "2029-10-09T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2029-10-31 18:00:00",
     "start": "2029-10-31T21:00:00.000Z",
     "end": "2029-11-01T03:00:00.000Z",
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T04:00:00.000Z",
-    "end": "2029-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-NL-2015.json
+++ b/test/fixtures/CA-NL-2015.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T02:30:00.000Z",
-    "end": "2015-04-06T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-04-23 00:00:00",
     "start": "2015-04-23T02:30:00.000Z",
     "end": "2015-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2015-05-18 00:00:00",
-    "start": "2015-05-18T02:30:00.000Z",
-    "end": "2015-05-19T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2015-06-21 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2015-07-01 00:00:00",
     "start": "2015-07-01T02:30:00.000Z",
     "end": "2015-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Wed"
@@ -117,30 +99,12 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2015-08-03 00:00:00",
-    "start": "2015-08-03T02:30:00.000Z",
-    "end": "2015-08-04T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2015-09-07 00:00:00",
     "start": "2015-09-07T02:30:00.000Z",
     "end": "2015-09-08T02:30:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2015-10-12 00:00:00",
-    "start": "2015-10-12T02:30:00.000Z",
-    "end": "2015-10-13T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T03:30:00.000Z",
-    "end": "2015-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NL-2016.json
+++ b/test/fixtures/CA-NL-2016.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T02:30:00.000Z",
-    "end": "2016-03-28T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-04-23 00:00:00",
     "start": "2016-04-23T02:30:00.000Z",
     "end": "2016-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-05-23 00:00:00",
-    "start": "2016-05-23T02:30:00.000Z",
-    "end": "2016-05-24T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2016-06-19 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2016-07-01 00:00:00",
     "start": "2016-07-01T02:30:00.000Z",
     "end": "2016-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Fri"
@@ -117,30 +99,12 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2016-08-01 00:00:00",
-    "start": "2016-08-01T02:30:00.000Z",
-    "end": "2016-08-02T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2016-09-05 00:00:00",
     "start": "2016-09-05T02:30:00.000Z",
     "end": "2016-09-06T02:30:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2016-10-10 00:00:00",
-    "start": "2016-10-10T02:30:00.000Z",
-    "end": "2016-10-11T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T03:30:00.000Z",
-    "end": "2016-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-NL-2017.json
+++ b/test/fixtures/CA-NL-2017.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T02:30:00.000Z",
-    "end": "2017-04-17T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-04-23 00:00:00",
     "start": "2017-04-23T02:30:00.000Z",
     "end": "2017-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2017-05-22 00:00:00",
-    "start": "2017-05-22T02:30:00.000Z",
-    "end": "2017-05-23T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2017-06-18 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2017-07-01 00:00:00",
     "start": "2017-07-01T02:30:00.000Z",
     "end": "2017-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sat"
@@ -117,30 +99,12 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2017-08-07 00:00:00",
-    "start": "2017-08-07T02:30:00.000Z",
-    "end": "2017-08-08T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2017-09-04 00:00:00",
     "start": "2017-09-04T02:30:00.000Z",
     "end": "2017-09-05T02:30:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2017-10-09 00:00:00",
-    "start": "2017-10-09T02:30:00.000Z",
-    "end": "2017-10-10T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T03:30:00.000Z",
-    "end": "2017-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NL-2018.json
+++ b/test/fixtures/CA-NL-2018.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T02:30:00.000Z",
-    "end": "2018-04-02T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-04-23 00:00:00",
     "start": "2018-04-23T02:30:00.000Z",
     "end": "2018-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2018-05-21 00:00:00",
-    "start": "2018-05-21T02:30:00.000Z",
-    "end": "2018-05-22T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2018-06-17 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2018-07-01 00:00:00",
     "start": "2018-07-01T02:30:00.000Z",
     "end": "2018-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sun"
@@ -117,30 +99,12 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2018-08-06 00:00:00",
-    "start": "2018-08-06T02:30:00.000Z",
-    "end": "2018-08-07T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2018-09-03 00:00:00",
     "start": "2018-09-03T02:30:00.000Z",
     "end": "2018-09-04T02:30:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2018-10-08 00:00:00",
-    "start": "2018-10-08T02:30:00.000Z",
-    "end": "2018-10-09T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T03:30:00.000Z",
-    "end": "2018-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-NL-2019.json
+++ b/test/fixtures/CA-NL-2019.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T02:30:00.000Z",
-    "end": "2019-04-22T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-04-23 00:00:00",
     "start": "2019-04-23T02:30:00.000Z",
     "end": "2019-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2019-05-20 00:00:00",
-    "start": "2019-05-20T02:30:00.000Z",
-    "end": "2019-05-21T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2019-06-16 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2019-07-01 00:00:00",
     "start": "2019-07-01T02:30:00.000Z",
     "end": "2019-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Mon"
@@ -117,30 +99,12 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-08-05 00:00:00",
-    "start": "2019-08-05T02:30:00.000Z",
-    "end": "2019-08-06T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2019-09-02 00:00:00",
     "start": "2019-09-02T02:30:00.000Z",
     "end": "2019-09-03T02:30:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2019-10-14 00:00:00",
-    "start": "2019-10-14T02:30:00.000Z",
-    "end": "2019-10-15T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T03:30:00.000Z",
-    "end": "2019-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-NL-2020.json
+++ b/test/fixtures/CA-NL-2020.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T02:30:00.000Z",
-    "end": "2020-04-13T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-04-23 00:00:00",
     "start": "2020-04-23T02:30:00.000Z",
     "end": "2020-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2020-05-18 00:00:00",
-    "start": "2020-05-18T02:30:00.000Z",
-    "end": "2020-05-19T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2020-06-21 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2020-07-01 00:00:00",
     "start": "2020-07-01T02:30:00.000Z",
     "end": "2020-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Wed"
@@ -117,30 +99,12 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2020-08-03 00:00:00",
-    "start": "2020-08-03T02:30:00.000Z",
-    "end": "2020-08-04T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2020-09-07 00:00:00",
     "start": "2020-09-07T02:30:00.000Z",
     "end": "2020-09-08T02:30:00.000Z",
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2020-10-12 00:00:00",
-    "start": "2020-10-12T02:30:00.000Z",
-    "end": "2020-10-13T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T03:30:00.000Z",
-    "end": "2020-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NL-2021.json
+++ b/test/fixtures/CA-NL-2021.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T02:30:00.000Z",
-    "end": "2021-04-05T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-04-23 00:00:00",
     "start": "2021-04-23T02:30:00.000Z",
     "end": "2021-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2021-05-24 00:00:00",
-    "start": "2021-05-24T02:30:00.000Z",
-    "end": "2021-05-25T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-06-20 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2021-07-01 00:00:00",
     "start": "2021-07-01T02:30:00.000Z",
     "end": "2021-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Thu"
@@ -114,15 +96,6 @@
     "name": "Orangemen's Day",
     "type": "optional",
     "rule": "07-12",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2021-08-02 00:00:00",
-    "start": "2021-08-02T02:30:00.000Z",
-    "end": "2021-08-03T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {
@@ -143,15 +116,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2021-10-11 00:00:00",
-    "start": "2021-10-11T02:30:00.000Z",
-    "end": "2021-10-12T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-10-31 18:00:00",
@@ -179,14 +143,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T03:30:00.000Z",
-    "end": "2021-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-NL-2022.json
+++ b/test/fixtures/CA-NL-2022.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T02:30:00.000Z",
-    "end": "2022-04-18T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-04-23 00:00:00",
     "start": "2022-04-23T02:30:00.000Z",
     "end": "2022-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-05-23 00:00:00",
-    "start": "2022-05-23T02:30:00.000Z",
-    "end": "2022-05-24T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-06-19 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2022-07-01 00:00:00",
     "start": "2022-07-01T02:30:00.000Z",
     "end": "2022-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Fri"
@@ -115,15 +97,6 @@
     "type": "optional",
     "rule": "07-12",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2022-08-01 00:00:00",
-    "start": "2022-08-01T02:30:00.000Z",
-    "end": "2022-08-02T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-09-05 00:00:00",
@@ -143,15 +116,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2022-10-10 00:00:00",
-    "start": "2022-10-10T02:30:00.000Z",
-    "end": "2022-10-11T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-10-31 18:00:00",
@@ -179,14 +143,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T03:30:00.000Z",
-    "end": "2022-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-NL-2023.json
+++ b/test/fixtures/CA-NL-2023.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T02:30:00.000Z",
-    "end": "2023-04-10T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-04-23 00:00:00",
     "start": "2023-04-23T02:30:00.000Z",
     "end": "2023-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2023-05-22 00:00:00",
-    "start": "2023-05-22T02:30:00.000Z",
-    "end": "2023-05-23T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-06-18 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2023-07-01 00:00:00",
     "start": "2023-07-01T02:30:00.000Z",
     "end": "2023-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sat"
@@ -115,15 +97,6 @@
     "type": "optional",
     "rule": "07-12",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2023-08-07 00:00:00",
-    "start": "2023-08-07T02:30:00.000Z",
-    "end": "2023-08-08T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-09-04 00:00:00",
@@ -143,15 +116,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2023-10-09 00:00:00",
-    "start": "2023-10-09T02:30:00.000Z",
-    "end": "2023-10-10T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-10-31 18:00:00",
@@ -179,14 +143,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T03:30:00.000Z",
-    "end": "2023-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NL-2024.json
+++ b/test/fixtures/CA-NL-2024.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T02:30:00.000Z",
-    "end": "2024-04-01T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-04-23 00:00:00",
     "start": "2024-04-23T02:30:00.000Z",
     "end": "2024-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2024-05-20 00:00:00",
-    "start": "2024-05-20T02:30:00.000Z",
-    "end": "2024-05-21T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2024-06-16 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2024-07-01 00:00:00",
     "start": "2024-07-01T02:30:00.000Z",
     "end": "2024-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Mon"
@@ -115,15 +97,6 @@
     "type": "optional",
     "rule": "07-12",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2024-08-05 00:00:00",
-    "start": "2024-08-05T02:30:00.000Z",
-    "end": "2024-08-06T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2024-09-02 00:00:00",
@@ -142,15 +115,6 @@
     "type": "observance",
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2024-10-14 00:00:00",
-    "start": "2024-10-14T02:30:00.000Z",
-    "end": "2024-10-15T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -179,14 +143,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T03:30:00.000Z",
-    "end": "2024-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-NL-2025.json
+++ b/test/fixtures/CA-NL-2025.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T02:30:00.000Z",
-    "end": "2025-04-21T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-04-23 00:00:00",
     "start": "2025-04-23T02:30:00.000Z",
     "end": "2025-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2025-05-19 00:00:00",
-    "start": "2025-05-19T02:30:00.000Z",
-    "end": "2025-05-20T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2025-06-15 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2025-07-01 00:00:00",
     "start": "2025-07-01T02:30:00.000Z",
     "end": "2025-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Tue"
@@ -115,15 +97,6 @@
     "type": "optional",
     "rule": "07-12",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2025-08-04 00:00:00",
-    "start": "2025-08-04T02:30:00.000Z",
-    "end": "2025-08-05T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2025-09-01 00:00:00",
@@ -143,15 +116,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2025-10-13 00:00:00",
-    "start": "2025-10-13T02:30:00.000Z",
-    "end": "2025-10-14T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2025-10-31 18:00:00",
@@ -179,14 +143,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T03:30:00.000Z",
-    "end": "2025-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-NL-2026.json
+++ b/test/fixtures/CA-NL-2026.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T02:30:00.000Z",
-    "end": "2026-04-06T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-04-23 00:00:00",
     "start": "2026-04-23T02:30:00.000Z",
     "end": "2026-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2026-05-18 00:00:00",
-    "start": "2026-05-18T02:30:00.000Z",
-    "end": "2026-05-19T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-06-21 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2026-07-01 00:00:00",
     "start": "2026-07-01T02:30:00.000Z",
     "end": "2026-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Wed"
@@ -115,15 +97,6 @@
     "type": "optional",
     "rule": "07-12",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2026-08-03 00:00:00",
-    "start": "2026-08-03T02:30:00.000Z",
-    "end": "2026-08-04T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-09-07 00:00:00",
@@ -143,15 +116,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2026-10-12 00:00:00",
-    "start": "2026-10-12T02:30:00.000Z",
-    "end": "2026-10-13T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-10-31 18:00:00",
@@ -179,14 +143,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T03:30:00.000Z",
-    "end": "2026-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NL-2027.json
+++ b/test/fixtures/CA-NL-2027.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T02:30:00.000Z",
-    "end": "2027-03-29T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-04-23 00:00:00",
     "start": "2027-04-23T02:30:00.000Z",
     "end": "2027-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2027-05-24 00:00:00",
-    "start": "2027-05-24T02:30:00.000Z",
-    "end": "2027-05-25T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2027-06-20 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2027-07-01 00:00:00",
     "start": "2027-07-01T02:30:00.000Z",
     "end": "2027-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Thu"
@@ -114,15 +96,6 @@
     "name": "Orangemen's Day",
     "type": "optional",
     "rule": "07-12",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2027-08-02 00:00:00",
-    "start": "2027-08-02T02:30:00.000Z",
-    "end": "2027-08-03T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {
@@ -143,15 +116,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2027-10-11 00:00:00",
-    "start": "2027-10-11T02:30:00.000Z",
-    "end": "2027-10-12T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2027-10-31 18:00:00",
@@ -179,14 +143,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T03:30:00.000Z",
-    "end": "2027-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-NL-2028.json
+++ b/test/fixtures/CA-NL-2028.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T02:30:00.000Z",
-    "end": "2028-04-17T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-04-23 00:00:00",
     "start": "2028-04-23T02:30:00.000Z",
     "end": "2028-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2028-05-22 00:00:00",
-    "start": "2028-05-22T02:30:00.000Z",
-    "end": "2028-05-23T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2028-06-18 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2028-07-01 00:00:00",
     "start": "2028-07-01T02:30:00.000Z",
     "end": "2028-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sat"
@@ -115,15 +97,6 @@
     "type": "optional",
     "rule": "07-12",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2028-08-07 00:00:00",
-    "start": "2028-08-07T02:30:00.000Z",
-    "end": "2028-08-08T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2028-09-04 00:00:00",
@@ -143,15 +116,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2028-10-09 00:00:00",
-    "start": "2028-10-09T02:30:00.000Z",
-    "end": "2028-10-10T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2028-10-31 18:00:00",
@@ -179,14 +143,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T03:30:00.000Z",
-    "end": "2028-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NL-2029.json
+++ b/test/fixtures/CA-NL-2029.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T02:30:00.000Z",
-    "end": "2029-04-02T02:30:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-04-23 00:00:00",
     "start": "2029-04-23T02:30:00.000Z",
     "end": "2029-04-24T02:30:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2029-05-21 00:00:00",
-    "start": "2029-05-21T02:30:00.000Z",
-    "end": "2029-05-22T02:30:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-06-17 00:00:00",
@@ -102,7 +84,7 @@
     "date": "2029-07-01 00:00:00",
     "start": "2029-07-01T02:30:00.000Z",
     "end": "2029-07-02T02:30:00.000Z",
-    "name": "Canada Day",
+    "name": "Memorial Day",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sun"
@@ -115,15 +97,6 @@
     "type": "optional",
     "rule": "07-12",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2029-08-06 00:00:00",
-    "start": "2029-08-06T02:30:00.000Z",
-    "end": "2029-08-07T02:30:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-09-03 00:00:00",
@@ -143,15 +116,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2029-10-08 00:00:00",
-    "start": "2029-10-08T02:30:00.000Z",
-    "end": "2029-10-09T02:30:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-10-31 18:00:00",
@@ -179,14 +143,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T03:30:00.000Z",
-    "end": "2029-12-27T03:30:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-NS-2015.json
+++ b/test/fixtures/CA-NS-2015.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T03:00:00.000Z",
-    "end": "2015-04-06T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-05-10 00:00:00",
     "start": "2015-05-10T03:00:00.000Z",
     "end": "2015-05-11T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2015-05-18 00:00:00",
-    "start": "2015-05-18T03:00:00.000Z",
-    "end": "2015-05-19T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2015-06-21 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2015-08-03T03:00:00.000Z",
     "end": "2015-08-04T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -114,15 +96,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2015-10-12 00:00:00",
-    "start": "2015-10-12T03:00:00.000Z",
-    "end": "2015-10-13T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T04:00:00.000Z",
-    "end": "2015-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NS-2016.json
+++ b/test/fixtures/CA-NS-2016.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T03:00:00.000Z",
-    "end": "2016-03-28T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-05-08 00:00:00",
     "start": "2016-05-08T03:00:00.000Z",
     "end": "2016-05-09T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-05-23 00:00:00",
-    "start": "2016-05-23T03:00:00.000Z",
-    "end": "2016-05-24T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2016-06-19 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2016-08-01T03:00:00.000Z",
     "end": "2016-08-02T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -114,15 +96,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2016-10-10 00:00:00",
-    "start": "2016-10-10T03:00:00.000Z",
-    "end": "2016-10-11T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T04:00:00.000Z",
-    "end": "2016-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-NS-2017.json
+++ b/test/fixtures/CA-NS-2017.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T03:00:00.000Z",
-    "end": "2017-04-17T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-05-14 00:00:00",
     "start": "2017-05-14T03:00:00.000Z",
     "end": "2017-05-15T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2017-05-22 00:00:00",
-    "start": "2017-05-22T03:00:00.000Z",
-    "end": "2017-05-23T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2017-06-18 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2017-08-07T03:00:00.000Z",
     "end": "2017-08-08T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -114,15 +96,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2017-10-09 00:00:00",
-    "start": "2017-10-09T03:00:00.000Z",
-    "end": "2017-10-10T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T04:00:00.000Z",
-    "end": "2017-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NS-2018.json
+++ b/test/fixtures/CA-NS-2018.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T03:00:00.000Z",
-    "end": "2018-04-02T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-05-13 00:00:00",
     "start": "2018-05-13T03:00:00.000Z",
     "end": "2018-05-14T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2018-05-21 00:00:00",
-    "start": "2018-05-21T03:00:00.000Z",
-    "end": "2018-05-22T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2018-06-17 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2018-08-06T03:00:00.000Z",
     "end": "2018-08-07T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -114,15 +96,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2018-10-08 00:00:00",
-    "start": "2018-10-08T03:00:00.000Z",
-    "end": "2018-10-09T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T04:00:00.000Z",
-    "end": "2018-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-NS-2019.json
+++ b/test/fixtures/CA-NS-2019.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T03:00:00.000Z",
-    "end": "2019-04-22T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-05-12 00:00:00",
     "start": "2019-05-12T03:00:00.000Z",
     "end": "2019-05-13T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2019-05-20 00:00:00",
-    "start": "2019-05-20T03:00:00.000Z",
-    "end": "2019-05-21T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2019-06-16 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2019-08-05T03:00:00.000Z",
     "end": "2019-08-06T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -114,15 +96,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2019-10-14 00:00:00",
-    "start": "2019-10-14T03:00:00.000Z",
-    "end": "2019-10-15T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T04:00:00.000Z",
-    "end": "2019-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-NS-2020.json
+++ b/test/fixtures/CA-NS-2020.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T03:00:00.000Z",
-    "end": "2020-04-13T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-05-10 00:00:00",
     "start": "2020-05-10T03:00:00.000Z",
     "end": "2020-05-11T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2020-05-18 00:00:00",
-    "start": "2020-05-18T03:00:00.000Z",
-    "end": "2020-05-19T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2020-06-21 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2020-08-03T03:00:00.000Z",
     "end": "2020-08-04T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -114,15 +96,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2020-10-12 00:00:00",
-    "start": "2020-10-12T03:00:00.000Z",
-    "end": "2020-10-13T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -151,14 +124,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T04:00:00.000Z",
-    "end": "2020-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NS-2021.json
+++ b/test/fixtures/CA-NS-2021.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T03:00:00.000Z",
-    "end": "2021-04-05T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-05-09 00:00:00",
     "start": "2021-05-09T03:00:00.000Z",
     "end": "2021-05-10T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2021-05-24 00:00:00",
-    "start": "2021-05-24T03:00:00.000Z",
-    "end": "2021-05-25T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-06-20 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2021-08-02T03:00:00.000Z",
     "end": "2021-08-03T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -125,15 +107,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2021-10-11 00:00:00",
-    "start": "2021-10-11T03:00:00.000Z",
-    "end": "2021-10-12T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-10-31 18:00:00",
@@ -161,14 +134,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T04:00:00.000Z",
-    "end": "2021-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-NS-2022.json
+++ b/test/fixtures/CA-NS-2022.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T03:00:00.000Z",
-    "end": "2022-04-18T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-05-08 00:00:00",
     "start": "2022-05-08T03:00:00.000Z",
     "end": "2022-05-09T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-05-23 00:00:00",
-    "start": "2022-05-23T03:00:00.000Z",
-    "end": "2022-05-24T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-06-19 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2022-08-01T03:00:00.000Z",
     "end": "2022-08-02T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -125,15 +107,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2022-10-10 00:00:00",
-    "start": "2022-10-10T03:00:00.000Z",
-    "end": "2022-10-11T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-10-31 18:00:00",
@@ -161,14 +134,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T04:00:00.000Z",
-    "end": "2022-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-NS-2023.json
+++ b/test/fixtures/CA-NS-2023.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T03:00:00.000Z",
-    "end": "2023-04-10T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-05-14 00:00:00",
     "start": "2023-05-14T03:00:00.000Z",
     "end": "2023-05-15T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2023-05-22 00:00:00",
-    "start": "2023-05-22T03:00:00.000Z",
-    "end": "2023-05-23T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-06-18 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2023-08-07T03:00:00.000Z",
     "end": "2023-08-08T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -125,15 +107,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2023-10-09 00:00:00",
-    "start": "2023-10-09T03:00:00.000Z",
-    "end": "2023-10-10T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-10-31 18:00:00",
@@ -161,14 +134,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T04:00:00.000Z",
-    "end": "2023-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NS-2024.json
+++ b/test/fixtures/CA-NS-2024.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T03:00:00.000Z",
-    "end": "2024-04-01T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-05-12 00:00:00",
     "start": "2024-05-12T03:00:00.000Z",
     "end": "2024-05-13T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2024-05-20 00:00:00",
-    "start": "2024-05-20T03:00:00.000Z",
-    "end": "2024-05-21T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2024-06-16 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2024-08-05T03:00:00.000Z",
     "end": "2024-08-06T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -124,15 +106,6 @@
     "type": "observance",
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2024-10-14 00:00:00",
-    "start": "2024-10-14T03:00:00.000Z",
-    "end": "2024-10-15T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -161,14 +134,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T04:00:00.000Z",
-    "end": "2024-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-NS-2025.json
+++ b/test/fixtures/CA-NS-2025.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T03:00:00.000Z",
-    "end": "2025-04-21T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-05-11 00:00:00",
     "start": "2025-05-11T03:00:00.000Z",
     "end": "2025-05-12T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2025-05-19 00:00:00",
-    "start": "2025-05-19T03:00:00.000Z",
-    "end": "2025-05-20T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2025-06-15 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2025-08-04T03:00:00.000Z",
     "end": "2025-08-05T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -125,15 +107,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2025-10-13 00:00:00",
-    "start": "2025-10-13T03:00:00.000Z",
-    "end": "2025-10-14T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2025-10-31 18:00:00",
@@ -161,14 +134,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T04:00:00.000Z",
-    "end": "2025-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-NS-2026.json
+++ b/test/fixtures/CA-NS-2026.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T03:00:00.000Z",
-    "end": "2026-04-06T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-05-10 00:00:00",
     "start": "2026-05-10T03:00:00.000Z",
     "end": "2026-05-11T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2026-05-18 00:00:00",
-    "start": "2026-05-18T03:00:00.000Z",
-    "end": "2026-05-19T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-06-21 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2026-08-03T03:00:00.000Z",
     "end": "2026-08-04T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -125,15 +107,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2026-10-12 00:00:00",
-    "start": "2026-10-12T03:00:00.000Z",
-    "end": "2026-10-13T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-10-31 18:00:00",
@@ -161,14 +134,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T04:00:00.000Z",
-    "end": "2026-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NS-2027.json
+++ b/test/fixtures/CA-NS-2027.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T03:00:00.000Z",
-    "end": "2027-03-29T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-05-09 00:00:00",
     "start": "2027-05-09T03:00:00.000Z",
     "end": "2027-05-10T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2027-05-24 00:00:00",
-    "start": "2027-05-24T03:00:00.000Z",
-    "end": "2027-05-25T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2027-06-20 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2027-08-02T03:00:00.000Z",
     "end": "2027-08-03T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -125,15 +107,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2027-10-11 00:00:00",
-    "start": "2027-10-11T03:00:00.000Z",
-    "end": "2027-10-12T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2027-10-31 18:00:00",
@@ -161,14 +134,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T04:00:00.000Z",
-    "end": "2027-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-NS-2028.json
+++ b/test/fixtures/CA-NS-2028.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T03:00:00.000Z",
-    "end": "2028-04-17T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-05-14 00:00:00",
     "start": "2028-05-14T03:00:00.000Z",
     "end": "2028-05-15T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2028-05-22 00:00:00",
-    "start": "2028-05-22T03:00:00.000Z",
-    "end": "2028-05-23T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2028-06-18 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2028-08-07T03:00:00.000Z",
     "end": "2028-08-08T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -125,15 +107,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2028-10-09 00:00:00",
-    "start": "2028-10-09T03:00:00.000Z",
-    "end": "2028-10-10T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2028-10-31 18:00:00",
@@ -161,14 +134,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T04:00:00.000Z",
-    "end": "2028-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NS-2029.json
+++ b/test/fixtures/CA-NS-2029.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T03:00:00.000Z",
-    "end": "2029-04-02T03:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-05-13 00:00:00",
     "start": "2029-05-13T03:00:00.000Z",
     "end": "2029-05-14T03:00:00.000Z",
@@ -70,15 +61,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2029-05-21 00:00:00",
-    "start": "2029-05-21T03:00:00.000Z",
-    "end": "2029-05-22T03:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-06-17 00:00:00",
@@ -103,7 +85,7 @@
     "start": "2029-08-06T03:00:00.000Z",
     "end": "2029-08-07T03:00:00.000Z",
     "name": "Natal Day",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -125,15 +107,6 @@
     "note": "Not a paid statutory holiday in all provinces and territories; Only federally-regulated employers governed by the Canada Labour Code are required to give their employees a paid day off work",
     "rule": "09-30 since 2021",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2029-10-08 00:00:00",
-    "start": "2029-10-08T03:00:00.000Z",
-    "end": "2029-10-09T03:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-10-31 18:00:00",
@@ -161,14 +134,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T04:00:00.000Z",
-    "end": "2029-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-NT-2015.json
+++ b/test/fixtures/CA-NT-2015.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T06:00:00.000Z",
-    "end": "2015-04-06T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2015-04-06 00:00:00",
+    "start": "2015-04-06T06:00:00.000Z",
+    "end": "2015-04-07T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2015-05-10 00:00:00",

--- a/test/fixtures/CA-NT-2016.json
+++ b/test/fixtures/CA-NT-2016.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T06:00:00.000Z",
-    "end": "2016-03-28T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2016-03-28 00:00:00",
+    "start": "2016-03-28T06:00:00.000Z",
+    "end": "2016-03-29T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2016-05-08 00:00:00",

--- a/test/fixtures/CA-NT-2017.json
+++ b/test/fixtures/CA-NT-2017.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T06:00:00.000Z",
-    "end": "2017-04-17T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2017-04-17 00:00:00",
+    "start": "2017-04-17T06:00:00.000Z",
+    "end": "2017-04-18T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2017-05-14 00:00:00",

--- a/test/fixtures/CA-NT-2018.json
+++ b/test/fixtures/CA-NT-2018.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T06:00:00.000Z",
-    "end": "2018-04-02T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2018-04-02 00:00:00",
+    "start": "2018-04-02T06:00:00.000Z",
+    "end": "2018-04-03T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2018-05-13 00:00:00",

--- a/test/fixtures/CA-NT-2019.json
+++ b/test/fixtures/CA-NT-2019.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T06:00:00.000Z",
-    "end": "2019-04-22T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2019-04-22 00:00:00",
+    "start": "2019-04-22T06:00:00.000Z",
+    "end": "2019-04-23T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2019-05-12 00:00:00",

--- a/test/fixtures/CA-NT-2020.json
+++ b/test/fixtures/CA-NT-2020.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T06:00:00.000Z",
-    "end": "2020-04-13T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2020-04-13 00:00:00",
+    "start": "2020-04-13T06:00:00.000Z",
+    "end": "2020-04-14T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2020-05-10 00:00:00",

--- a/test/fixtures/CA-NT-2021.json
+++ b/test/fixtures/CA-NT-2021.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T06:00:00.000Z",
-    "end": "2021-04-05T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2021-04-05 00:00:00",
+    "start": "2021-04-05T06:00:00.000Z",
+    "end": "2021-04-06T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2021-05-09 00:00:00",

--- a/test/fixtures/CA-NT-2022.json
+++ b/test/fixtures/CA-NT-2022.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T06:00:00.000Z",
-    "end": "2022-04-18T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2022-04-18 00:00:00",
+    "start": "2022-04-18T06:00:00.000Z",
+    "end": "2022-04-19T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2022-05-08 00:00:00",

--- a/test/fixtures/CA-NT-2023.json
+++ b/test/fixtures/CA-NT-2023.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T06:00:00.000Z",
-    "end": "2023-04-10T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2023-04-10 00:00:00",
+    "start": "2023-04-10T06:00:00.000Z",
+    "end": "2023-04-11T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2023-05-14 00:00:00",

--- a/test/fixtures/CA-NT-2024.json
+++ b/test/fixtures/CA-NT-2024.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T06:00:00.000Z",
-    "end": "2024-04-01T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2024-04-01 00:00:00",
+    "start": "2024-04-01T06:00:00.000Z",
+    "end": "2024-04-02T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2024-05-12 00:00:00",

--- a/test/fixtures/CA-NT-2025.json
+++ b/test/fixtures/CA-NT-2025.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T06:00:00.000Z",
-    "end": "2025-04-21T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2025-04-21 00:00:00",
+    "start": "2025-04-21T06:00:00.000Z",
+    "end": "2025-04-22T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2025-05-11 00:00:00",

--- a/test/fixtures/CA-NT-2026.json
+++ b/test/fixtures/CA-NT-2026.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T06:00:00.000Z",
-    "end": "2026-04-06T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2026-04-06 00:00:00",
+    "start": "2026-04-06T06:00:00.000Z",
+    "end": "2026-04-07T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2026-05-10 00:00:00",

--- a/test/fixtures/CA-NT-2027.json
+++ b/test/fixtures/CA-NT-2027.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T06:00:00.000Z",
-    "end": "2027-03-29T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2027-03-29 00:00:00",
+    "start": "2027-03-29T06:00:00.000Z",
+    "end": "2027-03-30T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2027-05-09 00:00:00",

--- a/test/fixtures/CA-NT-2028.json
+++ b/test/fixtures/CA-NT-2028.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T06:00:00.000Z",
-    "end": "2028-04-17T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2028-04-17 00:00:00",
+    "start": "2028-04-17T06:00:00.000Z",
+    "end": "2028-04-18T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2028-05-14 00:00:00",

--- a/test/fixtures/CA-NT-2029.json
+++ b/test/fixtures/CA-NT-2029.json
@@ -45,13 +45,13 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T06:00:00.000Z",
-    "end": "2029-04-02T06:00:00.000Z",
-    "name": "Easter Sunday",
+    "date": "2029-04-02 00:00:00",
+    "start": "2029-04-02T06:00:00.000Z",
+    "end": "2029-04-03T06:00:00.000Z",
+    "name": "Easter Monday",
     "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
+    "rule": "easter 1",
+    "_weekday": "Mon"
   },
   {
     "date": "2029-05-13 00:00:00",

--- a/test/fixtures/CA-NU-2015.json
+++ b/test/fixtures/CA-NU-2015.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T04:00:00.000Z",
-    "end": "2015-04-06T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-05-10 00:00:00",
     "start": "2015-05-10T04:00:00.000Z",
     "end": "2015-05-11T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T05:00:00.000Z",
-    "end": "2015-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NU-2016.json
+++ b/test/fixtures/CA-NU-2016.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T04:00:00.000Z",
-    "end": "2016-03-28T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-05-08 00:00:00",
     "start": "2016-05-08T04:00:00.000Z",
     "end": "2016-05-09T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T05:00:00.000Z",
-    "end": "2016-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-NU-2017.json
+++ b/test/fixtures/CA-NU-2017.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T04:00:00.000Z",
-    "end": "2017-04-17T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-05-14 00:00:00",
     "start": "2017-05-14T04:00:00.000Z",
     "end": "2017-05-15T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T05:00:00.000Z",
-    "end": "2017-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NU-2018.json
+++ b/test/fixtures/CA-NU-2018.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T04:00:00.000Z",
-    "end": "2018-04-02T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-05-13 00:00:00",
     "start": "2018-05-13T04:00:00.000Z",
     "end": "2018-05-14T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T05:00:00.000Z",
-    "end": "2018-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-NU-2019.json
+++ b/test/fixtures/CA-NU-2019.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T04:00:00.000Z",
-    "end": "2019-04-22T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-05-12 00:00:00",
     "start": "2019-05-12T04:00:00.000Z",
     "end": "2019-05-13T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T05:00:00.000Z",
-    "end": "2019-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-NU-2020.json
+++ b/test/fixtures/CA-NU-2020.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T04:00:00.000Z",
-    "end": "2020-04-13T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-05-10 00:00:00",
     "start": "2020-05-10T04:00:00.000Z",
     "end": "2020-05-11T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T05:00:00.000Z",
-    "end": "2020-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NU-2021.json
+++ b/test/fixtures/CA-NU-2021.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T04:00:00.000Z",
-    "end": "2021-04-05T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-05-09 00:00:00",
     "start": "2021-05-09T04:00:00.000Z",
     "end": "2021-05-10T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T05:00:00.000Z",
-    "end": "2021-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-NU-2022.json
+++ b/test/fixtures/CA-NU-2022.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T04:00:00.000Z",
-    "end": "2022-04-18T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-05-08 00:00:00",
     "start": "2022-05-08T04:00:00.000Z",
     "end": "2022-05-09T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T05:00:00.000Z",
-    "end": "2022-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-NU-2023.json
+++ b/test/fixtures/CA-NU-2023.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T04:00:00.000Z",
-    "end": "2023-04-10T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-05-14 00:00:00",
     "start": "2023-05-14T04:00:00.000Z",
     "end": "2023-05-15T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T05:00:00.000Z",
-    "end": "2023-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NU-2024.json
+++ b/test/fixtures/CA-NU-2024.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T04:00:00.000Z",
-    "end": "2024-04-01T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-05-12 00:00:00",
     "start": "2024-05-12T04:00:00.000Z",
     "end": "2024-05-13T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T05:00:00.000Z",
-    "end": "2024-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-NU-2025.json
+++ b/test/fixtures/CA-NU-2025.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T04:00:00.000Z",
-    "end": "2025-04-21T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-05-11 00:00:00",
     "start": "2025-05-11T04:00:00.000Z",
     "end": "2025-05-12T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T05:00:00.000Z",
-    "end": "2025-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-NU-2026.json
+++ b/test/fixtures/CA-NU-2026.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T04:00:00.000Z",
-    "end": "2026-04-06T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-05-10 00:00:00",
     "start": "2026-05-10T04:00:00.000Z",
     "end": "2026-05-11T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T05:00:00.000Z",
-    "end": "2026-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-NU-2027.json
+++ b/test/fixtures/CA-NU-2027.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T04:00:00.000Z",
-    "end": "2027-03-29T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-05-09 00:00:00",
     "start": "2027-05-09T04:00:00.000Z",
     "end": "2027-05-10T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T05:00:00.000Z",
-    "end": "2027-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-NU-2028.json
+++ b/test/fixtures/CA-NU-2028.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T04:00:00.000Z",
-    "end": "2028-04-17T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-05-14 00:00:00",
     "start": "2028-05-14T04:00:00.000Z",
     "end": "2028-05-15T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T05:00:00.000Z",
-    "end": "2028-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-NU-2029.json
+++ b/test/fixtures/CA-NU-2029.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T04:00:00.000Z",
-    "end": "2029-04-02T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-05-13 00:00:00",
     "start": "2029-05-13T04:00:00.000Z",
     "end": "2029-05-14T04:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T05:00:00.000Z",
-    "end": "2029-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-ON-2015.json
+++ b/test/fixtures/CA-ON-2015.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T04:00:00.000Z",
-    "end": "2015-04-06T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-06T04:00:00.000Z",
     "end": "2015-04-07T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2015-08-03T04:00:00.000Z",
     "end": "2015-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2015-11-11T05:00:00.000Z",
     "end": "2015-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/CA-ON-2016.json
+++ b/test/fixtures/CA-ON-2016.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T04:00:00.000Z",
-    "end": "2016-03-28T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-28T04:00:00.000Z",
     "end": "2016-03-29T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2016-08-01T04:00:00.000Z",
     "end": "2016-08-02T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2016-11-11T05:00:00.000Z",
     "end": "2016-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/CA-ON-2017.json
+++ b/test/fixtures/CA-ON-2017.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T04:00:00.000Z",
-    "end": "2017-04-17T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-17T04:00:00.000Z",
     "end": "2017-04-18T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2017-08-07T04:00:00.000Z",
     "end": "2017-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2017-11-11T05:00:00.000Z",
     "end": "2017-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/CA-ON-2018.json
+++ b/test/fixtures/CA-ON-2018.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T04:00:00.000Z",
-    "end": "2018-04-02T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-02T04:00:00.000Z",
     "end": "2018-04-03T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2018-08-06T04:00:00.000Z",
     "end": "2018-08-07T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2018-11-11T05:00:00.000Z",
     "end": "2018-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CA-ON-2019.json
+++ b/test/fixtures/CA-ON-2019.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T04:00:00.000Z",
-    "end": "2019-04-22T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-22T04:00:00.000Z",
     "end": "2019-04-23T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2019-08-05T04:00:00.000Z",
     "end": "2019-08-06T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2019-11-11T05:00:00.000Z",
     "end": "2019-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CA-ON-2020.json
+++ b/test/fixtures/CA-ON-2020.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T04:00:00.000Z",
-    "end": "2020-04-13T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-13T04:00:00.000Z",
     "end": "2020-04-14T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2020-08-03T04:00:00.000Z",
     "end": "2020-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2020-11-11T05:00:00.000Z",
     "end": "2020-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/CA-ON-2021.json
+++ b/test/fixtures/CA-ON-2021.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T04:00:00.000Z",
-    "end": "2021-04-05T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-05T04:00:00.000Z",
     "end": "2021-04-06T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2021-08-02T04:00:00.000Z",
     "end": "2021-08-03T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2021-11-11T05:00:00.000Z",
     "end": "2021-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/CA-ON-2022.json
+++ b/test/fixtures/CA-ON-2022.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T04:00:00.000Z",
-    "end": "2022-04-18T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-18T04:00:00.000Z",
     "end": "2022-04-19T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2022-08-01T04:00:00.000Z",
     "end": "2022-08-02T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2022-11-11T05:00:00.000Z",
     "end": "2022-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/CA-ON-2023.json
+++ b/test/fixtures/CA-ON-2023.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T04:00:00.000Z",
-    "end": "2023-04-10T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-10T04:00:00.000Z",
     "end": "2023-04-11T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2023-08-07T04:00:00.000Z",
     "end": "2023-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2023-11-11T05:00:00.000Z",
     "end": "2023-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/CA-ON-2024.json
+++ b/test/fixtures/CA-ON-2024.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T04:00:00.000Z",
-    "end": "2024-04-01T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-04-01 00:00:00",
     "start": "2024-04-01T04:00:00.000Z",
     "end": "2024-04-02T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2024-08-05T04:00:00.000Z",
     "end": "2024-08-06T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2024-11-11T05:00:00.000Z",
     "end": "2024-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/CA-ON-2025.json
+++ b/test/fixtures/CA-ON-2025.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T04:00:00.000Z",
-    "end": "2025-04-21T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-21T04:00:00.000Z",
     "end": "2025-04-22T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2025-08-04T04:00:00.000Z",
     "end": "2025-08-05T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2025-11-11T05:00:00.000Z",
     "end": "2025-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/CA-ON-2026.json
+++ b/test/fixtures/CA-ON-2026.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T04:00:00.000Z",
-    "end": "2026-04-06T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-06T04:00:00.000Z",
     "end": "2026-04-07T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2026-08-03T04:00:00.000Z",
     "end": "2026-08-04T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2026-11-11T05:00:00.000Z",
     "end": "2026-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/CA-ON-2027.json
+++ b/test/fixtures/CA-ON-2027.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T04:00:00.000Z",
-    "end": "2027-03-29T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-29T04:00:00.000Z",
     "end": "2027-03-30T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2027-08-02T04:00:00.000Z",
     "end": "2027-08-03T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2027-11-11T05:00:00.000Z",
     "end": "2027-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/CA-ON-2028.json
+++ b/test/fixtures/CA-ON-2028.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T04:00:00.000Z",
-    "end": "2028-04-17T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-17T04:00:00.000Z",
     "end": "2028-04-18T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2028-08-07T04:00:00.000Z",
     "end": "2028-08-08T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2028-11-11T05:00:00.000Z",
     "end": "2028-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/CA-ON-2029.json
+++ b/test/fixtures/CA-ON-2029.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T04:00:00.000Z",
-    "end": "2029-04-02T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-02T04:00:00.000Z",
     "end": "2029-04-03T04:00:00.000Z",
@@ -112,7 +103,7 @@
     "start": "2029-08-06T04:00:00.000Z",
     "end": "2029-08-07T04:00:00.000Z",
     "name": "Civic Holiday",
-    "type": "public",
+    "type": "optional",
     "rule": "1st monday in August",
     "_weekday": "Mon"
   },
@@ -148,7 +139,7 @@
     "start": "2029-11-11T05:00:00.000Z",
     "end": "2029-11-12T05:00:00.000Z",
     "name": "Remembrance Day",
-    "type": "public",
+    "type": "optional",
     "rule": "11-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/CA-PE-2015.json
+++ b/test/fixtures/CA-PE-2015.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T04:00:00.000Z",
-    "end": "2015-04-06T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-06T04:00:00.000Z",
     "end": "2015-04-07T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2015-05-18 00:00:00",
-    "start": "2015-05-18T04:00:00.000Z",
-    "end": "2015-05-19T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2015-06-21 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2015-08-03 00:00:00",
-    "start": "2015-08-03T04:00:00.000Z",
-    "end": "2015-08-04T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2015-08-21 00:00:00",
     "start": "2015-08-21T04:00:00.000Z",
     "end": "2015-08-22T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2015-10-12 00:00:00",
-    "start": "2015-10-12T04:00:00.000Z",
-    "end": "2015-10-13T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T05:00:00.000Z",
-    "end": "2015-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-PE-2016.json
+++ b/test/fixtures/CA-PE-2016.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T04:00:00.000Z",
-    "end": "2016-03-28T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-28T04:00:00.000Z",
     "end": "2016-03-29T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-05-23 00:00:00",
-    "start": "2016-05-23T04:00:00.000Z",
-    "end": "2016-05-24T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2016-06-19 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-08-01 00:00:00",
-    "start": "2016-08-01T04:00:00.000Z",
-    "end": "2016-08-02T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2016-08-19 00:00:00",
     "start": "2016-08-19T04:00:00.000Z",
     "end": "2016-08-20T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2016-10-10 00:00:00",
-    "start": "2016-10-10T04:00:00.000Z",
-    "end": "2016-10-11T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T05:00:00.000Z",
-    "end": "2016-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-PE-2017.json
+++ b/test/fixtures/CA-PE-2017.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T04:00:00.000Z",
-    "end": "2017-04-17T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-17T04:00:00.000Z",
     "end": "2017-04-18T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2017-05-22 00:00:00",
-    "start": "2017-05-22T04:00:00.000Z",
-    "end": "2017-05-23T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2017-06-18 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2017-08-07 00:00:00",
-    "start": "2017-08-07T04:00:00.000Z",
-    "end": "2017-08-08T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2017-08-18 00:00:00",
     "start": "2017-08-18T04:00:00.000Z",
     "end": "2017-08-19T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2017-10-09 00:00:00",
-    "start": "2017-10-09T04:00:00.000Z",
-    "end": "2017-10-10T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T05:00:00.000Z",
-    "end": "2017-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-PE-2018.json
+++ b/test/fixtures/CA-PE-2018.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T04:00:00.000Z",
-    "end": "2018-04-02T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-02T04:00:00.000Z",
     "end": "2018-04-03T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2018-05-21 00:00:00",
-    "start": "2018-05-21T04:00:00.000Z",
-    "end": "2018-05-22T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2018-06-17 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2018-08-06 00:00:00",
-    "start": "2018-08-06T04:00:00.000Z",
-    "end": "2018-08-07T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2018-08-17 00:00:00",
     "start": "2018-08-17T04:00:00.000Z",
     "end": "2018-08-18T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2018-10-08 00:00:00",
-    "start": "2018-10-08T04:00:00.000Z",
-    "end": "2018-10-09T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T05:00:00.000Z",
-    "end": "2018-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-PE-2019.json
+++ b/test/fixtures/CA-PE-2019.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T04:00:00.000Z",
-    "end": "2019-04-22T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-22T04:00:00.000Z",
     "end": "2019-04-23T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2019-05-20 00:00:00",
-    "start": "2019-05-20T04:00:00.000Z",
-    "end": "2019-05-21T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2019-06-16 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2019-08-05 00:00:00",
-    "start": "2019-08-05T04:00:00.000Z",
-    "end": "2019-08-06T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2019-08-16 00:00:00",
     "start": "2019-08-16T04:00:00.000Z",
     "end": "2019-08-17T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2019-10-14 00:00:00",
-    "start": "2019-10-14T04:00:00.000Z",
-    "end": "2019-10-15T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T05:00:00.000Z",
-    "end": "2019-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-PE-2020.json
+++ b/test/fixtures/CA-PE-2020.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T04:00:00.000Z",
-    "end": "2020-04-13T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-13T04:00:00.000Z",
     "end": "2020-04-14T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2020-05-18 00:00:00",
-    "start": "2020-05-18T04:00:00.000Z",
-    "end": "2020-05-19T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2020-06-21 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2020-08-03 00:00:00",
-    "start": "2020-08-03T04:00:00.000Z",
-    "end": "2020-08-04T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2020-08-21 00:00:00",
     "start": "2020-08-21T04:00:00.000Z",
     "end": "2020-08-22T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2020-10-12 00:00:00",
-    "start": "2020-10-12T04:00:00.000Z",
-    "end": "2020-10-13T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T05:00:00.000Z",
-    "end": "2020-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-PE-2021.json
+++ b/test/fixtures/CA-PE-2021.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T04:00:00.000Z",
-    "end": "2021-04-05T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-05T04:00:00.000Z",
     "end": "2021-04-06T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2021-05-24 00:00:00",
-    "start": "2021-05-24T04:00:00.000Z",
-    "end": "2021-05-25T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-06-20 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2021-08-02 00:00:00",
-    "start": "2021-08-02T04:00:00.000Z",
-    "end": "2021-08-03T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2021-08-20 00:00:00",
     "start": "2021-08-20T04:00:00.000Z",
     "end": "2021-08-21T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2021-10-11 00:00:00",
-    "start": "2021-10-11T04:00:00.000Z",
-    "end": "2021-10-12T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T05:00:00.000Z",
-    "end": "2021-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-PE-2022.json
+++ b/test/fixtures/CA-PE-2022.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T04:00:00.000Z",
-    "end": "2022-04-18T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-18T04:00:00.000Z",
     "end": "2022-04-19T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-05-23 00:00:00",
-    "start": "2022-05-23T04:00:00.000Z",
-    "end": "2022-05-24T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-06-19 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-08-01 00:00:00",
-    "start": "2022-08-01T04:00:00.000Z",
-    "end": "2022-08-02T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2022-08-19 00:00:00",
     "start": "2022-08-19T04:00:00.000Z",
     "end": "2022-08-20T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2022-10-10 00:00:00",
-    "start": "2022-10-10T04:00:00.000Z",
-    "end": "2022-10-11T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T05:00:00.000Z",
-    "end": "2022-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-PE-2023.json
+++ b/test/fixtures/CA-PE-2023.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T04:00:00.000Z",
-    "end": "2023-04-10T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-10T04:00:00.000Z",
     "end": "2023-04-11T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2023-05-22 00:00:00",
-    "start": "2023-05-22T04:00:00.000Z",
-    "end": "2023-05-23T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-06-18 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2023-08-07 00:00:00",
-    "start": "2023-08-07T04:00:00.000Z",
-    "end": "2023-08-08T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2023-08-18 00:00:00",
     "start": "2023-08-18T04:00:00.000Z",
     "end": "2023-08-19T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2023-10-09 00:00:00",
-    "start": "2023-10-09T04:00:00.000Z",
-    "end": "2023-10-10T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T05:00:00.000Z",
-    "end": "2023-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-PE-2024.json
+++ b/test/fixtures/CA-PE-2024.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T04:00:00.000Z",
-    "end": "2024-04-01T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-04-01 00:00:00",
     "start": "2024-04-01T04:00:00.000Z",
     "end": "2024-04-02T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2024-05-20 00:00:00",
-    "start": "2024-05-20T04:00:00.000Z",
-    "end": "2024-05-21T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2024-06-16 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2024-08-05 00:00:00",
-    "start": "2024-08-05T04:00:00.000Z",
-    "end": "2024-08-06T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2024-08-16 00:00:00",
     "start": "2024-08-16T04:00:00.000Z",
     "end": "2024-08-17T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2024-10-14 00:00:00",
-    "start": "2024-10-14T04:00:00.000Z",
-    "end": "2024-10-15T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T05:00:00.000Z",
-    "end": "2024-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-PE-2025.json
+++ b/test/fixtures/CA-PE-2025.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T04:00:00.000Z",
-    "end": "2025-04-21T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-21T04:00:00.000Z",
     "end": "2025-04-22T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2025-05-19 00:00:00",
-    "start": "2025-05-19T04:00:00.000Z",
-    "end": "2025-05-20T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2025-06-15 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2025-08-04 00:00:00",
-    "start": "2025-08-04T04:00:00.000Z",
-    "end": "2025-08-05T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-15T04:00:00.000Z",
     "end": "2025-08-16T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2025-10-13 00:00:00",
-    "start": "2025-10-13T04:00:00.000Z",
-    "end": "2025-10-14T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T05:00:00.000Z",
-    "end": "2025-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-PE-2026.json
+++ b/test/fixtures/CA-PE-2026.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T04:00:00.000Z",
-    "end": "2026-04-06T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-06T04:00:00.000Z",
     "end": "2026-04-07T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2026-05-18 00:00:00",
-    "start": "2026-05-18T04:00:00.000Z",
-    "end": "2026-05-19T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-06-21 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2026-08-03 00:00:00",
-    "start": "2026-08-03T04:00:00.000Z",
-    "end": "2026-08-04T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2026-08-21 00:00:00",
     "start": "2026-08-21T04:00:00.000Z",
     "end": "2026-08-22T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2026-10-12 00:00:00",
-    "start": "2026-10-12T04:00:00.000Z",
-    "end": "2026-10-13T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T05:00:00.000Z",
-    "end": "2026-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-PE-2027.json
+++ b/test/fixtures/CA-PE-2027.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T04:00:00.000Z",
-    "end": "2027-03-29T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-29T04:00:00.000Z",
     "end": "2027-03-30T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2027-05-24 00:00:00",
-    "start": "2027-05-24T04:00:00.000Z",
-    "end": "2027-05-25T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2027-06-20 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2027-08-02 00:00:00",
-    "start": "2027-08-02T04:00:00.000Z",
-    "end": "2027-08-03T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2027-08-20 00:00:00",
     "start": "2027-08-20T04:00:00.000Z",
     "end": "2027-08-21T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2027-10-11 00:00:00",
-    "start": "2027-10-11T04:00:00.000Z",
-    "end": "2027-10-12T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T05:00:00.000Z",
-    "end": "2027-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-PE-2028.json
+++ b/test/fixtures/CA-PE-2028.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T04:00:00.000Z",
-    "end": "2028-04-17T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-17T04:00:00.000Z",
     "end": "2028-04-18T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2028-05-22 00:00:00",
-    "start": "2028-05-22T04:00:00.000Z",
-    "end": "2028-05-23T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2028-06-18 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2028-08-07 00:00:00",
-    "start": "2028-08-07T04:00:00.000Z",
-    "end": "2028-08-08T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2028-08-18 00:00:00",
     "start": "2028-08-18T04:00:00.000Z",
     "end": "2028-08-19T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2028-10-09 00:00:00",
-    "start": "2028-10-09T04:00:00.000Z",
-    "end": "2028-10-10T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T05:00:00.000Z",
-    "end": "2028-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-PE-2029.json
+++ b/test/fixtures/CA-PE-2029.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T04:00:00.000Z",
-    "end": "2029-04-02T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-02T04:00:00.000Z",
     "end": "2029-04-03T04:00:00.000Z",
@@ -79,15 +70,6 @@
     "type": "observance",
     "rule": "2nd sunday after 05-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2029-05-21 00:00:00",
-    "start": "2029-05-21T04:00:00.000Z",
-    "end": "2029-05-22T04:00:00.000Z",
-    "name": "Victoria Day",
-    "type": "public",
-    "rule": "monday before 05-25",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-06-17 00:00:00",
@@ -108,15 +90,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2029-08-06 00:00:00",
-    "start": "2029-08-06T04:00:00.000Z",
-    "end": "2029-08-07T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2029-08-17 00:00:00",
     "start": "2029-08-17T04:00:00.000Z",
     "end": "2029-08-18T04:00:00.000Z",
@@ -132,15 +105,6 @@
     "name": "Labour Day",
     "type": "public",
     "rule": "1st monday in September",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2029-10-08 00:00:00",
-    "start": "2029-10-08T04:00:00.000Z",
-    "end": "2029-10-09T04:00:00.000Z",
-    "name": "Thanksgiving",
-    "type": "public",
-    "rule": "2nd monday after 10-01",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +133,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T05:00:00.000Z",
-    "end": "2029-12-27T05:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-QC-2015.json
+++ b/test/fixtures/CA-QC-2015.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T04:00:00.000Z",
-    "end": "2015-04-06T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-06T04:00:00.000Z",
     "end": "2015-04-07T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2015-08-03 00:00:00",
-    "start": "2015-08-03T04:00:00.000Z",
-    "end": "2015-08-04T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2015-09-07 00:00:00",
     "start": "2015-09-07T04:00:00.000Z",
     "end": "2015-09-08T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2015-11-11 00:00:00",
-    "start": "2015-11-11T04:00:00.000Z",
-    "end": "2015-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Wed"
-  },
-  {
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-25T04:00:00.000Z",
     "end": "2015-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T04:00:00.000Z",
-    "end": "2015-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-QC-2016.json
+++ b/test/fixtures/CA-QC-2016.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T04:00:00.000Z",
-    "end": "2016-03-28T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-28T04:00:00.000Z",
     "end": "2016-03-29T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-08-01 00:00:00",
-    "start": "2016-08-01T04:00:00.000Z",
-    "end": "2016-08-02T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2016-09-05 00:00:00",
     "start": "2016-09-05T04:00:00.000Z",
     "end": "2016-09-06T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2016-11-11 00:00:00",
-    "start": "2016-11-11T04:00:00.000Z",
-    "end": "2016-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-25T04:00:00.000Z",
     "end": "2016-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T04:00:00.000Z",
-    "end": "2016-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-QC-2017.json
+++ b/test/fixtures/CA-QC-2017.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T04:00:00.000Z",
-    "end": "2017-04-17T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-17T04:00:00.000Z",
     "end": "2017-04-18T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2017-08-07 00:00:00",
-    "start": "2017-08-07T04:00:00.000Z",
-    "end": "2017-08-08T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2017-09-04 00:00:00",
     "start": "2017-09-04T04:00:00.000Z",
     "end": "2017-09-05T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2017-11-11 00:00:00",
-    "start": "2017-11-11T04:00:00.000Z",
-    "end": "2017-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Sat"
-  },
-  {
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-25T04:00:00.000Z",
     "end": "2017-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T04:00:00.000Z",
-    "end": "2017-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-QC-2018.json
+++ b/test/fixtures/CA-QC-2018.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T04:00:00.000Z",
-    "end": "2018-04-02T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-02T04:00:00.000Z",
     "end": "2018-04-03T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2018-08-06 00:00:00",
-    "start": "2018-08-06T04:00:00.000Z",
-    "end": "2018-08-07T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2018-09-03 00:00:00",
     "start": "2018-09-03T04:00:00.000Z",
     "end": "2018-09-04T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2018-11-11 00:00:00",
-    "start": "2018-11-11T04:00:00.000Z",
-    "end": "2018-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-25T04:00:00.000Z",
     "end": "2018-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T04:00:00.000Z",
-    "end": "2018-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-QC-2019.json
+++ b/test/fixtures/CA-QC-2019.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T04:00:00.000Z",
-    "end": "2019-04-22T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-22T04:00:00.000Z",
     "end": "2019-04-23T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2019-08-05 00:00:00",
-    "start": "2019-08-05T04:00:00.000Z",
-    "end": "2019-08-06T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2019-09-02 00:00:00",
     "start": "2019-09-02T04:00:00.000Z",
     "end": "2019-09-03T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2019-11-11 00:00:00",
-    "start": "2019-11-11T04:00:00.000Z",
-    "end": "2019-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-25T04:00:00.000Z",
     "end": "2019-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T04:00:00.000Z",
-    "end": "2019-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-QC-2020.json
+++ b/test/fixtures/CA-QC-2020.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T04:00:00.000Z",
-    "end": "2020-04-13T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-13T04:00:00.000Z",
     "end": "2020-04-14T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2020-08-03 00:00:00",
-    "start": "2020-08-03T04:00:00.000Z",
-    "end": "2020-08-04T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2020-09-07 00:00:00",
     "start": "2020-09-07T04:00:00.000Z",
     "end": "2020-09-08T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2020-11-11 00:00:00",
-    "start": "2020-11-11T04:00:00.000Z",
-    "end": "2020-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Wed"
-  },
-  {
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-25T04:00:00.000Z",
     "end": "2020-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T04:00:00.000Z",
-    "end": "2020-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-QC-2021.json
+++ b/test/fixtures/CA-QC-2021.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T04:00:00.000Z",
-    "end": "2021-04-05T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-05T04:00:00.000Z",
     "end": "2021-04-06T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2021-08-02 00:00:00",
-    "start": "2021-08-02T04:00:00.000Z",
-    "end": "2021-08-03T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2021-09-06 00:00:00",
     "start": "2021-09-06T04:00:00.000Z",
     "end": "2021-09-07T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2021-11-11 00:00:00",
-    "start": "2021-11-11T04:00:00.000Z",
-    "end": "2021-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Thu"
-  },
-  {
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-25T04:00:00.000Z",
     "end": "2021-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T04:00:00.000Z",
-    "end": "2021-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-QC-2022.json
+++ b/test/fixtures/CA-QC-2022.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T04:00:00.000Z",
-    "end": "2022-04-18T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-18T04:00:00.000Z",
     "end": "2022-04-19T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-08-01 00:00:00",
-    "start": "2022-08-01T04:00:00.000Z",
-    "end": "2022-08-02T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2022-09-05 00:00:00",
     "start": "2022-09-05T04:00:00.000Z",
     "end": "2022-09-06T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-11-11 00:00:00",
-    "start": "2022-11-11T04:00:00.000Z",
-    "end": "2022-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Fri"
-  },
-  {
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-25T04:00:00.000Z",
     "end": "2022-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T04:00:00.000Z",
-    "end": "2022-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-QC-2023.json
+++ b/test/fixtures/CA-QC-2023.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T04:00:00.000Z",
-    "end": "2023-04-10T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-10T04:00:00.000Z",
     "end": "2023-04-11T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2023-08-07 00:00:00",
-    "start": "2023-08-07T04:00:00.000Z",
-    "end": "2023-08-08T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2023-09-04 00:00:00",
     "start": "2023-09-04T04:00:00.000Z",
     "end": "2023-09-05T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2023-11-11 00:00:00",
-    "start": "2023-11-11T04:00:00.000Z",
-    "end": "2023-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Sat"
-  },
-  {
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-25T04:00:00.000Z",
     "end": "2023-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T04:00:00.000Z",
-    "end": "2023-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-QC-2024.json
+++ b/test/fixtures/CA-QC-2024.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T04:00:00.000Z",
-    "end": "2024-04-01T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-04-01 00:00:00",
     "start": "2024-04-01T04:00:00.000Z",
     "end": "2024-04-02T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2024-08-05 00:00:00",
-    "start": "2024-08-05T04:00:00.000Z",
-    "end": "2024-08-06T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2024-09-02 00:00:00",
     "start": "2024-09-02T04:00:00.000Z",
     "end": "2024-09-03T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2024-11-11 00:00:00",
-    "start": "2024-11-11T04:00:00.000Z",
-    "end": "2024-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-25T04:00:00.000Z",
     "end": "2024-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T04:00:00.000Z",
-    "end": "2024-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-QC-2025.json
+++ b/test/fixtures/CA-QC-2025.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T04:00:00.000Z",
-    "end": "2025-04-21T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-21T04:00:00.000Z",
     "end": "2025-04-22T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2025-08-04 00:00:00",
-    "start": "2025-08-04T04:00:00.000Z",
-    "end": "2025-08-05T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2025-09-01 00:00:00",
     "start": "2025-09-01T04:00:00.000Z",
     "end": "2025-09-02T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-11-11 00:00:00",
-    "start": "2025-11-11T04:00:00.000Z",
-    "end": "2025-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Tue"
-  },
-  {
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-25T04:00:00.000Z",
     "end": "2025-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T04:00:00.000Z",
-    "end": "2025-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-QC-2026.json
+++ b/test/fixtures/CA-QC-2026.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T04:00:00.000Z",
-    "end": "2026-04-06T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-06T04:00:00.000Z",
     "end": "2026-04-07T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2026-08-03 00:00:00",
-    "start": "2026-08-03T04:00:00.000Z",
-    "end": "2026-08-04T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2026-09-07 00:00:00",
     "start": "2026-09-07T04:00:00.000Z",
     "end": "2026-09-08T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2026-11-11 00:00:00",
-    "start": "2026-11-11T04:00:00.000Z",
-    "end": "2026-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Wed"
-  },
-  {
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-25T04:00:00.000Z",
     "end": "2026-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T04:00:00.000Z",
-    "end": "2026-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-QC-2027.json
+++ b/test/fixtures/CA-QC-2027.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T04:00:00.000Z",
-    "end": "2027-03-29T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-29T04:00:00.000Z",
     "end": "2027-03-30T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2027-08-02 00:00:00",
-    "start": "2027-08-02T04:00:00.000Z",
-    "end": "2027-08-03T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2027-09-06 00:00:00",
     "start": "2027-09-06T04:00:00.000Z",
     "end": "2027-09-07T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2027-11-11 00:00:00",
-    "start": "2027-11-11T04:00:00.000Z",
-    "end": "2027-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Thu"
-  },
-  {
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-25T04:00:00.000Z",
     "end": "2027-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T04:00:00.000Z",
-    "end": "2027-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-QC-2028.json
+++ b/test/fixtures/CA-QC-2028.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T04:00:00.000Z",
-    "end": "2028-04-17T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-17T04:00:00.000Z",
     "end": "2028-04-18T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2028-08-07 00:00:00",
-    "start": "2028-08-07T04:00:00.000Z",
-    "end": "2028-08-08T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2028-09-04 00:00:00",
     "start": "2028-09-04T04:00:00.000Z",
     "end": "2028-09-05T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2028-11-11 00:00:00",
-    "start": "2028-11-11T04:00:00.000Z",
-    "end": "2028-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Sat"
-  },
-  {
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-25T04:00:00.000Z",
     "end": "2028-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T04:00:00.000Z",
-    "end": "2028-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-QC-2029.json
+++ b/test/fixtures/CA-QC-2029.json
@@ -46,20 +46,11 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T04:00:00.000Z",
-    "end": "2029-04-02T04:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-02T04:00:00.000Z",
     "end": "2029-04-03T04:00:00.000Z",
     "name": "Easter Monday",
-    "type": "public",
+    "type": "optional",
     "note": "Either Good Friday or Easter Monday, at the employer’s option",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -110,15 +101,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2029-08-06 00:00:00",
-    "start": "2029-08-06T04:00:00.000Z",
-    "end": "2029-08-07T04:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2029-09-03 00:00:00",
     "start": "2029-09-03T04:00:00.000Z",
     "end": "2029-09-04T04:00:00.000Z",
@@ -146,15 +128,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2029-11-11 00:00:00",
-    "start": "2029-11-11T04:00:00.000Z",
-    "end": "2029-11-12T04:00:00.000Z",
-    "name": "Remembrance Day",
-    "type": "public",
-    "rule": "11-11",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-25T04:00:00.000Z",
     "end": "2029-12-26T04:00:00.000Z",
@@ -162,14 +135,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T04:00:00.000Z",
-    "end": "2029-12-27T04:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-SK-2015.json
+++ b/test/fixtures/CA-SK-2015.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T06:00:00.000Z",
-    "end": "2015-04-06T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-05-10 00:00:00",
     "start": "2015-05-10T06:00:00.000Z",
     "end": "2015-05-11T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T06:00:00.000Z",
-    "end": "2015-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-SK-2016.json
+++ b/test/fixtures/CA-SK-2016.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T06:00:00.000Z",
-    "end": "2016-03-28T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-05-08 00:00:00",
     "start": "2016-05-08T06:00:00.000Z",
     "end": "2016-05-09T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T06:00:00.000Z",
-    "end": "2016-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-SK-2017.json
+++ b/test/fixtures/CA-SK-2017.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T06:00:00.000Z",
-    "end": "2017-04-17T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-05-14 00:00:00",
     "start": "2017-05-14T06:00:00.000Z",
     "end": "2017-05-15T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T06:00:00.000Z",
-    "end": "2017-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-SK-2018.json
+++ b/test/fixtures/CA-SK-2018.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T06:00:00.000Z",
-    "end": "2018-04-02T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-05-13 00:00:00",
     "start": "2018-05-13T06:00:00.000Z",
     "end": "2018-05-14T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T06:00:00.000Z",
-    "end": "2018-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-SK-2019.json
+++ b/test/fixtures/CA-SK-2019.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T06:00:00.000Z",
-    "end": "2019-04-22T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-05-12 00:00:00",
     "start": "2019-05-12T06:00:00.000Z",
     "end": "2019-05-13T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T06:00:00.000Z",
-    "end": "2019-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-SK-2020.json
+++ b/test/fixtures/CA-SK-2020.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T06:00:00.000Z",
-    "end": "2020-04-13T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-05-10 00:00:00",
     "start": "2020-05-10T06:00:00.000Z",
     "end": "2020-05-11T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T06:00:00.000Z",
-    "end": "2020-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-SK-2021.json
+++ b/test/fixtures/CA-SK-2021.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T06:00:00.000Z",
-    "end": "2021-04-05T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-05-09 00:00:00",
     "start": "2021-05-09T06:00:00.000Z",
     "end": "2021-05-10T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T06:00:00.000Z",
-    "end": "2021-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-SK-2022.json
+++ b/test/fixtures/CA-SK-2022.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T06:00:00.000Z",
-    "end": "2022-04-18T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-05-08 00:00:00",
     "start": "2022-05-08T06:00:00.000Z",
     "end": "2022-05-09T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T06:00:00.000Z",
-    "end": "2022-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-SK-2023.json
+++ b/test/fixtures/CA-SK-2023.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T06:00:00.000Z",
-    "end": "2023-04-10T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-05-14 00:00:00",
     "start": "2023-05-14T06:00:00.000Z",
     "end": "2023-05-15T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T06:00:00.000Z",
-    "end": "2023-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-SK-2024.json
+++ b/test/fixtures/CA-SK-2024.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T06:00:00.000Z",
-    "end": "2024-04-01T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-05-12 00:00:00",
     "start": "2024-05-12T06:00:00.000Z",
     "end": "2024-05-13T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T06:00:00.000Z",
-    "end": "2024-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-SK-2025.json
+++ b/test/fixtures/CA-SK-2025.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T06:00:00.000Z",
-    "end": "2025-04-21T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-05-11 00:00:00",
     "start": "2025-05-11T06:00:00.000Z",
     "end": "2025-05-12T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T06:00:00.000Z",
-    "end": "2025-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-SK-2026.json
+++ b/test/fixtures/CA-SK-2026.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T06:00:00.000Z",
-    "end": "2026-04-06T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-05-10 00:00:00",
     "start": "2026-05-10T06:00:00.000Z",
     "end": "2026-05-11T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T06:00:00.000Z",
-    "end": "2026-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-SK-2027.json
+++ b/test/fixtures/CA-SK-2027.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T06:00:00.000Z",
-    "end": "2027-03-29T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-05-09 00:00:00",
     "start": "2027-05-09T06:00:00.000Z",
     "end": "2027-05-10T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T06:00:00.000Z",
-    "end": "2027-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-SK-2028.json
+++ b/test/fixtures/CA-SK-2028.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T06:00:00.000Z",
-    "end": "2028-04-17T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-05-14 00:00:00",
     "start": "2028-05-14T06:00:00.000Z",
     "end": "2028-05-15T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T06:00:00.000Z",
-    "end": "2028-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-SK-2029.json
+++ b/test/fixtures/CA-SK-2029.json
@@ -54,15 +54,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T06:00:00.000Z",
-    "end": "2029-04-02T06:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-05-13 00:00:00",
     "start": "2029-05-13T06:00:00.000Z",
     "end": "2029-05-14T06:00:00.000Z",
@@ -151,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T06:00:00.000Z",
-    "end": "2029-12-27T06:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-YT-2015.json
+++ b/test/fixtures/CA-YT-2015.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2015-04-05 00:00:00",
-    "start": "2015-04-05T07:00:00.000Z",
-    "end": "2015-04-06T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-06T07:00:00.000Z",
     "end": "2015-04-07T07:00:00.000Z",
@@ -97,15 +88,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2015-08-03 00:00:00",
-    "start": "2015-08-03T07:00:00.000Z",
-    "end": "2015-08-04T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2015-08-17 00:00:00",
@@ -160,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2015-12-26 00:00:00",
-    "start": "2015-12-26T08:00:00.000Z",
-    "end": "2015-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-YT-2016.json
+++ b/test/fixtures/CA-YT-2016.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2016-03-27 00:00:00",
-    "start": "2016-03-27T07:00:00.000Z",
-    "end": "2016-03-28T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-28T07:00:00.000Z",
     "end": "2016-03-29T07:00:00.000Z",
@@ -97,15 +88,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2016-08-01 00:00:00",
-    "start": "2016-08-01T07:00:00.000Z",
-    "end": "2016-08-02T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2016-08-15 00:00:00",
@@ -160,14 +142,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2016-12-26 00:00:00",
-    "start": "2016-12-26T08:00:00.000Z",
-    "end": "2016-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-YT-2017.json
+++ b/test/fixtures/CA-YT-2017.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2017-04-16 00:00:00",
-    "start": "2017-04-16T07:00:00.000Z",
-    "end": "2017-04-17T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-17T07:00:00.000Z",
     "end": "2017-04-18T07:00:00.000Z",
@@ -108,15 +99,6 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2017-08-07 00:00:00",
-    "start": "2017-08-07T07:00:00.000Z",
-    "end": "2017-08-08T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2017-08-21 00:00:00",
     "start": "2017-08-21T07:00:00.000Z",
     "end": "2017-08-22T07:00:00.000Z",
@@ -169,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2017-12-26 00:00:00",
-    "start": "2017-12-26T08:00:00.000Z",
-    "end": "2017-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-YT-2018.json
+++ b/test/fixtures/CA-YT-2018.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2018-04-01 00:00:00",
-    "start": "2018-04-01T07:00:00.000Z",
-    "end": "2018-04-02T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-02T07:00:00.000Z",
     "end": "2018-04-03T07:00:00.000Z",
@@ -108,15 +99,6 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2018-08-06 00:00:00",
-    "start": "2018-08-06T07:00:00.000Z",
-    "end": "2018-08-07T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2018-08-20 00:00:00",
     "start": "2018-08-20T07:00:00.000Z",
     "end": "2018-08-21T07:00:00.000Z",
@@ -169,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2018-12-26 00:00:00",
-    "start": "2018-12-26T08:00:00.000Z",
-    "end": "2018-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/CA-YT-2019.json
+++ b/test/fixtures/CA-YT-2019.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2019-04-21 00:00:00",
-    "start": "2019-04-21T07:00:00.000Z",
-    "end": "2019-04-22T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-22T07:00:00.000Z",
     "end": "2019-04-23T07:00:00.000Z",
@@ -105,15 +96,6 @@
     "name": "Canada Day",
     "type": "public",
     "rule": "07-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2019-08-05 00:00:00",
-    "start": "2019-08-05T07:00:00.000Z",
-    "end": "2019-08-06T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {
@@ -169,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2019-12-26 00:00:00",
-    "start": "2019-12-26T08:00:00.000Z",
-    "end": "2019-12-27T08:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-YT-2020.json
+++ b/test/fixtures/CA-YT-2020.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2020-04-12 00:00:00",
-    "start": "2020-04-12T07:00:00.000Z",
-    "end": "2020-04-13T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-13T07:00:00.000Z",
     "end": "2020-04-14T07:00:00.000Z",
@@ -108,15 +99,6 @@
     "_weekday": "Wed"
   },
   {
-    "date": "2020-08-03 00:00:00",
-    "start": "2020-08-03T07:00:00.000Z",
-    "end": "2020-08-04T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2020-08-17 00:00:00",
     "start": "2020-08-17T07:00:00.000Z",
     "end": "2020-08-18T07:00:00.000Z",
@@ -169,14 +151,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2020-12-26 00:00:00",
-    "start": "2020-12-26T07:00:00.000Z",
-    "end": "2020-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-YT-2021.json
+++ b/test/fixtures/CA-YT-2021.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2021-04-04 00:00:00",
-    "start": "2021-04-04T07:00:00.000Z",
-    "end": "2021-04-05T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-05T07:00:00.000Z",
     "end": "2021-04-06T07:00:00.000Z",
@@ -106,15 +97,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2021-08-02 00:00:00",
-    "start": "2021-08-02T07:00:00.000Z",
-    "end": "2021-08-03T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2021-08-16 00:00:00",
@@ -179,14 +161,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2021-12-26 00:00:00",
-    "start": "2021-12-26T07:00:00.000Z",
-    "end": "2021-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-YT-2022.json
+++ b/test/fixtures/CA-YT-2022.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2022-04-17 00:00:00",
-    "start": "2022-04-17T07:00:00.000Z",
-    "end": "2022-04-18T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-18T07:00:00.000Z",
     "end": "2022-04-19T07:00:00.000Z",
@@ -106,15 +97,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2022-08-01 00:00:00",
-    "start": "2022-08-01T07:00:00.000Z",
-    "end": "2022-08-02T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2022-08-15 00:00:00",
@@ -179,14 +161,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2022-12-26 00:00:00",
-    "start": "2022-12-26T07:00:00.000Z",
-    "end": "2022-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/CA-YT-2023.json
+++ b/test/fixtures/CA-YT-2023.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2023-04-09 00:00:00",
-    "start": "2023-04-09T07:00:00.000Z",
-    "end": "2023-04-10T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-10T07:00:00.000Z",
     "end": "2023-04-11T07:00:00.000Z",
@@ -106,15 +97,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2023-08-07 00:00:00",
-    "start": "2023-08-07T07:00:00.000Z",
-    "end": "2023-08-08T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2023-08-21 00:00:00",
@@ -179,14 +161,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2023-12-26 00:00:00",
-    "start": "2023-12-26T07:00:00.000Z",
-    "end": "2023-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-YT-2024.json
+++ b/test/fixtures/CA-YT-2024.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2024-03-31 00:00:00",
-    "start": "2024-03-31T07:00:00.000Z",
-    "end": "2024-04-01T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2024-04-01 00:00:00",
     "start": "2024-04-01T07:00:00.000Z",
     "end": "2024-04-02T07:00:00.000Z",
@@ -105,15 +96,6 @@
     "name": "Canada Day",
     "type": "public",
     "rule": "07-01",
-    "_weekday": "Mon"
-  },
-  {
-    "date": "2024-08-05 00:00:00",
-    "start": "2024-08-05T07:00:00.000Z",
-    "end": "2024-08-06T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
     "_weekday": "Mon"
   },
   {
@@ -179,14 +161,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2024-12-26 00:00:00",
-    "start": "2024-12-26T07:00:00.000Z",
-    "end": "2024-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/CA-YT-2025.json
+++ b/test/fixtures/CA-YT-2025.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2025-04-20 00:00:00",
-    "start": "2025-04-20T07:00:00.000Z",
-    "end": "2025-04-21T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-21T07:00:00.000Z",
     "end": "2025-04-22T07:00:00.000Z",
@@ -106,15 +97,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2025-08-04 00:00:00",
-    "start": "2025-08-04T07:00:00.000Z",
-    "end": "2025-08-05T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2025-08-18 00:00:00",
@@ -179,14 +161,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2025-12-26 00:00:00",
-    "start": "2025-12-26T07:00:00.000Z",
-    "end": "2025-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/CA-YT-2026.json
+++ b/test/fixtures/CA-YT-2026.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2026-04-05 00:00:00",
-    "start": "2026-04-05T07:00:00.000Z",
-    "end": "2026-04-06T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-06T07:00:00.000Z",
     "end": "2026-04-07T07:00:00.000Z",
@@ -106,15 +97,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Wed"
-  },
-  {
-    "date": "2026-08-03 00:00:00",
-    "start": "2026-08-03T07:00:00.000Z",
-    "end": "2026-08-04T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2026-08-17 00:00:00",
@@ -179,14 +161,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
-  },
-  {
-    "date": "2026-12-26 00:00:00",
-    "start": "2026-12-26T07:00:00.000Z",
-    "end": "2026-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sat"
   }
 ]

--- a/test/fixtures/CA-YT-2027.json
+++ b/test/fixtures/CA-YT-2027.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2027-03-28 00:00:00",
-    "start": "2027-03-28T07:00:00.000Z",
-    "end": "2027-03-29T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-29T07:00:00.000Z",
     "end": "2027-03-30T07:00:00.000Z",
@@ -106,15 +97,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Thu"
-  },
-  {
-    "date": "2027-08-02 00:00:00",
-    "start": "2027-08-02T07:00:00.000Z",
-    "end": "2027-08-03T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2027-08-16 00:00:00",
@@ -179,14 +161,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2027-12-26 00:00:00",
-    "start": "2027-12-26T07:00:00.000Z",
-    "end": "2027-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Sun"
   }
 ]

--- a/test/fixtures/CA-YT-2028.json
+++ b/test/fixtures/CA-YT-2028.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2028-04-16 00:00:00",
-    "start": "2028-04-16T07:00:00.000Z",
-    "end": "2028-04-17T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-17T07:00:00.000Z",
     "end": "2028-04-18T07:00:00.000Z",
@@ -106,15 +97,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sat"
-  },
-  {
-    "date": "2028-08-07 00:00:00",
-    "start": "2028-08-07T07:00:00.000Z",
-    "end": "2028-08-08T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2028-08-21 00:00:00",
@@ -179,14 +161,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2028-12-26 00:00:00",
-    "start": "2028-12-26T07:00:00.000Z",
-    "end": "2028-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/CA-YT-2029.json
+++ b/test/fixtures/CA-YT-2029.json
@@ -45,15 +45,6 @@
     "_weekday": "Fri"
   },
   {
-    "date": "2029-04-01 00:00:00",
-    "start": "2029-04-01T07:00:00.000Z",
-    "end": "2029-04-02T07:00:00.000Z",
-    "name": "Easter Sunday",
-    "type": "public",
-    "rule": "easter",
-    "_weekday": "Sun"
-  },
-  {
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-02T07:00:00.000Z",
     "end": "2029-04-03T07:00:00.000Z",
@@ -106,15 +97,6 @@
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sun"
-  },
-  {
-    "date": "2029-08-06 00:00:00",
-    "start": "2029-08-06T07:00:00.000Z",
-    "end": "2029-08-07T07:00:00.000Z",
-    "name": "Civic Holiday",
-    "type": "public",
-    "rule": "1st monday in August",
-    "_weekday": "Mon"
   },
   {
     "date": "2029-08-20 00:00:00",
@@ -179,14 +161,5 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
-  },
-  {
-    "date": "2029-12-26 00:00:00",
-    "start": "2029-12-26T07:00:00.000Z",
-    "end": "2029-12-27T07:00:00.000Z",
-    "name": "Boxing Day",
-    "type": "public",
-    "rule": "12-26",
-    "_weekday": "Wed"
   }
 ]


### PR DESCRIPTION
While comparing opening_hours.js and date-holidays, I noticed a few differences in the Canadian holiday data, so I did some primary-source checking and adjusted the confirmed cases.

----

I took another pass over the Canada data and checked a few more province-specific rules and sources. That led to a few more follow-up cleanups, mainly to avoid modeling certain holidays too broadly at the national level.

In particular, this now tightens the provincial handling for Thanksgiving, Victoria Day, Boxing Day, the August holiday, and Remembrance Day, removes national Easter Sunday, and keeps the Quebec-specific handling around National Patriots' Day and the Good Friday/Easter Monday choice.

This makes the CA data more precise.