### PR TITLE
feat(pe): add 4 missing national holidays

### DIFF
--- a/data/countries/PE.yaml
+++ b/data/countries/PE.yaml
@@ -21,12 +21,30 @@ holidays:
         _name: easter
       05-01:
         _name: 05-01
+      # @source https://busquedas.elperuano.pe/dispositivo/NL/2187453-1
+      06-07 since 2024:
+        name:
+          en: Battle of Arica and Flag Day
+          es: Batalla de Arica y Día de la Bandera
+        note: Established as a national holiday by Ley 31788 (2023); first observed in 2024
       06-29:
         _name: 06-29
+      # @source https://busquedas.elperuano.pe/dispositivo/NL/2194316-1
+      07-23 since 2023:
+        name:
+          en: Peruvian Air Force Day
+          es: Día de la Fuerza Aérea del Perú
+        note: Established as a national holiday by Ley 31822 (2023)
       07-28:
         _name: Independence Day
       07-29:
         _name: Independence Day
+      # @source https://busquedas.elperuano.pe/dispositivo/NL/2089960-2
+      08-06 since 2022:
+        name:
+          en: Battle of Junín
+          es: Batalla de Junín
+        note: Established as a national holiday by Ley 31530 (2022)
       08-30:
         name:
           en: Santa Rosa de Lima
@@ -39,6 +57,12 @@ holidays:
         _name: 11-01
       12-08:
         _name: 12-08
+      # @source https://busquedas.elperuano.pe/dispositivo/NL/2026913-1
+      12-09 since 2022:
+        name:
+          en: Battle of Ayacucho
+          es: Batalla de Ayacucho
+        note: Established as a national holiday by Ley 31381 (2021); first observed in 2022
       12-25:
         _name: 12-25
     regions:

--- a/test/fixtures/PE-2022.json
+++ b/test/fixtures/PE-2022.json
@@ -72,6 +72,16 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T05:00:00.000Z",
+    "end": "2022-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2022-08-30 00:00:00",
     "start": "2022-08-30T05:00:00.000Z",
     "end": "2022-08-31T05:00:00.000Z",
@@ -106,6 +116,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2022-12-09 00:00:00",
+    "start": "2022-12-09T05:00:00.000Z",
+    "end": "2022-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Fri"
   },
   {
     "date": "2022-12-25 00:00:00",

--- a/test/fixtures/PE-2023.json
+++ b/test/fixtures/PE-2023.json
@@ -54,6 +54,16 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2023-07-23 00:00:00",
+    "start": "2023-07-23T05:00:00.000Z",
+    "end": "2023-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-07-28 00:00:00",
     "start": "2023-07-28T05:00:00.000Z",
     "end": "2023-07-29T05:00:00.000Z",
@@ -70,6 +80,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T05:00:00.000Z",
+    "end": "2023-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Sun"
   },
   {
     "date": "2023-08-30 00:00:00",
@@ -106,6 +126,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2023-12-09 00:00:00",
+    "start": "2023-12-09T05:00:00.000Z",
+    "end": "2023-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Sat"
   },
   {
     "date": "2023-12-25 00:00:00",

--- a/test/fixtures/PE-2024.json
+++ b/test/fixtures/PE-2024.json
@@ -45,6 +45,16 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2024-06-07 00:00:00",
+    "start": "2024-06-07T05:00:00.000Z",
+    "end": "2024-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2024-06-29 00:00:00",
     "start": "2024-06-29T05:00:00.000Z",
     "end": "2024-06-30T05:00:00.000Z",
@@ -52,6 +62,16 @@
     "type": "public",
     "rule": "06-29",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2024-07-23 00:00:00",
+    "start": "2024-07-23T05:00:00.000Z",
+    "end": "2024-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Tue"
   },
   {
     "date": "2024-07-28 00:00:00",
@@ -70,6 +90,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T05:00:00.000Z",
+    "end": "2024-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Tue"
   },
   {
     "date": "2024-08-30 00:00:00",
@@ -106,6 +136,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2024-12-09 00:00:00",
+    "start": "2024-12-09T05:00:00.000Z",
+    "end": "2024-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Mon"
   },
   {
     "date": "2024-12-25 00:00:00",

--- a/test/fixtures/PE-2025.json
+++ b/test/fixtures/PE-2025.json
@@ -45,6 +45,16 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2025-06-07 00:00:00",
+    "start": "2025-06-07T05:00:00.000Z",
+    "end": "2025-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2025-06-29 00:00:00",
     "start": "2025-06-29T05:00:00.000Z",
     "end": "2025-06-30T05:00:00.000Z",
@@ -52,6 +62,16 @@
     "type": "public",
     "rule": "06-29",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2025-07-23 00:00:00",
+    "start": "2025-07-23T05:00:00.000Z",
+    "end": "2025-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-07-28 00:00:00",
@@ -70,6 +90,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T05:00:00.000Z",
+    "end": "2025-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-08-30 00:00:00",
@@ -106,6 +136,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2025-12-09 00:00:00",
+    "start": "2025-12-09T05:00:00.000Z",
+    "end": "2025-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Tue"
   },
   {
     "date": "2025-12-25 00:00:00",

--- a/test/fixtures/PE-2026.json
+++ b/test/fixtures/PE-2026.json
@@ -45,6 +45,16 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2026-06-07 00:00:00",
+    "start": "2026-06-07T05:00:00.000Z",
+    "end": "2026-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2026-06-29 00:00:00",
     "start": "2026-06-29T05:00:00.000Z",
     "end": "2026-06-30T05:00:00.000Z",
@@ -52,6 +62,16 @@
     "type": "public",
     "rule": "06-29",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2026-07-23 00:00:00",
+    "start": "2026-07-23T05:00:00.000Z",
+    "end": "2026-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Thu"
   },
   {
     "date": "2026-07-28 00:00:00",
@@ -70,6 +90,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T05:00:00.000Z",
+    "end": "2026-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Thu"
   },
   {
     "date": "2026-08-30 00:00:00",
@@ -106,6 +136,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2026-12-09 00:00:00",
+    "start": "2026-12-09T05:00:00.000Z",
+    "end": "2026-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-12-25 00:00:00",

--- a/test/fixtures/PE-2027.json
+++ b/test/fixtures/PE-2027.json
@@ -45,6 +45,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2027-06-07 00:00:00",
+    "start": "2027-06-07T05:00:00.000Z",
+    "end": "2027-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-06-29 00:00:00",
     "start": "2027-06-29T05:00:00.000Z",
     "end": "2027-06-30T05:00:00.000Z",
@@ -52,6 +62,16 @@
     "type": "public",
     "rule": "06-29",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2027-07-23 00:00:00",
+    "start": "2027-07-23T05:00:00.000Z",
+    "end": "2027-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Fri"
   },
   {
     "date": "2027-07-28 00:00:00",
@@ -70,6 +90,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T05:00:00.000Z",
+    "end": "2027-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Fri"
   },
   {
     "date": "2027-08-30 00:00:00",
@@ -106,6 +136,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2027-12-09 00:00:00",
+    "start": "2027-12-09T05:00:00.000Z",
+    "end": "2027-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Thu"
   },
   {
     "date": "2027-12-25 00:00:00",

--- a/test/fixtures/PE-2028.json
+++ b/test/fixtures/PE-2028.json
@@ -45,6 +45,16 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2028-06-07 00:00:00",
+    "start": "2028-06-07T05:00:00.000Z",
+    "end": "2028-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2028-06-29 00:00:00",
     "start": "2028-06-29T05:00:00.000Z",
     "end": "2028-06-30T05:00:00.000Z",
@@ -52,6 +62,16 @@
     "type": "public",
     "rule": "06-29",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2028-07-23 00:00:00",
+    "start": "2028-07-23T05:00:00.000Z",
+    "end": "2028-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Sun"
   },
   {
     "date": "2028-07-28 00:00:00",
@@ -70,6 +90,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2028-08-06 00:00:00",
+    "start": "2028-08-06T05:00:00.000Z",
+    "end": "2028-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Sun"
   },
   {
     "date": "2028-08-30 00:00:00",
@@ -106,6 +136,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2028-12-09 00:00:00",
+    "start": "2028-12-09T05:00:00.000Z",
+    "end": "2028-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Sat"
   },
   {
     "date": "2028-12-25 00:00:00",

--- a/test/fixtures/PE-2029.json
+++ b/test/fixtures/PE-2029.json
@@ -45,6 +45,16 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2029-06-07 00:00:00",
+    "start": "2029-06-07T05:00:00.000Z",
+    "end": "2029-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2029-06-29 00:00:00",
     "start": "2029-06-29T05:00:00.000Z",
     "end": "2029-06-30T05:00:00.000Z",
@@ -52,6 +62,16 @@
     "type": "public",
     "rule": "06-29",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2029-07-23 00:00:00",
+    "start": "2029-07-23T05:00:00.000Z",
+    "end": "2029-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Mon"
   },
   {
     "date": "2029-07-28 00:00:00",
@@ -70,6 +90,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2029-08-06 00:00:00",
+    "start": "2029-08-06T05:00:00.000Z",
+    "end": "2029-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Mon"
   },
   {
     "date": "2029-08-30 00:00:00",
@@ -106,6 +136,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2029-12-09 00:00:00",
+    "start": "2029-12-09T05:00:00.000Z",
+    "end": "2029-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Sun"
   },
   {
     "date": "2029-12-25 00:00:00",

--- a/test/fixtures/PE-CUS-2022.json
+++ b/test/fixtures/PE-CUS-2022.json
@@ -81,6 +81,16 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2022-08-06 00:00:00",
+    "start": "2022-08-06T05:00:00.000Z",
+    "end": "2022-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2022-08-30 00:00:00",
     "start": "2022-08-30T05:00:00.000Z",
     "end": "2022-08-31T05:00:00.000Z",
@@ -115,6 +125,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2022-12-09 00:00:00",
+    "start": "2022-12-09T05:00:00.000Z",
+    "end": "2022-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Fri"
   },
   {
     "date": "2022-12-25 00:00:00",

--- a/test/fixtures/PE-CUS-2023.json
+++ b/test/fixtures/PE-CUS-2023.json
@@ -63,6 +63,16 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2023-07-23 00:00:00",
+    "start": "2023-07-23T05:00:00.000Z",
+    "end": "2023-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2023-07-28 00:00:00",
     "start": "2023-07-28T05:00:00.000Z",
     "end": "2023-07-29T05:00:00.000Z",
@@ -79,6 +89,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2023-08-06 00:00:00",
+    "start": "2023-08-06T05:00:00.000Z",
+    "end": "2023-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Sun"
   },
   {
     "date": "2023-08-30 00:00:00",
@@ -115,6 +135,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2023-12-09 00:00:00",
+    "start": "2023-12-09T05:00:00.000Z",
+    "end": "2023-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Sat"
   },
   {
     "date": "2023-12-25 00:00:00",

--- a/test/fixtures/PE-CUS-2024.json
+++ b/test/fixtures/PE-CUS-2024.json
@@ -45,6 +45,16 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2024-06-07 00:00:00",
+    "start": "2024-06-07T05:00:00.000Z",
+    "end": "2024-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2024-06-24 00:00:00",
     "start": "2024-06-24T05:00:00.000Z",
     "end": "2024-06-25T05:00:00.000Z",
@@ -63,6 +73,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2024-07-23 00:00:00",
+    "start": "2024-07-23T05:00:00.000Z",
+    "end": "2024-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Tue"
+  },
+  {
     "date": "2024-07-28 00:00:00",
     "start": "2024-07-28T05:00:00.000Z",
     "end": "2024-07-29T05:00:00.000Z",
@@ -79,6 +99,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2024-08-06 00:00:00",
+    "start": "2024-08-06T05:00:00.000Z",
+    "end": "2024-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Tue"
   },
   {
     "date": "2024-08-30 00:00:00",
@@ -115,6 +145,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2024-12-09 00:00:00",
+    "start": "2024-12-09T05:00:00.000Z",
+    "end": "2024-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Mon"
   },
   {
     "date": "2024-12-25 00:00:00",

--- a/test/fixtures/PE-CUS-2025.json
+++ b/test/fixtures/PE-CUS-2025.json
@@ -45,6 +45,16 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2025-06-07 00:00:00",
+    "start": "2025-06-07T05:00:00.000Z",
+    "end": "2025-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2025-06-24 00:00:00",
     "start": "2025-06-24T05:00:00.000Z",
     "end": "2025-06-25T05:00:00.000Z",
@@ -63,6 +73,16 @@
     "_weekday": "Sun"
   },
   {
+    "date": "2025-07-23 00:00:00",
+    "start": "2025-07-23T05:00:00.000Z",
+    "end": "2025-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2025-07-28 00:00:00",
     "start": "2025-07-28T05:00:00.000Z",
     "end": "2025-07-29T05:00:00.000Z",
@@ -79,6 +99,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2025-08-06 00:00:00",
+    "start": "2025-08-06T05:00:00.000Z",
+    "end": "2025-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Wed"
   },
   {
     "date": "2025-08-30 00:00:00",
@@ -115,6 +145,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2025-12-09 00:00:00",
+    "start": "2025-12-09T05:00:00.000Z",
+    "end": "2025-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Tue"
   },
   {
     "date": "2025-12-25 00:00:00",

--- a/test/fixtures/PE-CUS-2026.json
+++ b/test/fixtures/PE-CUS-2026.json
@@ -45,6 +45,16 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2026-06-07 00:00:00",
+    "start": "2026-06-07T05:00:00.000Z",
+    "end": "2026-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2026-06-24 00:00:00",
     "start": "2026-06-24T05:00:00.000Z",
     "end": "2026-06-25T05:00:00.000Z",
@@ -63,6 +73,16 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2026-07-23 00:00:00",
+    "start": "2026-07-23T05:00:00.000Z",
+    "end": "2026-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2026-07-28 00:00:00",
     "start": "2026-07-28T05:00:00.000Z",
     "end": "2026-07-29T05:00:00.000Z",
@@ -79,6 +99,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2026-08-06 00:00:00",
+    "start": "2026-08-06T05:00:00.000Z",
+    "end": "2026-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Thu"
   },
   {
     "date": "2026-08-30 00:00:00",
@@ -115,6 +145,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2026-12-09 00:00:00",
+    "start": "2026-12-09T05:00:00.000Z",
+    "end": "2026-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Wed"
   },
   {
     "date": "2026-12-25 00:00:00",

--- a/test/fixtures/PE-CUS-2027.json
+++ b/test/fixtures/PE-CUS-2027.json
@@ -45,6 +45,16 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2027-06-07 00:00:00",
+    "start": "2027-06-07T05:00:00.000Z",
+    "end": "2027-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2027-06-24 00:00:00",
     "start": "2027-06-24T05:00:00.000Z",
     "end": "2027-06-25T05:00:00.000Z",
@@ -63,6 +73,16 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2027-07-23 00:00:00",
+    "start": "2027-07-23T05:00:00.000Z",
+    "end": "2027-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2027-07-28 00:00:00",
     "start": "2027-07-28T05:00:00.000Z",
     "end": "2027-07-29T05:00:00.000Z",
@@ -79,6 +99,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2027-08-06 00:00:00",
+    "start": "2027-08-06T05:00:00.000Z",
+    "end": "2027-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Fri"
   },
   {
     "date": "2027-08-30 00:00:00",
@@ -115,6 +145,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2027-12-09 00:00:00",
+    "start": "2027-12-09T05:00:00.000Z",
+    "end": "2027-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Thu"
   },
   {
     "date": "2027-12-25 00:00:00",

--- a/test/fixtures/PE-CUS-2028.json
+++ b/test/fixtures/PE-CUS-2028.json
@@ -45,6 +45,16 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2028-06-07 00:00:00",
+    "start": "2028-06-07T05:00:00.000Z",
+    "end": "2028-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2028-06-24 00:00:00",
     "start": "2028-06-24T05:00:00.000Z",
     "end": "2028-06-25T05:00:00.000Z",
@@ -63,6 +73,16 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2028-07-23 00:00:00",
+    "start": "2028-07-23T05:00:00.000Z",
+    "end": "2028-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2028-07-28 00:00:00",
     "start": "2028-07-28T05:00:00.000Z",
     "end": "2028-07-29T05:00:00.000Z",
@@ -79,6 +99,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2028-08-06 00:00:00",
+    "start": "2028-08-06T05:00:00.000Z",
+    "end": "2028-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Sun"
   },
   {
     "date": "2028-08-30 00:00:00",
@@ -115,6 +145,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2028-12-09 00:00:00",
+    "start": "2028-12-09T05:00:00.000Z",
+    "end": "2028-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Sat"
   },
   {
     "date": "2028-12-25 00:00:00",

--- a/test/fixtures/PE-CUS-2029.json
+++ b/test/fixtures/PE-CUS-2029.json
@@ -45,6 +45,16 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2029-06-07 00:00:00",
+    "start": "2029-06-07T05:00:00.000Z",
+    "end": "2029-06-08T05:00:00.000Z",
+    "name": "Batalla de Arica y Día de la Bandera",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31788 (2023); first observed in 2024",
+    "rule": "06-07 since 2024",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2029-06-24 00:00:00",
     "start": "2029-06-24T05:00:00.000Z",
     "end": "2029-06-25T05:00:00.000Z",
@@ -63,6 +73,16 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2029-07-23 00:00:00",
+    "start": "2029-07-23T05:00:00.000Z",
+    "end": "2029-07-24T05:00:00.000Z",
+    "name": "Día de la Fuerza Aérea del Perú",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31822 (2023)",
+    "rule": "07-23 since 2023",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2029-07-28 00:00:00",
     "start": "2029-07-28T05:00:00.000Z",
     "end": "2029-07-29T05:00:00.000Z",
@@ -79,6 +99,16 @@
     "type": "public",
     "rule": "07-29",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2029-08-06 00:00:00",
+    "start": "2029-08-06T05:00:00.000Z",
+    "end": "2029-08-07T05:00:00.000Z",
+    "name": "Batalla de Junín",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31530 (2022)",
+    "rule": "08-06 since 2022",
+    "_weekday": "Mon"
   },
   {
     "date": "2029-08-30 00:00:00",
@@ -115,6 +145,16 @@
     "type": "public",
     "rule": "12-08",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2029-12-09 00:00:00",
+    "start": "2029-12-09T05:00:00.000Z",
+    "end": "2029-12-10T05:00:00.000Z",
+    "name": "Batalla de Ayacucho",
+    "type": "public",
+    "note": "Established as a national holiday by Ley 31381 (2021); first observed in 2022",
+    "rule": "12-09 since 2022",
+    "_weekday": "Sun"
   },
   {
     "date": "2029-12-25 00:00:00",


### PR DESCRIPTION
## Summary

Peru's PE calendar is missing 4 permanent national holidays that were added by law after this data was last updated — confirmed still missing even in the latest published version (3.34.1):

| Date | Holiday | Law | First applies |
|---|---|---|---|
| Jun 7 | Batalla de Arica y Día de la Bandera | Ley 31788 | 2024 |
| Jul 23 | Día de la Fuerza Aérea del Perú | Ley 31822 | 2023 |
| Aug 6 | Batalla de Junín | Ley 31530 | 2022 |
| Dec 9 | Batalla de Ayacucho | Ley 31381 | 2022 |

Each rule is bound with `since <year>` to the year the law actually took effect (verified against the primary source cited in each `@source` comment), so the fixtures for years before each law existed are unaffected.

## Sources

Each addition cites the primary source — the official gazette (El Peruano) publication — directly above its rule in `data/countries/PE.yaml`:
- Ley 31788: https://busquedas.elperuano.pe/dispositivo/NL/2187453-1
- Ley 31822: https://busquedas.elperuano.pe/dispositivo/NL/2194316-1
- Ley 31530: https://busquedas.elperuano.pe/dispositivo/NL/2089960-2
- Ley 31381: https://busquedas.elperuano.pe/dispositivo/NL/2026913-1

## Test plan

- [x] `npm run yaml` regenerated JSON from the updated YAML
- [x] `node test/sample.js "pe" 2026` shows all 4 new holidays with correct names/notes
- [x] Verified `since <year>` boundaries: none of the 4 appear before their law's effective year (spot-checked 2021–2024)
- [x] `npx mocha test/all.mocha.js --writetests --countries PE` regenerated only PE/PE-CUS fixtures
- [x] `npm test` — full suite passes (5373 passing)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean