### PR TITLE
chore: centralize Greek and English name for 03-25

### DIFF
--- a/data/countries/CY.yaml
+++ b/data/countries/CY.yaml
@@ -24,9 +24,7 @@ holidays:
           el: Καθαρά Δευτέρα
           en: Clean Monday
       03-25:
-        name:
-          el: Ευαγγελισμός, Εθνική Εορτή
-          en: Annunciation, Anniversary of 1821 Revolution
+        _name: 03-25
       04-01:
         name:
           en: Cyprus National Day

--- a/data/countries/GR.yaml
+++ b/data/countries/GR.yaml
@@ -19,9 +19,7 @@ holidays:
           el: Καθαρά Δευτέρα
           en: Ash Sunday
       03-25:
-        name:
-          el: Ευαγγελισμός, Εθνική Εορτή
-          en: Annunciation, Anniversary of 1821 Revolution
+        _name: 03-25
       orthodox -2:
         _name: easter -2
       orthodox:

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -148,6 +148,10 @@ names:
       mt: San Ġużepp
       nl: Hoogfeest van de Heilige Jozef
       vi: Kính Thánh Giuse
+  03-25:
+    name:
+      en: Annunciation, Anniversary of 1821 Revolution
+      el: Ευαγγελισμός, Εθνική Εορτή
   04-01:
     name:
       en: April Fools' Day


### PR DESCRIPTION
A nitpicky change to avoid duplicating the same holiday name in the Cyprus and Greece data.