### PR TITLE
feat(US): add Frances Xavier Cabrini Day for Colorado

### DIFF
--- a/data/countries/US.yaml
+++ b/data/countries/US.yaml
@@ -260,6 +260,12 @@ holidays:
           3rd monday in February:
             name:
               en: Washington-Lincoln Day
+          1st monday in October:
+            name:
+              en: Frances Xavier Cabrini Day
+            active:
+              - from: "2020-01-01"
+            # @source HB20-1031 (2020) https://leg.colorado.gov/bills/hb20-1031
           2nd monday in October:
             type: observance
       CT:

--- a/test/fixtures/US-CO-2020.json
+++ b/test/fixtures/US-CO-2020.json
@@ -127,6 +127,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2020-10-05 00:00:00",
+    "start": "2020-10-05T06:00:00.000Z",
+    "end": "2020-10-06T06:00:00.000Z",
+    "name": "Frances Xavier Cabrini Day",
+    "type": "public",
+    "rule": "1st monday in October",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2020-10-12 00:00:00",
     "start": "2020-10-12T06:00:00.000Z",
     "end": "2020-10-13T06:00:00.000Z",

--- a/test/fixtures/US-CO-2021.json
+++ b/test/fixtures/US-CO-2021.json
@@ -146,6 +146,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2021-10-04 00:00:00",
+    "start": "2021-10-04T06:00:00.000Z",
+    "end": "2021-10-05T06:00:00.000Z",
+    "name": "Frances Xavier Cabrini Day",
+    "type": "public",
+    "rule": "1st monday in October",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-10-11 00:00:00",
     "start": "2021-10-11T06:00:00.000Z",
     "end": "2021-10-12T06:00:00.000Z",

--- a/test/fixtures/US-CO-2022.json
+++ b/test/fixtures/US-CO-2022.json
@@ -136,6 +136,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2022-10-03 00:00:00",
+    "start": "2022-10-03T06:00:00.000Z",
+    "end": "2022-10-04T06:00:00.000Z",
+    "name": "Frances Xavier Cabrini Day",
+    "type": "public",
+    "rule": "1st monday in October",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-10-10 00:00:00",
     "start": "2022-10-10T06:00:00.000Z",
     "end": "2022-10-11T06:00:00.000Z",

--- a/test/fixtures/US-CO-2023.json
+++ b/test/fixtures/US-CO-2023.json
@@ -136,6 +136,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2023-10-02 00:00:00",
+    "start": "2023-10-02T06:00:00.000Z",
+    "end": "2023-10-03T06:00:00.000Z",
+    "name": "Frances Xavier Cabrini Day",
+    "type": "public",
+    "rule": "1st monday in October",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-10-09 00:00:00",
     "start": "2023-10-09T06:00:00.000Z",
     "end": "2023-10-10T06:00:00.000Z",

--- a/test/fixtures/US-CO-2024.json
+++ b/test/fixtures/US-CO-2024.json
@@ -126,6 +126,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2024-10-07 00:00:00",
+    "start": "2024-10-07T06:00:00.000Z",
+    "end": "2024-10-08T06:00:00.000Z",
+    "name": "Frances Xavier Cabrini Day",
+    "type": "public",
+    "rule": "1st monday in October",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-10-14 00:00:00",
     "start": "2024-10-14T06:00:00.000Z",
     "end": "2024-10-15T06:00:00.000Z",

--- a/test/fixtures/US-CO-2025.json
+++ b/test/fixtures/US-CO-2025.json
@@ -126,6 +126,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-10-06 00:00:00",
+    "start": "2025-10-06T06:00:00.000Z",
+    "end": "2025-10-07T06:00:00.000Z",
+    "name": "Frances Xavier Cabrini Day",
+    "type": "public",
+    "rule": "1st monday in October",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2025-10-13 00:00:00",
     "start": "2025-10-13T06:00:00.000Z",
     "end": "2025-10-14T06:00:00.000Z",

--- a/test/fixtures/US-CO-2026.json
+++ b/test/fixtures/US-CO-2026.json
@@ -136,6 +136,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2026-10-05 00:00:00",
+    "start": "2026-10-05T06:00:00.000Z",
+    "end": "2026-10-06T06:00:00.000Z",
+    "name": "Frances Xavier Cabrini Day",
+    "type": "public",
+    "rule": "1st monday in October",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-10-12 00:00:00",
     "start": "2026-10-12T06:00:00.000Z",
     "end": "2026-10-13T06:00:00.000Z",

--- a/test/fixtures/US-CO-2027.json
+++ b/test/fixtures/US-CO-2027.json
@@ -146,6 +146,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2027-10-04 00:00:00",
+    "start": "2027-10-04T06:00:00.000Z",
+    "end": "2027-10-05T06:00:00.000Z",
+    "name": "Frances Xavier Cabrini Day",
+    "type": "public",
+    "rule": "1st monday in October",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-10-11 00:00:00",
     "start": "2027-10-11T06:00:00.000Z",
     "end": "2027-10-12T06:00:00.000Z",

--- a/test/fixtures/US-CO-2028.json
+++ b/test/fixtures/US-CO-2028.json
@@ -126,6 +126,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2028-10-02 00:00:00",
+    "start": "2028-10-02T06:00:00.000Z",
+    "end": "2028-10-03T06:00:00.000Z",
+    "name": "Frances Xavier Cabrini Day",
+    "type": "public",
+    "rule": "1st monday in October",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2028-10-09 00:00:00",
     "start": "2028-10-09T06:00:00.000Z",
     "end": "2028-10-10T06:00:00.000Z",

--- a/test/fixtures/US-CO-2029.json
+++ b/test/fixtures/US-CO-2029.json
@@ -126,6 +126,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2029-10-01 00:00:00",
+    "start": "2029-10-01T06:00:00.000Z",
+    "end": "2029-10-02T06:00:00.000Z",
+    "name": "Frances Xavier Cabrini Day",
+    "type": "public",
+    "rule": "1st monday in October",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2029-10-08 00:00:00",
     "start": "2029-10-08T06:00:00.000Z",
     "end": "2029-10-09T06:00:00.000Z",


### PR DESCRIPTION
## Summary
- Add "1st Monday in October" as Frances Xavier Cabrini Day for Colorado (CO), effective from 2020 per HB20-1031, which replaced Columbus Day as the state holiday.
- Existing Columbus Day observance handling for CO is left unchanged (out of scope).

## Test plan
- [x] `npm run build`
- [x] `npm test` (regenerated `test/fixtures/US-CO-2020..2029.json`, full suite passing)
- [x] Verified via `test/sample.js "us.co"`: 2020-10-05, 2024-10-07 present as Cabrini Day; absent in 2019

Closes #486