### PR TITLE
feat(KR): add substitute holiday (대체공휴일) support

### DIFF
--- a/data/countries/KR.yaml
+++ b/data/countries/KR.yaml
@@ -21,14 +21,35 @@ holidays:
         name:
           en: Independence Movement Day
           ko: 3·1절
+      substitutes 03-01 if Saturday,Sunday then next Monday:
+        substitute: true
+        name:
+          en: Independence Movement Day
+          ko: 3·1절
+        active:
+          - from: "2021-01-01"
       05-05:
         name:
           en: Children's Day
           ko: 어린이날
+      substitutes 05-05 if Saturday,Sunday then next Monday:
+        substitute: true
+        name:
+          en: Children's Day
+          ko: 어린이날
+        active:
+          - from: "2014-01-01"
       korean 4-0-8:
         name:
           en: Buddha's Birthday
           ko: 석가탄신일
+      substitutes korean 4-0-8 if Saturday,Sunday then next Monday:
+        substitute: true
+        name:
+          en: Buddha's Birthday
+          ko: 석가탄신일
+        active:
+          - from: "2023-01-01"
       06-06:
         name:
           en: Memorial Day
@@ -43,10 +64,24 @@ holidays:
         name:
           en: Constitution Day
           ko: 제헌절
+      substitutes 07-17 if Saturday,Sunday then next Monday:
+        substitute: true
+        name:
+          en: Constitution Day
+          ko: 제헌절
+        active:
+          - from: "2026-01-01"
       08-15:
         name:
           en: Liberation Day
           ko: 광복절
+      substitutes 08-15 if Saturday,Sunday then next Monday:
+        substitute: true
+        name:
+          en: Liberation Day
+          ko: 광복절
+        active:
+          - from: "2021-01-01"
       korean 8-0-14 P3D:
         name:
           en: Korean Thanksgiving
@@ -55,12 +90,261 @@ holidays:
         name:
           en: National Foundation Day
           ko: 개천절
+      substitutes 10-03 if Saturday,Sunday then next Monday:
+        substitute: true
+        name:
+          en: National Foundation Day
+          ko: 개천절
+        active:
+          - from: "2021-01-01"
       10-09:
         name:
           en: Hangul Day
           ko: 한글날
+      substitutes 10-09 if Saturday,Sunday then next Monday:
+        substitute: true
+        name:
+          en: Hangul Day
+          ko: 한글날
+        active:
+          - from: "2021-01-01"
       12-25:
         _name: 12-25
+      substitutes 12-25 if Saturday,Sunday then next Monday:
+        _name: 12-25
+        substitute: true
+        active:
+          - from: "2023-01-01"
+      # Seollal substitute holidays (Sunday overlap, or overlap with another public
+      # holiday on a weekday) can't use the generic weekend-substitute pattern above:
+      # the underlying `korean 01-0-01 P3D` 3-day span is anchored at 당일 (1st lunar
+      # day) instead of 전날, so it omits 전날 and includes an extra day past 다음날 --
+      # a rule keyed off that span would trigger on the wrong day. Anchored here at the
+      # real (corrected) 전날/당일/다음날 dates instead, computed per year. Chuseok is
+      # anchored correctly already (`korean 8-0-14` = the day before Chuseok) but still
+      # needs explicit entries below for the rare cases where it overlaps another
+      # holiday. Covers 2014-2050; needs extending past that.
+      # @source https://github.com/commenthol/date-holidays/issues/640
+      "substitutes 2014-09-07 if Sunday then next Wednesday": # -> 2014-09-10
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2015-09-27 if Sunday then next Tuesday": # -> 2015-09-29
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2016-02-07 if Sunday then next Wednesday": # -> 2016-02-10
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2017-01-29 if Sunday then next Monday": # -> 2017-01-30
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2017-10-03 if Tuesday then next Friday": # -> 2017-10-06
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2018-09-23 if Sunday then next Wednesday": # -> 2018-09-26
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2020-01-26 if Sunday then next Monday": # -> 2020-01-27
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2022-09-11 if Sunday then next Monday": # -> 2022-09-12
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2023-01-22 if Sunday then next Tuesday": # -> 2023-01-24
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2024-02-11 if Sunday then next Monday": # -> 2024-02-12
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2025-05-05 if Monday then next Tuesday": # -> 2025-05-06
+        substitute: true
+        name:
+          en: Children's Day
+          ko: 어린이날
+      "substitutes 2025-05-05 if Monday then next Tuesday #1": # -> 2025-05-06
+        substitute: true
+        name:
+          en: Buddha's Birthday
+          ko: 석가탄신일
+      "substitutes 2025-10-05 if Sunday then next Wednesday": # -> 2025-10-08
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2027-02-07 if Sunday then next Tuesday": # -> 2027-02-09
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2028-10-03 if Tuesday then next Thursday": # -> 2028-10-05
+        substitute: true
+        name:
+          en: National Foundation Day
+          ko: 개천절
+      "substitutes 2028-10-03 if Tuesday then next Thursday #1": # -> 2028-10-05
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2029-09-23 if Sunday then next Monday": # -> 2029-09-24
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2030-02-03 if Sunday then next Tuesday": # -> 2030-02-05
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2032-09-19 if Sunday then next Tuesday": # -> 2032-09-21
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2033-01-30 if Sunday then next Wednesday": # -> 2033-02-02
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2034-02-19 if Sunday then next Tuesday": # -> 2034-02-21
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2035-09-16 if Sunday then next Tuesday": # -> 2035-09-18
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2036-01-27 if Sunday then next Wednesday": # -> 2036-01-30
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2036-10-03 if Friday then next Monday": # -> 2036-10-06
+        substitute: true
+        name:
+          en: National Foundation Day
+          ko: 개천절
+      "substitutes 2036-10-03 if Friday then next Monday #1": # -> 2036-10-06
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2036-10-05 if Sunday then next Tuesday": # -> 2036-10-07
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2037-02-15 if Sunday then next Tuesday": # -> 2037-02-17
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2038-09-12 if Sunday then next Wednesday": # -> 2038-09-15
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2039-01-23 if Sunday then next Wednesday": # -> 2039-01-26
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2039-10-02 if Sunday then next Tuesday": # -> 2039-10-04
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2039-10-03 if Monday then next Wednesday": # -> 2039-10-05
+        substitute: true
+        name:
+          en: National Foundation Day
+          ko: 개천절
+      "substitutes 2039-10-03 if Monday then next Wednesday #1": # -> 2039-10-05
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2040-02-12 if Sunday then next Tuesday": # -> 2040-02-14
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2042-09-28 if Sunday then next Tuesday": # -> 2042-09-30
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2044-01-31 if Sunday then next Monday": # -> 2044-02-01
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2044-05-05 if Thursday then next Friday": # -> 2044-05-06
+        substitute: true
+        name:
+          en: Children's Day
+          ko: 어린이날
+      "substitutes 2044-05-05 if Thursday then next Friday #1": # -> 2044-05-06
+        substitute: true
+        name:
+          en: Buddha's Birthday
+          ko: 석가탄신일
+      "substitutes 2045-09-24 if Sunday then next Wednesday": # -> 2045-09-27
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2046-09-16 if Sunday then next Monday": # -> 2046-09-17
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2047-01-27 if Sunday then next Monday": # -> 2047-01-28
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
+      "substitutes 2047-10-03 if Thursday then next Monday": # -> 2047-10-07
+        substitute: true
+        name:
+          en: National Foundation Day
+          ko: 개천절
+      "substitutes 2047-10-03 if Thursday then next Monday #1": # -> 2047-10-07
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2049-09-12 if Sunday then next Monday": # -> 2049-09-13
+        substitute: true
+        name:
+          en: Korean Thanksgiving
+          ko: 추석
+      "substitutes 2050-01-23 if Sunday then next Tuesday": # -> 2050-01-25
+        substitute: true
+        name:
+          en: Korean New Year
+          ko: 설날
     # states:
     #   11:
     #     name: Seoul

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -1169,6 +1169,7 @@ names:
       fr: jour substitut
       hr: zamjena dan
       jp: 振替休日
+      ko: 대체공휴일
       lv: aizstājējs diena
       mk: заменет ден
       nl: substituut

--- a/test/fixtures/KR-2015.json
+++ b/test/fixtures/KR-2015.json
@@ -81,6 +81,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2015-09-29 00:00:00",
+    "start": "2015-09-28T15:00:00.000Z",
+    "end": "2015-09-29T15:00:00.000Z",
+    "name": "추석 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2015-09-27 if Sunday then next Tuesday",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2015-10-03 00:00:00",
     "start": "2015-10-02T15:00:00.000Z",
     "end": "2015-10-03T15:00:00.000Z",

--- a/test/fixtures/KR-2016.json
+++ b/test/fixtures/KR-2016.json
@@ -18,6 +18,16 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2016-02-10 00:00:00",
+    "start": "2016-02-09T15:00:00.000Z",
+    "end": "2016-02-10T15:00:00.000Z",
+    "name": "설날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2016-02-07 if Sunday then next Wednesday",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2016-03-01 00:00:00",
     "start": "2016-02-29T15:00:00.000Z",
     "end": "2016-03-01T15:00:00.000Z",

--- a/test/fixtures/KR-2017.json
+++ b/test/fixtures/KR-2017.json
@@ -18,6 +18,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2017-01-30 00:00:00",
+    "start": "2017-01-29T15:00:00.000Z",
+    "end": "2017-01-30T15:00:00.000Z",
+    "name": "설날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2017-01-29 if Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2017-03-01 00:00:00",
     "start": "2017-02-28T15:00:00.000Z",
     "end": "2017-03-01T15:00:00.000Z",
@@ -88,6 +98,16 @@
     "type": "public",
     "rule": "korean 8-0-14 P3D",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2017-10-06 00:00:00",
+    "start": "2017-10-05T15:00:00.000Z",
+    "end": "2017-10-06T15:00:00.000Z",
+    "name": "추석 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2017-10-03 if Tuesday then next Friday",
+    "_weekday": "Fri"
   },
   {
     "date": "2017-10-09 00:00:00",

--- a/test/fixtures/KR-2018.json
+++ b/test/fixtures/KR-2018.json
@@ -36,6 +36,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2018-05-07 00:00:00",
+    "start": "2018-05-06T15:00:00.000Z",
+    "end": "2018-05-07T15:00:00.000Z",
+    "name": "어린이날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 05-05 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2018-05-22 00:00:00",
     "start": "2018-05-21T15:00:00.000Z",
     "end": "2018-05-22T15:00:00.000Z",
@@ -79,6 +89,16 @@
     "type": "public",
     "rule": "korean 8-0-14 P3D",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2018-09-26 00:00:00",
+    "start": "2018-09-25T15:00:00.000Z",
+    "end": "2018-09-26T15:00:00.000Z",
+    "name": "추석 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2018-09-23 if Sunday then next Wednesday",
+    "_weekday": "Wed"
   },
   {
     "date": "2018-10-03 00:00:00",

--- a/test/fixtures/KR-2019.json
+++ b/test/fixtures/KR-2019.json
@@ -36,6 +36,16 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2019-05-06 00:00:00",
+    "start": "2019-05-05T15:00:00.000Z",
+    "end": "2019-05-06T15:00:00.000Z",
+    "name": "어린이날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 05-05 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2019-05-12 00:00:00",
     "start": "2019-05-11T15:00:00.000Z",
     "end": "2019-05-12T15:00:00.000Z",

--- a/test/fixtures/KR-2020.json
+++ b/test/fixtures/KR-2020.json
@@ -18,6 +18,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2020-01-27 00:00:00",
+    "start": "2020-01-26T15:00:00.000Z",
+    "end": "2020-01-27T15:00:00.000Z",
+    "name": "설날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2020-01-26 if Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2020-03-01 00:00:00",
     "start": "2020-02-29T15:00:00.000Z",
     "end": "2020-03-01T15:00:00.000Z",

--- a/test/fixtures/KR-2021.json
+++ b/test/fixtures/KR-2021.json
@@ -72,6 +72,16 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-08-16 00:00:00",
+    "start": "2021-08-15T15:00:00.000Z",
+    "end": "2021-08-16T15:00:00.000Z",
+    "name": "광복절 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 08-15 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-09-20 00:00:00",
     "start": "2021-09-19T15:00:00.000Z",
     "end": "2021-09-22T15:00:00.000Z",
@@ -90,6 +100,16 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2021-10-04 00:00:00",
+    "start": "2021-10-03T15:00:00.000Z",
+    "end": "2021-10-04T15:00:00.000Z",
+    "name": "개천절 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 10-03 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2021-10-09 00:00:00",
     "start": "2021-10-08T15:00:00.000Z",
     "end": "2021-10-09T15:00:00.000Z",
@@ -97,6 +117,16 @@
     "type": "public",
     "rule": "10-09",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2021-10-11 00:00:00",
+    "start": "2021-10-10T15:00:00.000Z",
+    "end": "2021-10-11T15:00:00.000Z",
+    "name": "한글날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 10-09 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2021-12-25 00:00:00",

--- a/test/fixtures/KR-2022.json
+++ b/test/fixtures/KR-2022.json
@@ -81,6 +81,16 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-09-12 00:00:00",
+    "start": "2022-09-11T15:00:00.000Z",
+    "end": "2022-09-12T15:00:00.000Z",
+    "name": "추석 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2022-09-11 if Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2022-10-03 00:00:00",
     "start": "2022-10-02T15:00:00.000Z",
     "end": "2022-10-03T15:00:00.000Z",
@@ -97,6 +107,16 @@
     "type": "public",
     "rule": "10-09",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2022-10-10 00:00:00",
+    "start": "2022-10-09T15:00:00.000Z",
+    "end": "2022-10-10T15:00:00.000Z",
+    "name": "한글날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 10-09 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2022-12-25 00:00:00",

--- a/test/fixtures/KR-2023.json
+++ b/test/fixtures/KR-2023.json
@@ -18,6 +18,16 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2023-01-24 00:00:00",
+    "start": "2023-01-23T15:00:00.000Z",
+    "end": "2023-01-24T15:00:00.000Z",
+    "name": "설날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2023-01-22 if Sunday then next Tuesday",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2023-03-01 00:00:00",
     "start": "2023-02-28T15:00:00.000Z",
     "end": "2023-03-01T15:00:00.000Z",
@@ -43,6 +53,16 @@
     "type": "public",
     "rule": "korean 4-0-8",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2023-05-29 00:00:00",
+    "start": "2023-05-28T15:00:00.000Z",
+    "end": "2023-05-29T15:00:00.000Z",
+    "name": "석가탄신일 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes korean 4-0-8 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2023-06-06 00:00:00",

--- a/test/fixtures/KR-2024.json
+++ b/test/fixtures/KR-2024.json
@@ -18,6 +18,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2024-02-12 00:00:00",
+    "start": "2024-02-11T15:00:00.000Z",
+    "end": "2024-02-12T15:00:00.000Z",
+    "name": "설날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2024-02-11 if Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2024-03-01 00:00:00",
     "start": "2024-02-29T15:00:00.000Z",
     "end": "2024-03-01T15:00:00.000Z",
@@ -34,6 +44,16 @@
     "type": "public",
     "rule": "05-05",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2024-05-06 00:00:00",
+    "start": "2024-05-05T15:00:00.000Z",
+    "end": "2024-05-06T15:00:00.000Z",
+    "name": "어린이날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 05-05 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2024-05-15 00:00:00",

--- a/test/fixtures/KR-2025.json
+++ b/test/fixtures/KR-2025.json
@@ -27,6 +27,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2025-03-03 00:00:00",
+    "start": "2025-03-02T15:00:00.000Z",
+    "end": "2025-03-03T15:00:00.000Z",
+    "name": "3·1절 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 03-01 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2025-05-05 00:00:00",
     "start": "2025-05-04T15:00:00.000Z",
     "end": "2025-05-05T15:00:00.000Z",
@@ -43,6 +53,26 @@
     "type": "public",
     "rule": "05-05",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2025-05-06 00:00:00",
+    "start": "2025-05-05T15:00:00.000Z",
+    "end": "2025-05-06T15:00:00.000Z",
+    "name": "석가탄신일 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2025-05-05 if Monday then next Tuesday #1",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-05-06 00:00:00",
+    "start": "2025-05-05T15:00:00.000Z",
+    "end": "2025-05-06T15:00:00.000Z",
+    "name": "어린이날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2025-05-05 if Monday then next Tuesday",
+    "_weekday": "Tue"
   },
   {
     "date": "2025-06-06 00:00:00",
@@ -88,6 +118,16 @@
     "type": "public",
     "rule": "korean 8-0-14 P3D",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2025-10-08 00:00:00",
+    "start": "2025-10-07T15:00:00.000Z",
+    "end": "2025-10-08T15:00:00.000Z",
+    "name": "추석 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2025-10-05 if Sunday then next Wednesday",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-10-09 00:00:00",

--- a/test/fixtures/KR-2026.json
+++ b/test/fixtures/KR-2026.json
@@ -27,6 +27,16 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2026-03-02 00:00:00",
+    "start": "2026-03-01T15:00:00.000Z",
+    "end": "2026-03-02T15:00:00.000Z",
+    "name": "3·1절 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 03-01 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-05-05 00:00:00",
     "start": "2026-05-04T15:00:00.000Z",
     "end": "2026-05-05T15:00:00.000Z",
@@ -43,6 +53,16 @@
     "type": "public",
     "rule": "korean 4-0-8",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2026-05-25 00:00:00",
+    "start": "2026-05-24T15:00:00.000Z",
+    "end": "2026-05-25T15:00:00.000Z",
+    "name": "석가탄신일 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes korean 4-0-8 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2026-06-06 00:00:00",
@@ -72,6 +92,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2026-08-17 00:00:00",
+    "start": "2026-08-16T15:00:00.000Z",
+    "end": "2026-08-17T15:00:00.000Z",
+    "name": "광복절 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 08-15 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2026-09-24 00:00:00",
     "start": "2026-09-23T15:00:00.000Z",
     "end": "2026-09-26T15:00:00.000Z",
@@ -88,6 +118,16 @@
     "type": "public",
     "rule": "10-03",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2026-10-05 00:00:00",
+    "start": "2026-10-04T15:00:00.000Z",
+    "end": "2026-10-05T15:00:00.000Z",
+    "name": "개천절 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 10-03 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2026-10-09 00:00:00",

--- a/test/fixtures/KR-2027.json
+++ b/test/fixtures/KR-2027.json
@@ -18,6 +18,16 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2027-02-09 00:00:00",
+    "start": "2027-02-08T15:00:00.000Z",
+    "end": "2027-02-09T15:00:00.000Z",
+    "name": "설날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2027-02-07 if Sunday then next Tuesday",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2027-03-01 00:00:00",
     "start": "2027-02-28T15:00:00.000Z",
     "end": "2027-03-01T15:00:00.000Z",
@@ -63,6 +73,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2027-07-19 00:00:00",
+    "start": "2027-07-18T15:00:00.000Z",
+    "end": "2027-07-19T15:00:00.000Z",
+    "name": "제헌절 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 07-17 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T15:00:00.000Z",
     "end": "2027-08-15T15:00:00.000Z",
@@ -70,6 +90,16 @@
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2027-08-16 00:00:00",
+    "start": "2027-08-15T15:00:00.000Z",
+    "end": "2027-08-16T15:00:00.000Z",
+    "name": "광복절 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 08-15 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2027-09-14 00:00:00",
@@ -90,6 +120,16 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2027-10-04 00:00:00",
+    "start": "2027-10-03T15:00:00.000Z",
+    "end": "2027-10-04T15:00:00.000Z",
+    "name": "개천절 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 10-03 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-10-09 00:00:00",
     "start": "2027-10-08T15:00:00.000Z",
     "end": "2027-10-09T15:00:00.000Z",
@@ -99,6 +139,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2027-10-11 00:00:00",
+    "start": "2027-10-10T15:00:00.000Z",
+    "end": "2027-10-11T15:00:00.000Z",
+    "name": "한글날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 10-09 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T15:00:00.000Z",
     "end": "2027-12-25T15:00:00.000Z",
@@ -106,5 +156,15 @@
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-27 00:00:00",
+    "start": "2027-12-26T15:00:00.000Z",
+    "end": "2027-12-27T15:00:00.000Z",
+    "name": "기독탄신일 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 12-25 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/KR-2028.json
+++ b/test/fixtures/KR-2028.json
@@ -90,6 +90,26 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2028-10-05 00:00:00",
+    "start": "2028-10-04T15:00:00.000Z",
+    "end": "2028-10-05T15:00:00.000Z",
+    "name": "개천절 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2028-10-03 if Tuesday then next Thursday",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2028-10-05 00:00:00",
+    "start": "2028-10-04T15:00:00.000Z",
+    "end": "2028-10-05T15:00:00.000Z",
+    "name": "추석 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2028-10-03 if Tuesday then next Thursday #1",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2028-10-09 00:00:00",
     "start": "2028-10-08T15:00:00.000Z",
     "end": "2028-10-09T15:00:00.000Z",

--- a/test/fixtures/KR-2029.json
+++ b/test/fixtures/KR-2029.json
@@ -36,6 +36,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2029-05-07 00:00:00",
+    "start": "2029-05-06T15:00:00.000Z",
+    "end": "2029-05-07T15:00:00.000Z",
+    "name": "어린이날 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 05-05 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2029-05-20 00:00:00",
     "start": "2029-05-19T15:00:00.000Z",
     "end": "2029-05-20T15:00:00.000Z",
@@ -43,6 +53,16 @@
     "type": "public",
     "rule": "korean 4-0-8",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2029-05-21 00:00:00",
+    "start": "2029-05-20T15:00:00.000Z",
+    "end": "2029-05-21T15:00:00.000Z",
+    "name": "석가탄신일 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes korean 4-0-8 if Saturday,Sunday then next Monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2029-06-06 00:00:00",
@@ -79,6 +99,16 @@
     "type": "public",
     "rule": "korean 8-0-14 P3D",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2029-09-24 00:00:00",
+    "start": "2029-09-23T15:00:00.000Z",
+    "end": "2029-09-24T15:00:00.000Z",
+    "name": "추석 (대체공휴일)",
+    "type": "public",
+    "substitute": true,
+    "rule": "substitutes 2029-09-23 if Sunday then next Monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2029-10-03 00:00:00",


### PR DESCRIPTION
## Summary
- Add substitute-day (대체공휴일) rules for Korea: Children's Day, Independence Movement Day, Liberation Day, National Foundation Day, Hangul Day, Buddha's Birthday, Christmas Day and Constitution Day, each active from the year its substitute rule took legal effect (2014 / 2021 / 2023 / 2026 depending on the holiday).
- Seollal and Chuseok get explicit dated entries instead of a generic rule: their 3-day block can be pushed by either a Sunday overlap or an overlap with another public holiday (e.g. Chuseok colliding with National Foundation Day), and the existing `korean 01-0-01 P3D` rule for Seollal is anchored one day later than the real 전날/당일/다음날 window, so a rule computed against it directly would land on the wrong date. Entries are computed from the corrected window and cover 2014-2050 (see comment in the yaml for details/limitations).
- Verified against known real-world substitute dates, e.g. 2018 (no Seollal substitute), 2024-02-12 (Seollal), 2025-05-06 (Children's Day/Buddha's Birthday collision), 2017-10-06 (Chuseok/National Foundation Day collision).

## Test plan
- [x] `npm run build`
- [x] `npm test` (regenerated `test/fixtures/KR-*.json`, full suite passing: 5373 tests)
- [x] Cross-checked computed substitute dates for 2014-2050 against public sources for several representative years

Closes #640