### PR TITLE
Victoria, Australia school holidays

### DIFF
--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -311,6 +311,7 @@ holidays:
           1st tuesday in November:
             name:
               en: Melbourne Cup
+		  # @source https://www.vic.gov.au/school-term-dates-and-holidays-victoria
           "2026-04-03 P17D":
             name:
               en: Term 1 holidays

--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -311,6 +311,30 @@ holidays:
           1st tuesday in November:
             name:
               en: Melbourne Cup
+          "2026-04-03 P17D":
+            name:
+              en: Term 1 holidays
+            active:
+              - from: "2026-01-01"
+            type: school
+          "2026-06-27 P17D":
+            name:
+              en: Term 2 holidays
+            active:
+              - from: "2026-01-01"
+            type: school
+          "2026-09-19 P17D":
+            name:
+              en: Term 3 holidays
+            active:
+              - from: "2026-01-01"
+            type: school
+          "2026-12-19 P40D":
+            name:
+              en: Term 4 holidays
+            active:
+              - from: "2026-01-01"
+            type: school
       # @source https://www.legislation.wa.gov.au/legislation/statutes.nsf/law_a639.html
       # @source https://www.legislation.wa.gov.au/legislation/statutes.nsf/law_a147326.html
       WA:

--- a/data/countries/AU.yaml
+++ b/data/countries/AU.yaml
@@ -311,7 +311,7 @@ holidays:
           1st tuesday in November:
             name:
               en: Melbourne Cup
-		  # @source https://www.vic.gov.au/school-term-dates-and-holidays-victoria
+          # @source https://www.vic.gov.au/school-term-dates-and-holidays-victoria
           "2026-04-03 P17D":
             name:
               en: Term 1 holidays

--- a/test/fixtures/AU-VIC-2026.json
+++ b/test/fixtures/AU-VIC-2026.json
@@ -36,6 +36,15 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2026-04-03 00:00:00",
+    "start": "2026-04-02T13:00:00.000Z",
+    "end": "2026-04-19T14:00:00.000Z",
+    "name": "Term 1 holidays",
+    "type": "school",
+    "rule": "2026-04-03 P17D",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2026-04-04 00:00:00",
     "start": "2026-04-03T13:00:00.000Z",
     "end": "2026-04-04T13:00:00.000Z",
@@ -90,6 +99,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2026-06-27 00:00:00",
+    "start": "2026-06-26T14:00:00.000Z",
+    "end": "2026-07-13T14:00:00.000Z",
+    "name": "Term 2 holidays",
+    "type": "school",
+    "rule": "2026-06-27 P17D",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2026-09-06 00:00:00",
     "start": "2026-09-05T14:00:00.000Z",
     "end": "2026-09-06T14:00:00.000Z",
@@ -97,6 +115,15 @@
     "type": "observance",
     "rule": "1st sunday in September",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2026-09-19 00:00:00",
+    "start": "2026-09-18T14:00:00.000Z",
+    "end": "2026-10-05T13:00:00.000Z",
+    "name": "Term 3 holidays",
+    "type": "school",
+    "rule": "2026-09-19 P17D",
+    "_weekday": "Sat"
   },
   {
     "date": "2026-09-25 00:00:00",
@@ -116,6 +143,15 @@
     "type": "public",
     "rule": "1st tuesday in November",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2026-12-19 00:00:00",
+    "start": "2026-12-18T13:00:00.000Z",
+    "end": "2027-01-27T13:00:00.000Z",
+    "name": "Term 4 holidays",
+    "type": "school",
+    "rule": "2026-12-19 P40D",
+    "_weekday": "Sat"
   },
   {
     "date": "2026-12-25 00:00:00",


### PR DESCRIPTION
Adding Victorian school holidays.
Note: For 2026 only