### PR TITLE
fix(no): use consistent capitalization for Christmas holidays

### DIFF
--- a/data/names.yaml
+++ b/data/names.yaml
@@ -414,7 +414,7 @@ names:
       ms: Hari Krismas
       mt: Il-Milied
       nl: Kerstmis
-      no: Første Juledag
+      no: Første juledag
       pap: Dia Pasco di Nascimento
       pl: Pierwszy dzień Bożego Narodzenia
       pt: Natal

--- a/test/fixtures/NO-2015.json
+++ b/test/fixtures/NO-2015.json
@@ -309,7 +309,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/NO-2016.json
+++ b/test/fixtures/NO-2016.json
@@ -309,7 +309,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/NO-2017.json
+++ b/test/fixtures/NO-2017.json
@@ -309,7 +309,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/NO-2018.json
+++ b/test/fixtures/NO-2018.json
@@ -309,7 +309,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/NO-2019.json
+++ b/test/fixtures/NO-2019.json
@@ -309,7 +309,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/NO-2020.json
+++ b/test/fixtures/NO-2020.json
@@ -309,7 +309,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/NO-2021.json
+++ b/test/fixtures/NO-2021.json
@@ -309,7 +309,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/NO-2022.json
+++ b/test/fixtures/NO-2022.json
@@ -309,7 +309,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/NO-2023.json
+++ b/test/fixtures/NO-2023.json
@@ -309,7 +309,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/NO-2024.json
+++ b/test/fixtures/NO-2024.json
@@ -309,7 +309,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/NO-2025.json
+++ b/test/fixtures/NO-2025.json
@@ -309,7 +309,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/NO-2026.json
+++ b/test/fixtures/NO-2026.json
@@ -309,7 +309,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/NO-2027.json
+++ b/test/fixtures/NO-2027.json
@@ -309,7 +309,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/NO-2028.json
+++ b/test/fixtures/NO-2028.json
@@ -309,7 +309,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/NO-2029.json
+++ b/test/fixtures/NO-2029.json
@@ -309,7 +309,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/SJ-2015.json
+++ b/test/fixtures/SJ-2015.json
@@ -309,7 +309,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/SJ-2016.json
+++ b/test/fixtures/SJ-2016.json
@@ -309,7 +309,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/SJ-2017.json
+++ b/test/fixtures/SJ-2017.json
@@ -309,7 +309,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/SJ-2018.json
+++ b/test/fixtures/SJ-2018.json
@@ -309,7 +309,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/SJ-2019.json
+++ b/test/fixtures/SJ-2019.json
@@ -309,7 +309,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/SJ-2020.json
+++ b/test/fixtures/SJ-2020.json
@@ -309,7 +309,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/SJ-2021.json
+++ b/test/fixtures/SJ-2021.json
@@ -309,7 +309,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/SJ-2022.json
+++ b/test/fixtures/SJ-2022.json
@@ -309,7 +309,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/SJ-2023.json
+++ b/test/fixtures/SJ-2023.json
@@ -309,7 +309,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/SJ-2024.json
+++ b/test/fixtures/SJ-2024.json
@@ -309,7 +309,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/SJ-2025.json
+++ b/test/fixtures/SJ-2025.json
@@ -309,7 +309,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/SJ-2026.json
+++ b/test/fixtures/SJ-2026.json
@@ -309,7 +309,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/SJ-2027.json
+++ b/test/fixtures/SJ-2027.json
@@ -309,7 +309,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/SJ-2028.json
+++ b/test/fixtures/SJ-2028.json
@@ -309,7 +309,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/SJ-2029.json
+++ b/test/fixtures/SJ-2029.json
@@ -309,7 +309,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Første Juledag",
+    "name": "Første juledag",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"


### PR DESCRIPTION
This change the Norwegian translation from `Første Juledag` to `Første juledag` for consistency with `Andre juledag`. This also matches the spelling used by [Norwegian Wikipedia](https://no.wikipedia.org/wiki/F%C3%B8rste_juledag).