### PR TITLE
fix(se): normalize names; fix himmelsfärdsdag typo

### DIFF
--- a/data/countries/SE.yaml
+++ b/data/countries/SE.yaml
@@ -1,4 +1,5 @@
 holidays:
+  # @source https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-1989253-om-allmanna-helgdagar_sfs-1989-253/
   # @attrib https://de.wikipedia.org/wiki/Feiertage_in_Schweden
   # @attrib https://sv.wikipedia.org/wiki/Helgdagar_i_Sverige
   SE:
@@ -74,11 +75,11 @@ holidays:
       # @attrib https://sv.wikipedia.org/wiki/Sveriges_nationaldag#Svenska_flaggans_dag
       06-06 since 2005:
         name:
-          sv: Sveriges nationaldag
+          sv: nationaldagen
           en: National Day
       06-06 since 1983 prior to 2005:
         name:
-          sv: Sveriges nationaldag
+          sv: nationaldagen
           en: National Day
         type: observance
       friday after 06-19:

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -57,7 +57,7 @@ names:
       sl: Novo leto
       sq: Viti i Ri
       sr: Нова година
-      sv: Nyårsdagen
+      sv: nyårsdagen
       sw: Mwaka mpya
       th: วันขึ้นปีใหม่
       ti: ሓዲሽ ዓመት
@@ -90,7 +90,7 @@ names:
       pl: Święto Trzech Króli
       pt: Epifania do Senhor
       sk: Zjavenie Pána
-      sv: Trettondedag jul
+      sv: trettondedag jul
       ti: ጥምቀት
       vi: Lễ Hiển Linh
   02-02:
@@ -197,7 +197,7 @@ names:
       sl: Praznik dela
       sq: Dita Ndërkombëtare e Punonjësve
       sr: Празник рада
-      sv: Första Maj
+      sv: första maj
       ti: የላብ አደሮች ቀን
       uk: День міжнародної солідарності трудящих
       vi: Quốc tế Lao động
@@ -286,7 +286,7 @@ names:
       sk: Sviatok všetkých svätých
       sq: Të gjitha Saints
       sr: Сви Свети
-      sv: Alla Helgons dag
+      sv: alla helgons dag
       vi: Lễ Các Thánh
   11-02:
     name:
@@ -424,7 +424,7 @@ names:
       sl: Božič
       sq: Krishtlindja
       sr: Католички Божић
-      sv: Juldagen
+      sv: juldagen
       sw: Krismasi
       ti: ልደት
       uk: Різдво Христове
@@ -460,7 +460,7 @@ names:
       pl: Drugi dzień Bożego Narodzenia
       ro: A doua zi de Crăciun
       sk: Druhý sviatok vianočný
-      sv: Annandag jul
+      sv: annandag jul
       vi: Ngày tặng quà
   12-31:
     name:
@@ -597,7 +597,7 @@ names:
       sk: Veľkonočný piatok
       sq: E Premtja e Madhe
       sr: Католички Велики петак
-      sv: Långfredagen
+      sv: långfredagen
       sw: Ijumaa Kuu
       ta: புனித வெள்ளி
       vi: Thứ sáu Tuần Thánh
@@ -655,7 +655,7 @@ names:
       sl: Velika noč
       sq: Pashkët Katolike
       sr: Католички Васкрс
-      sv: Påskdagen
+      sv: påskdagen
       sw: Pasaka
       vi: Lễ Phục Sinh
       zh: 复活节
@@ -691,7 +691,7 @@ names:
       sk: Veľkonočný pondelok
       sl: Velikonočni ponedeljek
       sr: Католички Васкрсни понедељак
-      sv: Annandag påsk
+      sv: annandag påsk
       sw: Jumatatu ya Pasaka
       vi: Thứ hai phục sinh
       zh: 復活節星期一
@@ -714,7 +714,7 @@ names:
       no: Kristi himmelfartsdag
       pap: Dia di Asuncion
       ro: Ziua Eroilor
-      sv: Kristi himmelfärdsdag
+      sv: Kristi himmelsfärdsdag
       vi: Lễ Thăng Thiên
   easter 49: # Pentecost / Whit Sunday
     name:
@@ -738,7 +738,7 @@ names:
       pl: Zielone Świątki
       ro: Rusaliile
       sl: Binkošti
-      sv: Pingstdagen
+      sv: pingstdagen
       uk: Трійця
       vi: Lễ Chúa Thánh Thần Hiện Xuống
   easter 50: # Whit Monday

--- a/test/fixtures/AX-2015.json
+++ b/test/fixtures/AX-2015.json
@@ -3,7 +3,7 @@
     "date": "2015-01-01 00:00:00",
     "start": "2014-12-31T22:00:00.000Z",
     "end": "2015-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T22:00:00.000Z",
     "end": "2015-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -30,7 +30,7 @@
     "date": "2015-04-03 00:00:00",
     "start": "2015-04-02T21:00:00.000Z",
     "end": "2015-04-03T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2015-04-05 00:00:00",
     "start": "2015-04-04T21:00:00.000Z",
     "end": "2015-04-05T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-05T21:00:00.000Z",
     "end": "2015-04-06T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T21:00:00.000Z",
     "end": "2015-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -66,7 +66,7 @@
     "date": "2015-05-14 00:00:00",
     "start": "2015-05-13T21:00:00.000Z",
     "end": "2015-05-14T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2015-05-24 00:00:00",
     "start": "2015-05-23T21:00:00.000Z",
     "end": "2015-05-24T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T22:00:00.000Z",
     "end": "2015-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -138,7 +138,7 @@
     "date": "2015-12-26 00:00:00",
     "start": "2015-12-25T22:00:00.000Z",
     "end": "2015-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2016.json
+++ b/test/fixtures/AX-2016.json
@@ -3,7 +3,7 @@
     "date": "2016-01-01 00:00:00",
     "start": "2015-12-31T22:00:00.000Z",
     "end": "2016-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T22:00:00.000Z",
     "end": "2016-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -21,7 +21,7 @@
     "date": "2016-03-25 00:00:00",
     "start": "2016-03-24T22:00:00.000Z",
     "end": "2016-03-25T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2016-03-27 00:00:00",
     "start": "2016-03-26T22:00:00.000Z",
     "end": "2016-03-27T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-27T21:00:00.000Z",
     "end": "2016-03-28T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T21:00:00.000Z",
     "end": "2016-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -66,7 +66,7 @@
     "date": "2016-05-05 00:00:00",
     "start": "2016-05-04T21:00:00.000Z",
     "end": "2016-05-05T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2016-05-15 00:00:00",
     "start": "2016-05-14T21:00:00.000Z",
     "end": "2016-05-15T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T22:00:00.000Z",
     "end": "2016-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
@@ -138,7 +138,7 @@
     "date": "2016-12-26 00:00:00",
     "start": "2016-12-25T22:00:00.000Z",
     "end": "2016-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"

--- a/test/fixtures/AX-2017.json
+++ b/test/fixtures/AX-2017.json
@@ -3,7 +3,7 @@
     "date": "2017-01-01 00:00:00",
     "start": "2016-12-31T22:00:00.000Z",
     "end": "2017-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T22:00:00.000Z",
     "end": "2017-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2017-04-14 00:00:00",
     "start": "2017-04-13T21:00:00.000Z",
     "end": "2017-04-14T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-16 00:00:00",
     "start": "2017-04-15T21:00:00.000Z",
     "end": "2017-04-16T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T21:00:00.000Z",
     "end": "2017-04-17T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T21:00:00.000Z",
     "end": "2017-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2017-05-25 00:00:00",
     "start": "2017-05-24T21:00:00.000Z",
     "end": "2017-05-25T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2017-06-04 00:00:00",
     "start": "2017-06-03T21:00:00.000Z",
     "end": "2017-06-04T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T22:00:00.000Z",
     "end": "2017-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -138,7 +138,7 @@
     "date": "2017-12-26 00:00:00",
     "start": "2017-12-25T22:00:00.000Z",
     "end": "2017-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/AX-2018.json
+++ b/test/fixtures/AX-2018.json
@@ -3,7 +3,7 @@
     "date": "2018-01-01 00:00:00",
     "start": "2017-12-31T22:00:00.000Z",
     "end": "2018-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T22:00:00.000Z",
     "end": "2018-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -30,7 +30,7 @@
     "date": "2018-03-30 00:00:00",
     "start": "2018-03-29T21:00:00.000Z",
     "end": "2018-03-30T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2018-04-01 00:00:00",
     "start": "2018-03-31T21:00:00.000Z",
     "end": "2018-04-01T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-01T21:00:00.000Z",
     "end": "2018-04-02T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T21:00:00.000Z",
     "end": "2018-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -66,7 +66,7 @@
     "date": "2018-05-10 00:00:00",
     "start": "2018-05-09T21:00:00.000Z",
     "end": "2018-05-10T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2018-05-20 00:00:00",
     "start": "2018-05-19T21:00:00.000Z",
     "end": "2018-05-20T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T22:00:00.000Z",
     "end": "2018-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
@@ -138,7 +138,7 @@
     "date": "2018-12-26 00:00:00",
     "start": "2018-12-25T22:00:00.000Z",
     "end": "2018-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"

--- a/test/fixtures/AX-2019.json
+++ b/test/fixtures/AX-2019.json
@@ -3,7 +3,7 @@
     "date": "2019-01-01 00:00:00",
     "start": "2018-12-31T22:00:00.000Z",
     "end": "2019-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Tue"
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T22:00:00.000Z",
     "end": "2019-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -30,7 +30,7 @@
     "date": "2019-04-19 00:00:00",
     "start": "2019-04-18T21:00:00.000Z",
     "end": "2019-04-19T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2019-04-21 00:00:00",
     "start": "2019-04-20T21:00:00.000Z",
     "end": "2019-04-21T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-21T21:00:00.000Z",
     "end": "2019-04-22T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T21:00:00.000Z",
     "end": "2019-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -66,7 +66,7 @@
     "date": "2019-05-30 00:00:00",
     "start": "2019-05-29T21:00:00.000Z",
     "end": "2019-05-30T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2019-06-09 00:00:00",
     "start": "2019-06-08T21:00:00.000Z",
     "end": "2019-06-09T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T22:00:00.000Z",
     "end": "2019-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
@@ -138,7 +138,7 @@
     "date": "2019-12-26 00:00:00",
     "start": "2019-12-25T22:00:00.000Z",
     "end": "2019-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"

--- a/test/fixtures/AX-2020.json
+++ b/test/fixtures/AX-2020.json
@@ -3,7 +3,7 @@
     "date": "2020-01-01 00:00:00",
     "start": "2019-12-31T22:00:00.000Z",
     "end": "2020-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T22:00:00.000Z",
     "end": "2020-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -30,7 +30,7 @@
     "date": "2020-04-10 00:00:00",
     "start": "2020-04-09T21:00:00.000Z",
     "end": "2020-04-10T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2020-04-12 00:00:00",
     "start": "2020-04-11T21:00:00.000Z",
     "end": "2020-04-12T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-12T21:00:00.000Z",
     "end": "2020-04-13T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T21:00:00.000Z",
     "end": "2020-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -66,7 +66,7 @@
     "date": "2020-05-21 00:00:00",
     "start": "2020-05-20T21:00:00.000Z",
     "end": "2020-05-21T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2020-05-31 00:00:00",
     "start": "2020-05-30T21:00:00.000Z",
     "end": "2020-05-31T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T22:00:00.000Z",
     "end": "2020-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -138,7 +138,7 @@
     "date": "2020-12-26 00:00:00",
     "start": "2020-12-25T22:00:00.000Z",
     "end": "2020-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2021.json
+++ b/test/fixtures/AX-2021.json
@@ -3,7 +3,7 @@
     "date": "2021-01-01 00:00:00",
     "start": "2020-12-31T22:00:00.000Z",
     "end": "2021-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T22:00:00.000Z",
     "end": "2021-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -30,7 +30,7 @@
     "date": "2021-04-02 00:00:00",
     "start": "2021-04-01T21:00:00.000Z",
     "end": "2021-04-02T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2021-04-04 00:00:00",
     "start": "2021-04-03T21:00:00.000Z",
     "end": "2021-04-04T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-04T21:00:00.000Z",
     "end": "2021-04-05T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T21:00:00.000Z",
     "end": "2021-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -66,7 +66,7 @@
     "date": "2021-05-13 00:00:00",
     "start": "2021-05-12T21:00:00.000Z",
     "end": "2021-05-13T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2021-05-23 00:00:00",
     "start": "2021-05-22T21:00:00.000Z",
     "end": "2021-05-23T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T22:00:00.000Z",
     "end": "2021-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2021-12-26 00:00:00",
     "start": "2021-12-25T22:00:00.000Z",
     "end": "2021-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"

--- a/test/fixtures/AX-2022.json
+++ b/test/fixtures/AX-2022.json
@@ -3,7 +3,7 @@
     "date": "2022-01-01 00:00:00",
     "start": "2021-12-31T22:00:00.000Z",
     "end": "2022-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T22:00:00.000Z",
     "end": "2022-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -30,7 +30,7 @@
     "date": "2022-04-15 00:00:00",
     "start": "2022-04-14T21:00:00.000Z",
     "end": "2022-04-15T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2022-04-17 00:00:00",
     "start": "2022-04-16T21:00:00.000Z",
     "end": "2022-04-17T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-17T21:00:00.000Z",
     "end": "2022-04-18T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T21:00:00.000Z",
     "end": "2022-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -66,7 +66,7 @@
     "date": "2022-05-26 00:00:00",
     "start": "2022-05-25T21:00:00.000Z",
     "end": "2022-05-26T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2022-06-05 00:00:00",
     "start": "2022-06-04T21:00:00.000Z",
     "end": "2022-06-05T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T22:00:00.000Z",
     "end": "2022-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
@@ -138,7 +138,7 @@
     "date": "2022-12-26 00:00:00",
     "start": "2022-12-25T22:00:00.000Z",
     "end": "2022-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"

--- a/test/fixtures/AX-2023.json
+++ b/test/fixtures/AX-2023.json
@@ -3,7 +3,7 @@
     "date": "2023-01-01 00:00:00",
     "start": "2022-12-31T22:00:00.000Z",
     "end": "2023-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T22:00:00.000Z",
     "end": "2023-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2023-04-07 00:00:00",
     "start": "2023-04-06T21:00:00.000Z",
     "end": "2023-04-07T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-09 00:00:00",
     "start": "2023-04-08T21:00:00.000Z",
     "end": "2023-04-09T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-09T21:00:00.000Z",
     "end": "2023-04-10T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T21:00:00.000Z",
     "end": "2023-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2023-05-18 00:00:00",
     "start": "2023-05-17T21:00:00.000Z",
     "end": "2023-05-18T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2023-05-28 00:00:00",
     "start": "2023-05-27T21:00:00.000Z",
     "end": "2023-05-28T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T22:00:00.000Z",
     "end": "2023-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -138,7 +138,7 @@
     "date": "2023-12-26 00:00:00",
     "start": "2023-12-25T22:00:00.000Z",
     "end": "2023-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/AX-2024.json
+++ b/test/fixtures/AX-2024.json
@@ -3,7 +3,7 @@
     "date": "2024-01-01 00:00:00",
     "start": "2023-12-31T22:00:00.000Z",
     "end": "2024-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T22:00:00.000Z",
     "end": "2024-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -21,7 +21,7 @@
     "date": "2024-03-29 00:00:00",
     "start": "2024-03-28T22:00:00.000Z",
     "end": "2024-03-29T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2024-03-31 00:00:00",
     "start": "2024-03-30T22:00:00.000Z",
     "end": "2024-03-31T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-03-31T21:00:00.000Z",
     "end": "2024-04-01T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T21:00:00.000Z",
     "end": "2024-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -66,7 +66,7 @@
     "date": "2024-05-09 00:00:00",
     "start": "2024-05-08T21:00:00.000Z",
     "end": "2024-05-09T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2024-05-19 00:00:00",
     "start": "2024-05-18T21:00:00.000Z",
     "end": "2024-05-19T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T22:00:00.000Z",
     "end": "2024-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
@@ -138,7 +138,7 @@
     "date": "2024-12-26 00:00:00",
     "start": "2024-12-25T22:00:00.000Z",
     "end": "2024-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"

--- a/test/fixtures/AX-2025.json
+++ b/test/fixtures/AX-2025.json
@@ -3,7 +3,7 @@
     "date": "2025-01-01 00:00:00",
     "start": "2024-12-31T22:00:00.000Z",
     "end": "2025-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T22:00:00.000Z",
     "end": "2025-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -30,7 +30,7 @@
     "date": "2025-04-18 00:00:00",
     "start": "2025-04-17T21:00:00.000Z",
     "end": "2025-04-18T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2025-04-20 00:00:00",
     "start": "2025-04-19T21:00:00.000Z",
     "end": "2025-04-20T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T21:00:00.000Z",
     "end": "2025-04-21T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T21:00:00.000Z",
     "end": "2025-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2025-05-29 00:00:00",
     "start": "2025-05-28T21:00:00.000Z",
     "end": "2025-05-29T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2025-06-08 00:00:00",
     "start": "2025-06-07T21:00:00.000Z",
     "end": "2025-06-08T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T22:00:00.000Z",
     "end": "2025-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2025-12-26 00:00:00",
     "start": "2025-12-25T22:00:00.000Z",
     "end": "2025-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Fri"

--- a/test/fixtures/AX-2026.json
+++ b/test/fixtures/AX-2026.json
@@ -3,7 +3,7 @@
     "date": "2026-01-01 00:00:00",
     "start": "2025-12-31T22:00:00.000Z",
     "end": "2026-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T22:00:00.000Z",
     "end": "2026-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -30,7 +30,7 @@
     "date": "2026-04-03 00:00:00",
     "start": "2026-04-02T21:00:00.000Z",
     "end": "2026-04-03T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2026-04-05 00:00:00",
     "start": "2026-04-04T21:00:00.000Z",
     "end": "2026-04-05T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-05T21:00:00.000Z",
     "end": "2026-04-06T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T21:00:00.000Z",
     "end": "2026-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -66,7 +66,7 @@
     "date": "2026-05-14 00:00:00",
     "start": "2026-05-13T21:00:00.000Z",
     "end": "2026-05-14T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2026-05-24 00:00:00",
     "start": "2026-05-23T21:00:00.000Z",
     "end": "2026-05-24T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T22:00:00.000Z",
     "end": "2026-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -138,7 +138,7 @@
     "date": "2026-12-26 00:00:00",
     "start": "2026-12-25T22:00:00.000Z",
     "end": "2026-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2027.json
+++ b/test/fixtures/AX-2027.json
@@ -3,7 +3,7 @@
     "date": "2027-01-01 00:00:00",
     "start": "2026-12-31T22:00:00.000Z",
     "end": "2027-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T22:00:00.000Z",
     "end": "2027-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -21,7 +21,7 @@
     "date": "2027-03-26 00:00:00",
     "start": "2027-03-25T22:00:00.000Z",
     "end": "2027-03-26T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2027-03-28 00:00:00",
     "start": "2027-03-27T22:00:00.000Z",
     "end": "2027-03-28T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-28T21:00:00.000Z",
     "end": "2027-03-29T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T21:00:00.000Z",
     "end": "2027-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -66,7 +66,7 @@
     "date": "2027-05-06 00:00:00",
     "start": "2027-05-05T21:00:00.000Z",
     "end": "2027-05-06T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2027-05-16 00:00:00",
     "start": "2027-05-15T21:00:00.000Z",
     "end": "2027-05-16T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T22:00:00.000Z",
     "end": "2027-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2027-12-26 00:00:00",
     "start": "2027-12-25T22:00:00.000Z",
     "end": "2027-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"

--- a/test/fixtures/AX-2028.json
+++ b/test/fixtures/AX-2028.json
@@ -3,7 +3,7 @@
     "date": "2028-01-01 00:00:00",
     "start": "2027-12-31T22:00:00.000Z",
     "end": "2028-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T22:00:00.000Z",
     "end": "2028-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -30,7 +30,7 @@
     "date": "2028-04-14 00:00:00",
     "start": "2028-04-13T21:00:00.000Z",
     "end": "2028-04-14T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2028-04-16 00:00:00",
     "start": "2028-04-15T21:00:00.000Z",
     "end": "2028-04-16T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T21:00:00.000Z",
     "end": "2028-04-17T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T21:00:00.000Z",
     "end": "2028-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2028-05-25 00:00:00",
     "start": "2028-05-24T21:00:00.000Z",
     "end": "2028-05-25T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2028-06-04 00:00:00",
     "start": "2028-06-03T21:00:00.000Z",
     "end": "2028-06-04T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T22:00:00.000Z",
     "end": "2028-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -138,7 +138,7 @@
     "date": "2028-12-26 00:00:00",
     "start": "2028-12-25T22:00:00.000Z",
     "end": "2028-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/AX-2029.json
+++ b/test/fixtures/AX-2029.json
@@ -3,7 +3,7 @@
     "date": "2029-01-01 00:00:00",
     "start": "2028-12-31T22:00:00.000Z",
     "end": "2029-01-01T22:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T22:00:00.000Z",
     "end": "2029-01-06T22:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -30,7 +30,7 @@
     "date": "2029-03-30 00:00:00",
     "start": "2029-03-29T21:00:00.000Z",
     "end": "2029-03-30T21:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2029-04-01 00:00:00",
     "start": "2029-03-31T21:00:00.000Z",
     "end": "2029-04-01T21:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-01T21:00:00.000Z",
     "end": "2029-04-02T21:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T21:00:00.000Z",
     "end": "2029-05-01T21:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -66,7 +66,7 @@
     "date": "2029-05-10 00:00:00",
     "start": "2029-05-09T21:00:00.000Z",
     "end": "2029-05-10T21:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2029-05-20 00:00:00",
     "start": "2029-05-19T21:00:00.000Z",
     "end": "2029-05-20T21:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "observance",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T22:00:00.000Z",
     "end": "2029-12-25T22:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
@@ -138,7 +138,7 @@
     "date": "2029-12-26 00:00:00",
     "start": "2029-12-25T22:00:00.000Z",
     "end": "2029-12-26T22:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"

--- a/test/fixtures/SE-2015.json
+++ b/test/fixtures/SE-2015.json
@@ -3,7 +3,7 @@
     "date": "2015-01-01 00:00:00",
     "start": "2014-12-31T23:00:00.000Z",
     "end": "2015-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"
@@ -21,7 +21,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -57,7 +57,7 @@
     "date": "2015-04-03 00:00:00",
     "start": "2015-04-02T22:00:00.000Z",
     "end": "2015-04-03T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2015-04-05 00:00:00",
     "start": "2015-04-04T22:00:00.000Z",
     "end": "2015-04-05T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-05T22:00:00.000Z",
     "end": "2015-04-06T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -111,7 +111,7 @@
     "date": "2015-05-14 00:00:00",
     "start": "2015-05-13T22:00:00.000Z",
     "end": "2015-05-14T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2015-05-24 00:00:00",
     "start": "2015-05-23T22:00:00.000Z",
     "end": "2015-05-24T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2015-06-06 00:00:00",
     "start": "2015-06-05T22:00:00.000Z",
     "end": "2015-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Sat"
@@ -192,7 +192,7 @@
     "date": "2015-10-31 00:00:00",
     "start": "2015-10-30T23:00:00.000Z",
     "end": "2015-10-31T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -255,7 +255,7 @@
     "date": "2015-12-26 00:00:00",
     "start": "2015-12-25T23:00:00.000Z",
     "end": "2015-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2016.json
+++ b/test/fixtures/SE-2016.json
@@ -3,7 +3,7 @@
     "date": "2016-01-01 00:00:00",
     "start": "2015-12-31T23:00:00.000Z",
     "end": "2016-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -21,7 +21,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -57,7 +57,7 @@
     "date": "2016-03-25 00:00:00",
     "start": "2016-03-24T23:00:00.000Z",
     "end": "2016-03-25T23:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2016-03-27 00:00:00",
     "start": "2016-03-26T23:00:00.000Z",
     "end": "2016-03-27T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-27T22:00:00.000Z",
     "end": "2016-03-28T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2016-05-05 00:00:00",
     "start": "2016-05-04T22:00:00.000Z",
     "end": "2016-05-05T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2016-05-15 00:00:00",
     "start": "2016-05-14T22:00:00.000Z",
     "end": "2016-05-15T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2016-06-06 00:00:00",
     "start": "2016-06-05T22:00:00.000Z",
     "end": "2016-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Mon"
@@ -192,7 +192,7 @@
     "date": "2016-11-05 00:00:00",
     "start": "2016-11-04T23:00:00.000Z",
     "end": "2016-11-05T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
@@ -255,7 +255,7 @@
     "date": "2016-12-26 00:00:00",
     "start": "2016-12-25T23:00:00.000Z",
     "end": "2016-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"

--- a/test/fixtures/SE-2017.json
+++ b/test/fixtures/SE-2017.json
@@ -3,7 +3,7 @@
     "date": "2017-01-01 00:00:00",
     "start": "2016-12-31T23:00:00.000Z",
     "end": "2017-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"
@@ -21,7 +21,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -57,7 +57,7 @@
     "date": "2017-04-14 00:00:00",
     "start": "2017-04-13T22:00:00.000Z",
     "end": "2017-04-14T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2017-04-16 00:00:00",
     "start": "2017-04-15T22:00:00.000Z",
     "end": "2017-04-16T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T22:00:00.000Z",
     "end": "2017-04-17T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2017-05-25 00:00:00",
     "start": "2017-05-24T22:00:00.000Z",
     "end": "2017-05-25T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2017-06-04 00:00:00",
     "start": "2017-06-03T22:00:00.000Z",
     "end": "2017-06-04T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2017-06-06 00:00:00",
     "start": "2017-06-05T22:00:00.000Z",
     "end": "2017-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Tue"
@@ -192,7 +192,7 @@
     "date": "2017-11-04 00:00:00",
     "start": "2017-11-03T23:00:00.000Z",
     "end": "2017-11-04T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -255,7 +255,7 @@
     "date": "2017-12-26 00:00:00",
     "start": "2017-12-25T23:00:00.000Z",
     "end": "2017-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/SE-2018.json
+++ b/test/fixtures/SE-2018.json
@@ -3,7 +3,7 @@
     "date": "2018-01-01 00:00:00",
     "start": "2017-12-31T23:00:00.000Z",
     "end": "2018-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -21,7 +21,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -57,7 +57,7 @@
     "date": "2018-03-30 00:00:00",
     "start": "2018-03-29T22:00:00.000Z",
     "end": "2018-03-30T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2018-04-01 00:00:00",
     "start": "2018-03-31T22:00:00.000Z",
     "end": "2018-04-01T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-01T22:00:00.000Z",
     "end": "2018-04-02T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -111,7 +111,7 @@
     "date": "2018-05-10 00:00:00",
     "start": "2018-05-09T22:00:00.000Z",
     "end": "2018-05-10T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2018-05-20 00:00:00",
     "start": "2018-05-19T22:00:00.000Z",
     "end": "2018-05-20T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2018-06-06 00:00:00",
     "start": "2018-06-05T22:00:00.000Z",
     "end": "2018-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Wed"
@@ -192,7 +192,7 @@
     "date": "2018-11-03 00:00:00",
     "start": "2018-11-02T23:00:00.000Z",
     "end": "2018-11-03T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
@@ -255,7 +255,7 @@
     "date": "2018-12-26 00:00:00",
     "start": "2018-12-25T23:00:00.000Z",
     "end": "2018-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"

--- a/test/fixtures/SE-2019.json
+++ b/test/fixtures/SE-2019.json
@@ -3,7 +3,7 @@
     "date": "2019-01-01 00:00:00",
     "start": "2018-12-31T23:00:00.000Z",
     "end": "2019-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Tue"
@@ -21,7 +21,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2019-04-19 00:00:00",
     "start": "2019-04-18T22:00:00.000Z",
     "end": "2019-04-19T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2019-04-21 00:00:00",
     "start": "2019-04-20T22:00:00.000Z",
     "end": "2019-04-21T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-21T22:00:00.000Z",
     "end": "2019-04-22T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -120,7 +120,7 @@
     "date": "2019-05-30 00:00:00",
     "start": "2019-05-29T22:00:00.000Z",
     "end": "2019-05-30T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2019-06-06 00:00:00",
     "start": "2019-06-05T22:00:00.000Z",
     "end": "2019-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Thu"
@@ -147,7 +147,7 @@
     "date": "2019-06-09 00:00:00",
     "start": "2019-06-08T22:00:00.000Z",
     "end": "2019-06-09T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -192,7 +192,7 @@
     "date": "2019-11-02 00:00:00",
     "start": "2019-11-01T23:00:00.000Z",
     "end": "2019-11-02T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
@@ -255,7 +255,7 @@
     "date": "2019-12-26 00:00:00",
     "start": "2019-12-25T23:00:00.000Z",
     "end": "2019-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"

--- a/test/fixtures/SE-2020.json
+++ b/test/fixtures/SE-2020.json
@@ -3,7 +3,7 @@
     "date": "2020-01-01 00:00:00",
     "start": "2019-12-31T23:00:00.000Z",
     "end": "2020-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"
@@ -21,7 +21,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2020-04-10 00:00:00",
     "start": "2020-04-09T22:00:00.000Z",
     "end": "2020-04-10T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2020-04-12 00:00:00",
     "start": "2020-04-11T22:00:00.000Z",
     "end": "2020-04-12T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-12T22:00:00.000Z",
     "end": "2020-04-13T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -111,7 +111,7 @@
     "date": "2020-05-21 00:00:00",
     "start": "2020-05-20T22:00:00.000Z",
     "end": "2020-05-21T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2020-05-31 00:00:00",
     "start": "2020-05-30T22:00:00.000Z",
     "end": "2020-05-31T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2020-06-06 00:00:00",
     "start": "2020-06-05T22:00:00.000Z",
     "end": "2020-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Sat"
@@ -192,7 +192,7 @@
     "date": "2020-10-31 00:00:00",
     "start": "2020-10-30T23:00:00.000Z",
     "end": "2020-10-31T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -255,7 +255,7 @@
     "date": "2020-12-26 00:00:00",
     "start": "2020-12-25T23:00:00.000Z",
     "end": "2020-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2021.json
+++ b/test/fixtures/SE-2021.json
@@ -3,7 +3,7 @@
     "date": "2021-01-01 00:00:00",
     "start": "2020-12-31T23:00:00.000Z",
     "end": "2021-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -21,7 +21,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -57,7 +57,7 @@
     "date": "2021-04-02 00:00:00",
     "start": "2021-04-01T22:00:00.000Z",
     "end": "2021-04-02T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2021-04-04 00:00:00",
     "start": "2021-04-03T22:00:00.000Z",
     "end": "2021-04-04T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-04T22:00:00.000Z",
     "end": "2021-04-05T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -111,7 +111,7 @@
     "date": "2021-05-13 00:00:00",
     "start": "2021-05-12T22:00:00.000Z",
     "end": "2021-05-13T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2021-05-23 00:00:00",
     "start": "2021-05-22T22:00:00.000Z",
     "end": "2021-05-23T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2021-06-06 00:00:00",
     "start": "2021-06-05T22:00:00.000Z",
     "end": "2021-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Sun"
@@ -192,7 +192,7 @@
     "date": "2021-11-06 00:00:00",
     "start": "2021-11-05T23:00:00.000Z",
     "end": "2021-11-06T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
@@ -255,7 +255,7 @@
     "date": "2021-12-26 00:00:00",
     "start": "2021-12-25T23:00:00.000Z",
     "end": "2021-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"

--- a/test/fixtures/SE-2022.json
+++ b/test/fixtures/SE-2022.json
@@ -3,7 +3,7 @@
     "date": "2022-01-01 00:00:00",
     "start": "2021-12-31T23:00:00.000Z",
     "end": "2022-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"
@@ -21,7 +21,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -57,7 +57,7 @@
     "date": "2022-04-15 00:00:00",
     "start": "2022-04-14T22:00:00.000Z",
     "end": "2022-04-15T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2022-04-17 00:00:00",
     "start": "2022-04-16T22:00:00.000Z",
     "end": "2022-04-17T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-17T22:00:00.000Z",
     "end": "2022-04-18T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2022-05-26 00:00:00",
     "start": "2022-05-25T22:00:00.000Z",
     "end": "2022-05-26T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2022-06-05 00:00:00",
     "start": "2022-06-04T22:00:00.000Z",
     "end": "2022-06-05T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2022-06-06 00:00:00",
     "start": "2022-06-05T22:00:00.000Z",
     "end": "2022-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Mon"
@@ -192,7 +192,7 @@
     "date": "2022-11-05 00:00:00",
     "start": "2022-11-04T23:00:00.000Z",
     "end": "2022-11-05T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
@@ -255,7 +255,7 @@
     "date": "2022-12-26 00:00:00",
     "start": "2022-12-25T23:00:00.000Z",
     "end": "2022-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"

--- a/test/fixtures/SE-2023.json
+++ b/test/fixtures/SE-2023.json
@@ -3,7 +3,7 @@
     "date": "2023-01-01 00:00:00",
     "start": "2022-12-31T23:00:00.000Z",
     "end": "2023-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"
@@ -21,7 +21,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -57,7 +57,7 @@
     "date": "2023-04-07 00:00:00",
     "start": "2023-04-06T22:00:00.000Z",
     "end": "2023-04-07T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2023-04-09 00:00:00",
     "start": "2023-04-08T22:00:00.000Z",
     "end": "2023-04-09T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-09T22:00:00.000Z",
     "end": "2023-04-10T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2023-05-18 00:00:00",
     "start": "2023-05-17T22:00:00.000Z",
     "end": "2023-05-18T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2023-05-28 00:00:00",
     "start": "2023-05-27T22:00:00.000Z",
     "end": "2023-05-28T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2023-06-06 00:00:00",
     "start": "2023-06-05T22:00:00.000Z",
     "end": "2023-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Tue"
@@ -192,7 +192,7 @@
     "date": "2023-11-04 00:00:00",
     "start": "2023-11-03T23:00:00.000Z",
     "end": "2023-11-04T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -255,7 +255,7 @@
     "date": "2023-12-26 00:00:00",
     "start": "2023-12-25T23:00:00.000Z",
     "end": "2023-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/SE-2024.json
+++ b/test/fixtures/SE-2024.json
@@ -3,7 +3,7 @@
     "date": "2024-01-01 00:00:00",
     "start": "2023-12-31T23:00:00.000Z",
     "end": "2024-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -21,7 +21,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -57,7 +57,7 @@
     "date": "2024-03-29 00:00:00",
     "start": "2024-03-28T23:00:00.000Z",
     "end": "2024-03-29T23:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2024-03-31 00:00:00",
     "start": "2024-03-30T23:00:00.000Z",
     "end": "2024-03-31T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-03-31T22:00:00.000Z",
     "end": "2024-04-01T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -111,7 +111,7 @@
     "date": "2024-05-09 00:00:00",
     "start": "2024-05-08T22:00:00.000Z",
     "end": "2024-05-09T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2024-05-19 00:00:00",
     "start": "2024-05-18T22:00:00.000Z",
     "end": "2024-05-19T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2024-06-06 00:00:00",
     "start": "2024-06-05T22:00:00.000Z",
     "end": "2024-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Thu"
@@ -192,7 +192,7 @@
     "date": "2024-11-02 00:00:00",
     "start": "2024-11-01T23:00:00.000Z",
     "end": "2024-11-02T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
@@ -255,7 +255,7 @@
     "date": "2024-12-26 00:00:00",
     "start": "2024-12-25T23:00:00.000Z",
     "end": "2024-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"

--- a/test/fixtures/SE-2025.json
+++ b/test/fixtures/SE-2025.json
@@ -3,7 +3,7 @@
     "date": "2025-01-01 00:00:00",
     "start": "2024-12-31T23:00:00.000Z",
     "end": "2025-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"
@@ -21,7 +21,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -57,7 +57,7 @@
     "date": "2025-04-18 00:00:00",
     "start": "2025-04-17T22:00:00.000Z",
     "end": "2025-04-18T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2025-04-20 00:00:00",
     "start": "2025-04-19T22:00:00.000Z",
     "end": "2025-04-20T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T22:00:00.000Z",
     "end": "2025-04-21T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -120,7 +120,7 @@
     "date": "2025-05-29 00:00:00",
     "start": "2025-05-28T22:00:00.000Z",
     "end": "2025-05-29T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2025-06-06 00:00:00",
     "start": "2025-06-05T22:00:00.000Z",
     "end": "2025-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Fri"
@@ -147,7 +147,7 @@
     "date": "2025-06-08 00:00:00",
     "start": "2025-06-07T22:00:00.000Z",
     "end": "2025-06-08T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -192,7 +192,7 @@
     "date": "2025-11-01 00:00:00",
     "start": "2025-10-31T23:00:00.000Z",
     "end": "2025-11-01T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
@@ -255,7 +255,7 @@
     "date": "2025-12-26 00:00:00",
     "start": "2025-12-25T23:00:00.000Z",
     "end": "2025-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Fri"

--- a/test/fixtures/SE-2026.json
+++ b/test/fixtures/SE-2026.json
@@ -3,7 +3,7 @@
     "date": "2026-01-01 00:00:00",
     "start": "2025-12-31T23:00:00.000Z",
     "end": "2026-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"
@@ -21,7 +21,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -57,7 +57,7 @@
     "date": "2026-04-03 00:00:00",
     "start": "2026-04-02T22:00:00.000Z",
     "end": "2026-04-03T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2026-04-05 00:00:00",
     "start": "2026-04-04T22:00:00.000Z",
     "end": "2026-04-05T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-05T22:00:00.000Z",
     "end": "2026-04-06T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -111,7 +111,7 @@
     "date": "2026-05-14 00:00:00",
     "start": "2026-05-13T22:00:00.000Z",
     "end": "2026-05-14T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2026-05-24 00:00:00",
     "start": "2026-05-23T22:00:00.000Z",
     "end": "2026-05-24T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2026-06-06 00:00:00",
     "start": "2026-06-05T22:00:00.000Z",
     "end": "2026-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Sat"
@@ -192,7 +192,7 @@
     "date": "2026-10-31 00:00:00",
     "start": "2026-10-30T23:00:00.000Z",
     "end": "2026-10-31T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -255,7 +255,7 @@
     "date": "2026-12-26 00:00:00",
     "start": "2026-12-25T23:00:00.000Z",
     "end": "2026-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2027.json
+++ b/test/fixtures/SE-2027.json
@@ -3,7 +3,7 @@
     "date": "2027-01-01 00:00:00",
     "start": "2026-12-31T23:00:00.000Z",
     "end": "2027-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -21,7 +21,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -57,7 +57,7 @@
     "date": "2027-03-26 00:00:00",
     "start": "2027-03-25T23:00:00.000Z",
     "end": "2027-03-26T23:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2027-03-28 00:00:00",
     "start": "2027-03-27T23:00:00.000Z",
     "end": "2027-03-28T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-28T22:00:00.000Z",
     "end": "2027-03-29T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -111,7 +111,7 @@
     "date": "2027-05-06 00:00:00",
     "start": "2027-05-05T22:00:00.000Z",
     "end": "2027-05-06T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2027-05-16 00:00:00",
     "start": "2027-05-15T22:00:00.000Z",
     "end": "2027-05-16T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2027-06-06 00:00:00",
     "start": "2027-06-05T22:00:00.000Z",
     "end": "2027-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Sun"
@@ -192,7 +192,7 @@
     "date": "2027-11-06 00:00:00",
     "start": "2027-11-05T23:00:00.000Z",
     "end": "2027-11-06T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
@@ -255,7 +255,7 @@
     "date": "2027-12-26 00:00:00",
     "start": "2027-12-25T23:00:00.000Z",
     "end": "2027-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"

--- a/test/fixtures/SE-2028.json
+++ b/test/fixtures/SE-2028.json
@@ -3,7 +3,7 @@
     "date": "2028-01-01 00:00:00",
     "start": "2027-12-31T23:00:00.000Z",
     "end": "2028-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"
@@ -21,7 +21,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -57,7 +57,7 @@
     "date": "2028-04-14 00:00:00",
     "start": "2028-04-13T22:00:00.000Z",
     "end": "2028-04-14T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2028-04-16 00:00:00",
     "start": "2028-04-15T22:00:00.000Z",
     "end": "2028-04-16T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T22:00:00.000Z",
     "end": "2028-04-17T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2028-05-25 00:00:00",
     "start": "2028-05-24T22:00:00.000Z",
     "end": "2028-05-25T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2028-06-04 00:00:00",
     "start": "2028-06-03T22:00:00.000Z",
     "end": "2028-06-04T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2028-06-06 00:00:00",
     "start": "2028-06-05T22:00:00.000Z",
     "end": "2028-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Tue"
@@ -192,7 +192,7 @@
     "date": "2028-11-04 00:00:00",
     "start": "2028-11-03T23:00:00.000Z",
     "end": "2028-11-04T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -255,7 +255,7 @@
     "date": "2028-12-26 00:00:00",
     "start": "2028-12-25T23:00:00.000Z",
     "end": "2028-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/SE-2029.json
+++ b/test/fixtures/SE-2029.json
@@ -3,7 +3,7 @@
     "date": "2029-01-01 00:00:00",
     "start": "2028-12-31T23:00:00.000Z",
     "end": "2029-01-01T23:00:00.000Z",
-    "name": "Nyårsdagen",
+    "name": "nyårsdagen",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -21,7 +21,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Trettondedag jul",
+    "name": "trettondedag jul",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -57,7 +57,7 @@
     "date": "2029-03-30 00:00:00",
     "start": "2029-03-29T22:00:00.000Z",
     "end": "2029-03-30T22:00:00.000Z",
-    "name": "Långfredagen",
+    "name": "långfredagen",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2029-04-01 00:00:00",
     "start": "2029-03-31T22:00:00.000Z",
     "end": "2029-04-01T22:00:00.000Z",
-    "name": "Påskdagen",
+    "name": "påskdagen",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-01T22:00:00.000Z",
     "end": "2029-04-02T22:00:00.000Z",
-    "name": "Annandag påsk",
+    "name": "annandag påsk",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Första Maj",
+    "name": "första maj",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -111,7 +111,7 @@
     "date": "2029-05-10 00:00:00",
     "start": "2029-05-09T22:00:00.000Z",
     "end": "2029-05-10T22:00:00.000Z",
-    "name": "Kristi himmelfärdsdag",
+    "name": "Kristi himmelsfärdsdag",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2029-05-20 00:00:00",
     "start": "2029-05-19T22:00:00.000Z",
     "end": "2029-05-20T22:00:00.000Z",
-    "name": "Pingstdagen",
+    "name": "pingstdagen",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2029-06-06 00:00:00",
     "start": "2029-06-05T22:00:00.000Z",
     "end": "2029-06-06T22:00:00.000Z",
-    "name": "Sveriges nationaldag",
+    "name": "nationaldagen",
     "type": "public",
     "rule": "06-06 since 2005",
     "_weekday": "Wed"
@@ -192,7 +192,7 @@
     "date": "2029-11-03 00:00:00",
     "start": "2029-11-02T23:00:00.000Z",
     "end": "2029-11-03T23:00:00.000Z",
-    "name": "Alla Helgons dag",
+    "name": "alla helgons dag",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -246,7 +246,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Juldagen",
+    "name": "juldagen",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
@@ -255,7 +255,7 @@
     "date": "2029-12-26 00:00:00",
     "start": "2029-12-25T23:00:00.000Z",
     "end": "2029-12-26T23:00:00.000Z",
-    "name": "Annandag jul",
+    "name": "annandag jul",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"


### PR DESCRIPTION
I noticed a few differences in the Swedish holiday data, so I did some primary-source checking and adjusted the confirmed cases.

**Source:**  [Lag (1989:253) om allmänna helgdagar](https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-1989253-om-allmanna-helgdagar_sfs-1989-253/)