### PR TITLE
fix(fi): use official Finnish holiday names

### DIFF
--- a/data/countries/FI.yaml
+++ b/data/countries/FI.yaml
@@ -1,4 +1,5 @@
 holidays:
+  # @attrib https://almanakka.helsinki.fi/fi/liputus-ja-juhlapaivat/
   # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Finland
   FI:
     names:
@@ -31,15 +32,15 @@ holidays:
         type: observance
       friday after 06-19:
         name:
-          fi: Juhannusaatto
+          fi: juhannusaatto
           en: Midsummer Eve
-          sv: Midsommarafton
+          sv: midsommarafton
         type: bank
       saturday after 06-20:
         name:
-          fi: Juhannuspäivä
+          fi: juhannuspäivä
           en: Midsummer Day
-          sv: Midsommardagen
+          sv: midsommardagen
       saturday after 10-31:
         _name: 11-01
       2nd sunday in November:

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -24,7 +24,7 @@ names:
       el: Πρωτοχρονιά
       es: Año Nuevo
       et: uusaasta
-      fi: Uudenvuodenpäivä
+      fi: uudenvuodenpäivä
       fil: Araw ng Bagong Taon
       fo: Nýggjársdagur
       # fr: Jour de l'An
@@ -76,7 +76,7 @@ names:
       es: Día de los Reyes Magos
       # es: Epifanía del Señor
       et: kolmekuningapäev
-      fi: Loppiainen
+      fi: loppiainen
       fr: l'Épiphanie
       el: Θεοφάνεια
       hr: Bogojavljenje, Sveta tri kralja
@@ -171,7 +171,7 @@ names:
       el: Εργατική Πρωτομαγιά
       es: Día del Trabajador
       et: kevadpüha
-      fi: Vappu
+      fi: vappu
       fil: Araw ng mga Manggagawa
       fr: Fête du travail
       hr: Praznik rada
@@ -269,7 +269,7 @@ names:
       bs: Dita e të gjithë Shenjtorëve
       de: Allerheiligen
       es: Todos los Santos
-      fi: Pyhäinpäivä
+      fi: pyhäinpäivä
       fil: Undás; Todos los Santos; Araw ng mga Santo
       fr: Toussaint
       hr: Svi sveti
@@ -356,7 +356,7 @@ names:
       es: Nochebuena
       et: jõululaupäev
       fo: Jólaaftan
-      fi: Jouluaatto
+      fi: jouluaatto
       fil: Bisperas ng Pasko
       fr: Veille de Noël
       hr: Badnji dan
@@ -393,7 +393,7 @@ names:
       el: Χριστούγεννα
       es: Navidad
       et: esimene jõulupüha
-      fi: Joulupäivä
+      fi: joulupäivä
       fil: Araw ng Pasko
       fo: Fyrsti jóladagur
       fr: Noël
@@ -442,7 +442,7 @@ names:
       el: Δεύτερη μέρα των Χριστουγέννων
       es: San Esteban
       et: teine jõulupüha
-      fi: 2. joulupäivä
+      fi: tapaninpäivä
       fo: Fyrsti gerandisdagur eftir jóladag
       fr: Lendemain de Noël
       # fr: Saint Etienne
@@ -570,7 +570,7 @@ names:
       da: Langfredag
       de: Karfreitag
       es: Viernes Santo
-      fi: Pitkäperjantai
+      fi: pitkäperjantai
       fil: Biyernes Santo
       fo: Langafríggjadagur
       fr: Vendredi saint
@@ -632,7 +632,7 @@ names:
       el: Πάσχα
       es: Pascua
       et: lihavõtted
-      fi: Pääsiäispäivä
+      fi: pääsiäispäivä
       fil: Pasko ng Pagkabuhay
       fo: Páskadagur
       fr: Pâques
@@ -669,7 +669,7 @@ names:
       de: Ostermontag
       el: Δευτέρα του Πάσχα
       es: Lunes de Pascua
-      fi: 2. pääsiäispäivä
+      fi: toinen pääsiäispäivä
       fo: Annar páskadagur
       fr: Lundi de Pâques
       ge: აღდგომის ორშაბათი
@@ -701,7 +701,7 @@ names:
       da: Kristi Himmelfartsdag
       de: Christi Himmelfahrt
       es: La Asunción
-      fi: Helatorstai
+      fi: helatorstai
       fo: Kristi Himmalsferðardagur
       fr: Ascension
       id: Kenaikan Yesus Kristus
@@ -724,7 +724,7 @@ names:
       el: Πεντηκοστή
       es: Pentecostés
       et: nelipühade 1. püha
-      fi: Helluntaipäivä
+      fi: helluntaipäivä
       fo: Hvítusunnudagur
       fr: Pentecôte
       hu: Pünkösdvasárnap
@@ -1066,7 +1066,7 @@ names:
       de: Unabhängigkeitstag
       es: Día de la Independencia
       et: iseseisvuspäev
-      fi: Itsenäisyyspäivä
+      fi: itsenäisyyspäivä
       fil: Araw ng Kalayaan
       fr: Jour de l'Indépendance
       hr: Dan neovisnosti
@@ -1081,7 +1081,7 @@ names:
       ro: Ziua Independentei
       sq: Dita e Pavarësisë
       sr: Дан независности
-      sv: Självständighetsdagen
+      sv: självständighetsdagen
       sw: Siku ya uhuru
       ti: መዓልቲ ናጽነት
       uk: День Незалежності

--- a/test/fixtures/AX-2015.json
+++ b/test/fixtures/AX-2015.json
@@ -111,7 +111,7 @@
     "date": "2015-12-06 00:00:00",
     "start": "2015-12-05T22:00:00.000Z",
     "end": "2015-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Sun"

--- a/test/fixtures/AX-2016.json
+++ b/test/fixtures/AX-2016.json
@@ -111,7 +111,7 @@
     "date": "2016-12-06 00:00:00",
     "start": "2016-12-05T22:00:00.000Z",
     "end": "2016-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Tue"

--- a/test/fixtures/AX-2017.json
+++ b/test/fixtures/AX-2017.json
@@ -111,7 +111,7 @@
     "date": "2017-12-06 00:00:00",
     "start": "2017-12-05T22:00:00.000Z",
     "end": "2017-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Wed"

--- a/test/fixtures/AX-2018.json
+++ b/test/fixtures/AX-2018.json
@@ -111,7 +111,7 @@
     "date": "2018-12-06 00:00:00",
     "start": "2018-12-05T22:00:00.000Z",
     "end": "2018-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Thu"

--- a/test/fixtures/AX-2019.json
+++ b/test/fixtures/AX-2019.json
@@ -111,7 +111,7 @@
     "date": "2019-12-06 00:00:00",
     "start": "2019-12-05T22:00:00.000Z",
     "end": "2019-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Fri"

--- a/test/fixtures/AX-2020.json
+++ b/test/fixtures/AX-2020.json
@@ -111,7 +111,7 @@
     "date": "2020-12-06 00:00:00",
     "start": "2020-12-05T22:00:00.000Z",
     "end": "2020-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Sun"

--- a/test/fixtures/AX-2021.json
+++ b/test/fixtures/AX-2021.json
@@ -111,7 +111,7 @@
     "date": "2021-12-06 00:00:00",
     "start": "2021-12-05T22:00:00.000Z",
     "end": "2021-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Mon"

--- a/test/fixtures/AX-2022.json
+++ b/test/fixtures/AX-2022.json
@@ -111,7 +111,7 @@
     "date": "2022-12-06 00:00:00",
     "start": "2022-12-05T22:00:00.000Z",
     "end": "2022-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Tue"

--- a/test/fixtures/AX-2023.json
+++ b/test/fixtures/AX-2023.json
@@ -111,7 +111,7 @@
     "date": "2023-12-06 00:00:00",
     "start": "2023-12-05T22:00:00.000Z",
     "end": "2023-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Wed"

--- a/test/fixtures/AX-2024.json
+++ b/test/fixtures/AX-2024.json
@@ -111,7 +111,7 @@
     "date": "2024-12-06 00:00:00",
     "start": "2024-12-05T22:00:00.000Z",
     "end": "2024-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Fri"

--- a/test/fixtures/AX-2025.json
+++ b/test/fixtures/AX-2025.json
@@ -111,7 +111,7 @@
     "date": "2025-12-06 00:00:00",
     "start": "2025-12-05T22:00:00.000Z",
     "end": "2025-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2026.json
+++ b/test/fixtures/AX-2026.json
@@ -111,7 +111,7 @@
     "date": "2026-12-06 00:00:00",
     "start": "2026-12-05T22:00:00.000Z",
     "end": "2026-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Sun"

--- a/test/fixtures/AX-2027.json
+++ b/test/fixtures/AX-2027.json
@@ -111,7 +111,7 @@
     "date": "2027-12-06 00:00:00",
     "start": "2027-12-05T22:00:00.000Z",
     "end": "2027-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Mon"

--- a/test/fixtures/AX-2028.json
+++ b/test/fixtures/AX-2028.json
@@ -111,7 +111,7 @@
     "date": "2028-12-06 00:00:00",
     "start": "2028-12-05T22:00:00.000Z",
     "end": "2028-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Wed"

--- a/test/fixtures/AX-2029.json
+++ b/test/fixtures/AX-2029.json
@@ -111,7 +111,7 @@
     "date": "2029-12-06 00:00:00",
     "start": "2029-12-05T22:00:00.000Z",
     "end": "2029-12-06T22:00:00.000Z",
-    "name": "Självständighetsdagen",
+    "name": "självständighetsdagen",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Thu"

--- a/test/fixtures/FI-2015.json
+++ b/test/fixtures/FI-2015.json
@@ -3,7 +3,7 @@
     "date": "2015-01-01 00:00:00",
     "start": "2014-12-31T22:00:00.000Z",
     "end": "2015-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T22:00:00.000Z",
     "end": "2015-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -21,7 +21,7 @@
     "date": "2015-04-03 00:00:00",
     "start": "2015-04-02T21:00:00.000Z",
     "end": "2015-04-03T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2015-04-05 00:00:00",
     "start": "2015-04-04T21:00:00.000Z",
     "end": "2015-04-05T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-05T21:00:00.000Z",
     "end": "2015-04-06T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T21:00:00.000Z",
     "end": "2015-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -66,7 +66,7 @@
     "date": "2015-05-14 00:00:00",
     "start": "2015-05-13T21:00:00.000Z",
     "end": "2015-05-14T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2015-05-24 00:00:00",
     "start": "2015-05-23T21:00:00.000Z",
     "end": "2015-05-24T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2015-06-19 00:00:00",
     "start": "2015-06-18T21:00:00.000Z",
     "end": "2015-06-19T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2015-06-20 00:00:00",
     "start": "2015-06-19T21:00:00.000Z",
     "end": "2015-06-20T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2015-10-31 00:00:00",
     "start": "2015-10-30T22:00:00.000Z",
     "end": "2015-10-31T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2015-12-06 00:00:00",
     "start": "2015-12-05T22:00:00.000Z",
     "end": "2015-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2015-12-24 00:00:00",
     "start": "2015-12-23T22:00:00.000Z",
     "end": "2015-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T22:00:00.000Z",
     "end": "2015-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -147,7 +147,7 @@
     "date": "2015-12-26 00:00:00",
     "start": "2015-12-25T22:00:00.000Z",
     "end": "2015-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/FI-2016.json
+++ b/test/fixtures/FI-2016.json
@@ -3,7 +3,7 @@
     "date": "2016-01-01 00:00:00",
     "start": "2015-12-31T22:00:00.000Z",
     "end": "2016-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T22:00:00.000Z",
     "end": "2016-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -21,7 +21,7 @@
     "date": "2016-03-25 00:00:00",
     "start": "2016-03-24T22:00:00.000Z",
     "end": "2016-03-25T22:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2016-03-27 00:00:00",
     "start": "2016-03-26T22:00:00.000Z",
     "end": "2016-03-27T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-27T21:00:00.000Z",
     "end": "2016-03-28T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T21:00:00.000Z",
     "end": "2016-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2016-05-05 00:00:00",
     "start": "2016-05-04T21:00:00.000Z",
     "end": "2016-05-05T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2016-05-15 00:00:00",
     "start": "2016-05-14T21:00:00.000Z",
     "end": "2016-05-15T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2016-06-24 00:00:00",
     "start": "2016-06-23T21:00:00.000Z",
     "end": "2016-06-24T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2016-06-25 00:00:00",
     "start": "2016-06-24T21:00:00.000Z",
     "end": "2016-06-25T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2016-11-05 00:00:00",
     "start": "2016-11-04T22:00:00.000Z",
     "end": "2016-11-05T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2016-12-06 00:00:00",
     "start": "2016-12-05T22:00:00.000Z",
     "end": "2016-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Tue"
@@ -129,7 +129,7 @@
     "date": "2016-12-24 00:00:00",
     "start": "2016-12-23T22:00:00.000Z",
     "end": "2016-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T22:00:00.000Z",
     "end": "2016-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
@@ -147,7 +147,7 @@
     "date": "2016-12-26 00:00:00",
     "start": "2016-12-25T22:00:00.000Z",
     "end": "2016-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"

--- a/test/fixtures/FI-2017.json
+++ b/test/fixtures/FI-2017.json
@@ -3,7 +3,7 @@
     "date": "2017-01-01 00:00:00",
     "start": "2016-12-31T22:00:00.000Z",
     "end": "2017-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T22:00:00.000Z",
     "end": "2017-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -21,7 +21,7 @@
     "date": "2017-04-14 00:00:00",
     "start": "2017-04-13T21:00:00.000Z",
     "end": "2017-04-14T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2017-04-16 00:00:00",
     "start": "2017-04-15T21:00:00.000Z",
     "end": "2017-04-16T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T21:00:00.000Z",
     "end": "2017-04-17T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T21:00:00.000Z",
     "end": "2017-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2017-05-25 00:00:00",
     "start": "2017-05-24T21:00:00.000Z",
     "end": "2017-05-25T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2017-06-04 00:00:00",
     "start": "2017-06-03T21:00:00.000Z",
     "end": "2017-06-04T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2017-06-23 00:00:00",
     "start": "2017-06-22T21:00:00.000Z",
     "end": "2017-06-23T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2017-06-24 00:00:00",
     "start": "2017-06-23T21:00:00.000Z",
     "end": "2017-06-24T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2017-11-04 00:00:00",
     "start": "2017-11-03T22:00:00.000Z",
     "end": "2017-11-04T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2017-12-06 00:00:00",
     "start": "2017-12-05T22:00:00.000Z",
     "end": "2017-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Wed"
@@ -129,7 +129,7 @@
     "date": "2017-12-24 00:00:00",
     "start": "2017-12-23T22:00:00.000Z",
     "end": "2017-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Sun"
@@ -138,7 +138,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T22:00:00.000Z",
     "end": "2017-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -147,7 +147,7 @@
     "date": "2017-12-26 00:00:00",
     "start": "2017-12-25T22:00:00.000Z",
     "end": "2017-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/FI-2018.json
+++ b/test/fixtures/FI-2018.json
@@ -3,7 +3,7 @@
     "date": "2018-01-01 00:00:00",
     "start": "2017-12-31T22:00:00.000Z",
     "end": "2018-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T22:00:00.000Z",
     "end": "2018-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -21,7 +21,7 @@
     "date": "2018-03-30 00:00:00",
     "start": "2018-03-29T21:00:00.000Z",
     "end": "2018-03-30T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2018-04-01 00:00:00",
     "start": "2018-03-31T21:00:00.000Z",
     "end": "2018-04-01T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-01T21:00:00.000Z",
     "end": "2018-04-02T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T21:00:00.000Z",
     "end": "2018-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -57,7 +57,7 @@
     "date": "2018-05-10 00:00:00",
     "start": "2018-05-09T21:00:00.000Z",
     "end": "2018-05-10T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2018-05-20 00:00:00",
     "start": "2018-05-19T21:00:00.000Z",
     "end": "2018-05-20T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2018-06-22 00:00:00",
     "start": "2018-06-21T21:00:00.000Z",
     "end": "2018-06-22T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2018-06-23 00:00:00",
     "start": "2018-06-22T21:00:00.000Z",
     "end": "2018-06-23T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2018-11-03 00:00:00",
     "start": "2018-11-02T22:00:00.000Z",
     "end": "2018-11-03T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2018-12-06 00:00:00",
     "start": "2018-12-05T22:00:00.000Z",
     "end": "2018-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2018-12-24 00:00:00",
     "start": "2018-12-23T22:00:00.000Z",
     "end": "2018-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Mon"
@@ -138,7 +138,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T22:00:00.000Z",
     "end": "2018-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
@@ -147,7 +147,7 @@
     "date": "2018-12-26 00:00:00",
     "start": "2018-12-25T22:00:00.000Z",
     "end": "2018-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"

--- a/test/fixtures/FI-2019.json
+++ b/test/fixtures/FI-2019.json
@@ -3,7 +3,7 @@
     "date": "2019-01-01 00:00:00",
     "start": "2018-12-31T22:00:00.000Z",
     "end": "2019-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Tue"
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T22:00:00.000Z",
     "end": "2019-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -21,7 +21,7 @@
     "date": "2019-04-19 00:00:00",
     "start": "2019-04-18T21:00:00.000Z",
     "end": "2019-04-19T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2019-04-21 00:00:00",
     "start": "2019-04-20T21:00:00.000Z",
     "end": "2019-04-21T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-21T21:00:00.000Z",
     "end": "2019-04-22T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T21:00:00.000Z",
     "end": "2019-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -66,7 +66,7 @@
     "date": "2019-05-30 00:00:00",
     "start": "2019-05-29T21:00:00.000Z",
     "end": "2019-05-30T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2019-06-09 00:00:00",
     "start": "2019-06-08T21:00:00.000Z",
     "end": "2019-06-09T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2019-06-21 00:00:00",
     "start": "2019-06-20T21:00:00.000Z",
     "end": "2019-06-21T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2019-06-22 00:00:00",
     "start": "2019-06-21T21:00:00.000Z",
     "end": "2019-06-22T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2019-11-02 00:00:00",
     "start": "2019-11-01T22:00:00.000Z",
     "end": "2019-11-02T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2019-12-06 00:00:00",
     "start": "2019-12-05T22:00:00.000Z",
     "end": "2019-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Fri"
@@ -129,7 +129,7 @@
     "date": "2019-12-24 00:00:00",
     "start": "2019-12-23T22:00:00.000Z",
     "end": "2019-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Tue"
@@ -138,7 +138,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T22:00:00.000Z",
     "end": "2019-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
@@ -147,7 +147,7 @@
     "date": "2019-12-26 00:00:00",
     "start": "2019-12-25T22:00:00.000Z",
     "end": "2019-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"

--- a/test/fixtures/FI-2020.json
+++ b/test/fixtures/FI-2020.json
@@ -3,7 +3,7 @@
     "date": "2020-01-01 00:00:00",
     "start": "2019-12-31T22:00:00.000Z",
     "end": "2020-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T22:00:00.000Z",
     "end": "2020-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -21,7 +21,7 @@
     "date": "2020-04-10 00:00:00",
     "start": "2020-04-09T21:00:00.000Z",
     "end": "2020-04-10T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2020-04-12 00:00:00",
     "start": "2020-04-11T21:00:00.000Z",
     "end": "2020-04-12T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-12T21:00:00.000Z",
     "end": "2020-04-13T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T21:00:00.000Z",
     "end": "2020-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -66,7 +66,7 @@
     "date": "2020-05-21 00:00:00",
     "start": "2020-05-20T21:00:00.000Z",
     "end": "2020-05-21T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2020-05-31 00:00:00",
     "start": "2020-05-30T21:00:00.000Z",
     "end": "2020-05-31T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2020-06-19 00:00:00",
     "start": "2020-06-18T21:00:00.000Z",
     "end": "2020-06-19T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2020-06-20 00:00:00",
     "start": "2020-06-19T21:00:00.000Z",
     "end": "2020-06-20T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2020-10-31 00:00:00",
     "start": "2020-10-30T22:00:00.000Z",
     "end": "2020-10-31T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2020-12-06 00:00:00",
     "start": "2020-12-05T22:00:00.000Z",
     "end": "2020-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2020-12-24 00:00:00",
     "start": "2020-12-23T22:00:00.000Z",
     "end": "2020-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T22:00:00.000Z",
     "end": "2020-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -147,7 +147,7 @@
     "date": "2020-12-26 00:00:00",
     "start": "2020-12-25T22:00:00.000Z",
     "end": "2020-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/FI-2021.json
+++ b/test/fixtures/FI-2021.json
@@ -3,7 +3,7 @@
     "date": "2021-01-01 00:00:00",
     "start": "2020-12-31T22:00:00.000Z",
     "end": "2021-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T22:00:00.000Z",
     "end": "2021-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -21,7 +21,7 @@
     "date": "2021-04-02 00:00:00",
     "start": "2021-04-01T21:00:00.000Z",
     "end": "2021-04-02T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2021-04-04 00:00:00",
     "start": "2021-04-03T21:00:00.000Z",
     "end": "2021-04-04T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-04T21:00:00.000Z",
     "end": "2021-04-05T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T21:00:00.000Z",
     "end": "2021-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -66,7 +66,7 @@
     "date": "2021-05-13 00:00:00",
     "start": "2021-05-12T21:00:00.000Z",
     "end": "2021-05-13T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2021-05-23 00:00:00",
     "start": "2021-05-22T21:00:00.000Z",
     "end": "2021-05-23T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2021-06-25 00:00:00",
     "start": "2021-06-24T21:00:00.000Z",
     "end": "2021-06-25T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2021-06-26 00:00:00",
     "start": "2021-06-25T21:00:00.000Z",
     "end": "2021-06-26T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2021-11-06 00:00:00",
     "start": "2021-11-05T22:00:00.000Z",
     "end": "2021-11-06T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2021-12-06 00:00:00",
     "start": "2021-12-05T22:00:00.000Z",
     "end": "2021-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Mon"
@@ -129,7 +129,7 @@
     "date": "2021-12-24 00:00:00",
     "start": "2021-12-23T22:00:00.000Z",
     "end": "2021-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Fri"
@@ -138,7 +138,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T22:00:00.000Z",
     "end": "2021-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2021-12-26 00:00:00",
     "start": "2021-12-25T22:00:00.000Z",
     "end": "2021-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"

--- a/test/fixtures/FI-2022.json
+++ b/test/fixtures/FI-2022.json
@@ -3,7 +3,7 @@
     "date": "2022-01-01 00:00:00",
     "start": "2021-12-31T22:00:00.000Z",
     "end": "2022-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T22:00:00.000Z",
     "end": "2022-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -21,7 +21,7 @@
     "date": "2022-04-15 00:00:00",
     "start": "2022-04-14T21:00:00.000Z",
     "end": "2022-04-15T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2022-04-17 00:00:00",
     "start": "2022-04-16T21:00:00.000Z",
     "end": "2022-04-17T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-17T21:00:00.000Z",
     "end": "2022-04-18T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T21:00:00.000Z",
     "end": "2022-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -66,7 +66,7 @@
     "date": "2022-05-26 00:00:00",
     "start": "2022-05-25T21:00:00.000Z",
     "end": "2022-05-26T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2022-06-05 00:00:00",
     "start": "2022-06-04T21:00:00.000Z",
     "end": "2022-06-05T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2022-06-24 00:00:00",
     "start": "2022-06-23T21:00:00.000Z",
     "end": "2022-06-24T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2022-06-25 00:00:00",
     "start": "2022-06-24T21:00:00.000Z",
     "end": "2022-06-25T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2022-11-05 00:00:00",
     "start": "2022-11-04T22:00:00.000Z",
     "end": "2022-11-05T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2022-12-06 00:00:00",
     "start": "2022-12-05T22:00:00.000Z",
     "end": "2022-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Tue"
@@ -129,7 +129,7 @@
     "date": "2022-12-24 00:00:00",
     "start": "2022-12-23T22:00:00.000Z",
     "end": "2022-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T22:00:00.000Z",
     "end": "2022-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
@@ -147,7 +147,7 @@
     "date": "2022-12-26 00:00:00",
     "start": "2022-12-25T22:00:00.000Z",
     "end": "2022-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"

--- a/test/fixtures/FI-2023.json
+++ b/test/fixtures/FI-2023.json
@@ -3,7 +3,7 @@
     "date": "2023-01-01 00:00:00",
     "start": "2022-12-31T22:00:00.000Z",
     "end": "2023-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T22:00:00.000Z",
     "end": "2023-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -21,7 +21,7 @@
     "date": "2023-04-07 00:00:00",
     "start": "2023-04-06T21:00:00.000Z",
     "end": "2023-04-07T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2023-04-09 00:00:00",
     "start": "2023-04-08T21:00:00.000Z",
     "end": "2023-04-09T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-09T21:00:00.000Z",
     "end": "2023-04-10T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T21:00:00.000Z",
     "end": "2023-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2023-05-18 00:00:00",
     "start": "2023-05-17T21:00:00.000Z",
     "end": "2023-05-18T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2023-05-28 00:00:00",
     "start": "2023-05-27T21:00:00.000Z",
     "end": "2023-05-28T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2023-06-23 00:00:00",
     "start": "2023-06-22T21:00:00.000Z",
     "end": "2023-06-23T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2023-06-24 00:00:00",
     "start": "2023-06-23T21:00:00.000Z",
     "end": "2023-06-24T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2023-11-04 00:00:00",
     "start": "2023-11-03T22:00:00.000Z",
     "end": "2023-11-04T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2023-12-06 00:00:00",
     "start": "2023-12-05T22:00:00.000Z",
     "end": "2023-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Wed"
@@ -129,7 +129,7 @@
     "date": "2023-12-24 00:00:00",
     "start": "2023-12-23T22:00:00.000Z",
     "end": "2023-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Sun"
@@ -138,7 +138,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T22:00:00.000Z",
     "end": "2023-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -147,7 +147,7 @@
     "date": "2023-12-26 00:00:00",
     "start": "2023-12-25T22:00:00.000Z",
     "end": "2023-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/FI-2024.json
+++ b/test/fixtures/FI-2024.json
@@ -3,7 +3,7 @@
     "date": "2024-01-01 00:00:00",
     "start": "2023-12-31T22:00:00.000Z",
     "end": "2024-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T22:00:00.000Z",
     "end": "2024-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -21,7 +21,7 @@
     "date": "2024-03-29 00:00:00",
     "start": "2024-03-28T22:00:00.000Z",
     "end": "2024-03-29T22:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2024-03-31 00:00:00",
     "start": "2024-03-30T22:00:00.000Z",
     "end": "2024-03-31T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-03-31T21:00:00.000Z",
     "end": "2024-04-01T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T21:00:00.000Z",
     "end": "2024-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -57,7 +57,7 @@
     "date": "2024-05-09 00:00:00",
     "start": "2024-05-08T21:00:00.000Z",
     "end": "2024-05-09T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2024-05-19 00:00:00",
     "start": "2024-05-18T21:00:00.000Z",
     "end": "2024-05-19T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2024-06-21 00:00:00",
     "start": "2024-06-20T21:00:00.000Z",
     "end": "2024-06-21T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2024-06-22 00:00:00",
     "start": "2024-06-21T21:00:00.000Z",
     "end": "2024-06-22T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2024-11-02 00:00:00",
     "start": "2024-11-01T22:00:00.000Z",
     "end": "2024-11-02T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2024-12-06 00:00:00",
     "start": "2024-12-05T22:00:00.000Z",
     "end": "2024-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Fri"
@@ -129,7 +129,7 @@
     "date": "2024-12-24 00:00:00",
     "start": "2024-12-23T22:00:00.000Z",
     "end": "2024-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Tue"
@@ -138,7 +138,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T22:00:00.000Z",
     "end": "2024-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
@@ -147,7 +147,7 @@
     "date": "2024-12-26 00:00:00",
     "start": "2024-12-25T22:00:00.000Z",
     "end": "2024-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"

--- a/test/fixtures/FI-2025.json
+++ b/test/fixtures/FI-2025.json
@@ -3,7 +3,7 @@
     "date": "2025-01-01 00:00:00",
     "start": "2024-12-31T22:00:00.000Z",
     "end": "2025-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T22:00:00.000Z",
     "end": "2025-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -21,7 +21,7 @@
     "date": "2025-04-18 00:00:00",
     "start": "2025-04-17T21:00:00.000Z",
     "end": "2025-04-18T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2025-04-20 00:00:00",
     "start": "2025-04-19T21:00:00.000Z",
     "end": "2025-04-20T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T21:00:00.000Z",
     "end": "2025-04-21T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T21:00:00.000Z",
     "end": "2025-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2025-05-29 00:00:00",
     "start": "2025-05-28T21:00:00.000Z",
     "end": "2025-05-29T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2025-06-08 00:00:00",
     "start": "2025-06-07T21:00:00.000Z",
     "end": "2025-06-08T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2025-06-20 00:00:00",
     "start": "2025-06-19T21:00:00.000Z",
     "end": "2025-06-20T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2025-06-21 00:00:00",
     "start": "2025-06-20T21:00:00.000Z",
     "end": "2025-06-21T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2025-11-01 00:00:00",
     "start": "2025-10-31T22:00:00.000Z",
     "end": "2025-11-01T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2025-12-06 00:00:00",
     "start": "2025-12-05T22:00:00.000Z",
     "end": "2025-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Sat"
@@ -129,7 +129,7 @@
     "date": "2025-12-24 00:00:00",
     "start": "2025-12-23T22:00:00.000Z",
     "end": "2025-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Wed"
@@ -138,7 +138,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T22:00:00.000Z",
     "end": "2025-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
@@ -147,7 +147,7 @@
     "date": "2025-12-26 00:00:00",
     "start": "2025-12-25T22:00:00.000Z",
     "end": "2025-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Fri"

--- a/test/fixtures/FI-2026.json
+++ b/test/fixtures/FI-2026.json
@@ -3,7 +3,7 @@
     "date": "2026-01-01 00:00:00",
     "start": "2025-12-31T22:00:00.000Z",
     "end": "2026-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T22:00:00.000Z",
     "end": "2026-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -21,7 +21,7 @@
     "date": "2026-04-03 00:00:00",
     "start": "2026-04-02T21:00:00.000Z",
     "end": "2026-04-03T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2026-04-05 00:00:00",
     "start": "2026-04-04T21:00:00.000Z",
     "end": "2026-04-05T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-05T21:00:00.000Z",
     "end": "2026-04-06T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T21:00:00.000Z",
     "end": "2026-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -66,7 +66,7 @@
     "date": "2026-05-14 00:00:00",
     "start": "2026-05-13T21:00:00.000Z",
     "end": "2026-05-14T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2026-05-24 00:00:00",
     "start": "2026-05-23T21:00:00.000Z",
     "end": "2026-05-24T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2026-06-19 00:00:00",
     "start": "2026-06-18T21:00:00.000Z",
     "end": "2026-06-19T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2026-06-20 00:00:00",
     "start": "2026-06-19T21:00:00.000Z",
     "end": "2026-06-20T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2026-10-31 00:00:00",
     "start": "2026-10-30T22:00:00.000Z",
     "end": "2026-10-31T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2026-12-06 00:00:00",
     "start": "2026-12-05T22:00:00.000Z",
     "end": "2026-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2026-12-24 00:00:00",
     "start": "2026-12-23T22:00:00.000Z",
     "end": "2026-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T22:00:00.000Z",
     "end": "2026-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -147,7 +147,7 @@
     "date": "2026-12-26 00:00:00",
     "start": "2026-12-25T22:00:00.000Z",
     "end": "2026-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/FI-2027.json
+++ b/test/fixtures/FI-2027.json
@@ -3,7 +3,7 @@
     "date": "2027-01-01 00:00:00",
     "start": "2026-12-31T22:00:00.000Z",
     "end": "2027-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T22:00:00.000Z",
     "end": "2027-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -21,7 +21,7 @@
     "date": "2027-03-26 00:00:00",
     "start": "2027-03-25T22:00:00.000Z",
     "end": "2027-03-26T22:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2027-03-28 00:00:00",
     "start": "2027-03-27T22:00:00.000Z",
     "end": "2027-03-28T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-28T21:00:00.000Z",
     "end": "2027-03-29T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T21:00:00.000Z",
     "end": "2027-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -57,7 +57,7 @@
     "date": "2027-05-06 00:00:00",
     "start": "2027-05-05T21:00:00.000Z",
     "end": "2027-05-06T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2027-05-16 00:00:00",
     "start": "2027-05-15T21:00:00.000Z",
     "end": "2027-05-16T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2027-06-25 00:00:00",
     "start": "2027-06-24T21:00:00.000Z",
     "end": "2027-06-25T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2027-06-26 00:00:00",
     "start": "2027-06-25T21:00:00.000Z",
     "end": "2027-06-26T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2027-11-06 00:00:00",
     "start": "2027-11-05T22:00:00.000Z",
     "end": "2027-11-06T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2027-12-06 00:00:00",
     "start": "2027-12-05T22:00:00.000Z",
     "end": "2027-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Mon"
@@ -129,7 +129,7 @@
     "date": "2027-12-24 00:00:00",
     "start": "2027-12-23T22:00:00.000Z",
     "end": "2027-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Fri"
@@ -138,7 +138,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T22:00:00.000Z",
     "end": "2027-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2027-12-26 00:00:00",
     "start": "2027-12-25T22:00:00.000Z",
     "end": "2027-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"

--- a/test/fixtures/FI-2028.json
+++ b/test/fixtures/FI-2028.json
@@ -3,7 +3,7 @@
     "date": "2028-01-01 00:00:00",
     "start": "2027-12-31T22:00:00.000Z",
     "end": "2028-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T22:00:00.000Z",
     "end": "2028-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -21,7 +21,7 @@
     "date": "2028-04-14 00:00:00",
     "start": "2028-04-13T21:00:00.000Z",
     "end": "2028-04-14T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2028-04-16 00:00:00",
     "start": "2028-04-15T21:00:00.000Z",
     "end": "2028-04-16T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T21:00:00.000Z",
     "end": "2028-04-17T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T21:00:00.000Z",
     "end": "2028-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2028-05-25 00:00:00",
     "start": "2028-05-24T21:00:00.000Z",
     "end": "2028-05-25T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2028-06-04 00:00:00",
     "start": "2028-06-03T21:00:00.000Z",
     "end": "2028-06-04T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2028-06-23 00:00:00",
     "start": "2028-06-22T21:00:00.000Z",
     "end": "2028-06-23T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2028-06-24 00:00:00",
     "start": "2028-06-23T21:00:00.000Z",
     "end": "2028-06-24T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2028-11-04 00:00:00",
     "start": "2028-11-03T22:00:00.000Z",
     "end": "2028-11-04T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2028-12-06 00:00:00",
     "start": "2028-12-05T22:00:00.000Z",
     "end": "2028-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Wed"
@@ -129,7 +129,7 @@
     "date": "2028-12-24 00:00:00",
     "start": "2028-12-23T22:00:00.000Z",
     "end": "2028-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Sun"
@@ -138,7 +138,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T22:00:00.000Z",
     "end": "2028-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -147,7 +147,7 @@
     "date": "2028-12-26 00:00:00",
     "start": "2028-12-25T22:00:00.000Z",
     "end": "2028-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/FI-2029.json
+++ b/test/fixtures/FI-2029.json
@@ -3,7 +3,7 @@
     "date": "2029-01-01 00:00:00",
     "start": "2028-12-31T22:00:00.000Z",
     "end": "2029-01-01T22:00:00.000Z",
-    "name": "Uudenvuodenpäivä",
+    "name": "uudenvuodenpäivä",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T22:00:00.000Z",
     "end": "2029-01-06T22:00:00.000Z",
-    "name": "Loppiainen",
+    "name": "loppiainen",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -21,7 +21,7 @@
     "date": "2029-03-30 00:00:00",
     "start": "2029-03-29T21:00:00.000Z",
     "end": "2029-03-30T21:00:00.000Z",
-    "name": "Pitkäperjantai",
+    "name": "pitkäperjantai",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2029-04-01 00:00:00",
     "start": "2029-03-31T21:00:00.000Z",
     "end": "2029-04-01T21:00:00.000Z",
-    "name": "Pääsiäispäivä",
+    "name": "pääsiäispäivä",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-01T21:00:00.000Z",
     "end": "2029-04-02T21:00:00.000Z",
-    "name": "2. pääsiäispäivä",
+    "name": "toinen pääsiäispäivä",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T21:00:00.000Z",
     "end": "2029-05-01T21:00:00.000Z",
-    "name": "Vappu",
+    "name": "vappu",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -57,7 +57,7 @@
     "date": "2029-05-10 00:00:00",
     "start": "2029-05-09T21:00:00.000Z",
     "end": "2029-05-10T21:00:00.000Z",
-    "name": "Helatorstai",
+    "name": "helatorstai",
     "type": "public",
     "rule": "easter 39",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2029-05-20 00:00:00",
     "start": "2029-05-19T21:00:00.000Z",
     "end": "2029-05-20T21:00:00.000Z",
-    "name": "Helluntaipäivä",
+    "name": "helluntaipäivä",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2029-06-22 00:00:00",
     "start": "2029-06-21T21:00:00.000Z",
     "end": "2029-06-22T21:00:00.000Z",
-    "name": "Juhannusaatto",
+    "name": "juhannusaatto",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2029-06-23 00:00:00",
     "start": "2029-06-22T21:00:00.000Z",
     "end": "2029-06-23T21:00:00.000Z",
-    "name": "Juhannuspäivä",
+    "name": "juhannuspäivä",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2029-11-03 00:00:00",
     "start": "2029-11-02T22:00:00.000Z",
     "end": "2029-11-03T22:00:00.000Z",
-    "name": "Pyhäinpäivä",
+    "name": "pyhäinpäivä",
     "type": "public",
     "rule": "saturday after 10-31",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2029-12-06 00:00:00",
     "start": "2029-12-05T22:00:00.000Z",
     "end": "2029-12-06T22:00:00.000Z",
-    "name": "Itsenäisyyspäivä",
+    "name": "itsenäisyyspäivä",
     "type": "public",
     "rule": "12-06",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2029-12-24 00:00:00",
     "start": "2029-12-23T22:00:00.000Z",
     "end": "2029-12-24T22:00:00.000Z",
-    "name": "Jouluaatto",
+    "name": "jouluaatto",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Mon"
@@ -138,7 +138,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T22:00:00.000Z",
     "end": "2029-12-25T22:00:00.000Z",
-    "name": "Joulupäivä",
+    "name": "joulupäivä",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
@@ -147,7 +147,7 @@
     "date": "2029-12-26 00:00:00",
     "start": "2029-12-25T22:00:00.000Z",
     "end": "2029-12-26T22:00:00.000Z",
-    "name": "2. joulupäivä",
+    "name": "tapaninpäivä",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"


### PR DESCRIPTION
Use official Finnish holiday names and lowercase spelling. Lowercase follows normal Finnish writing conventions for holiday names.
Add the University of Helsinki Almanac as the primary source.