### PR TITLE
feat(PA): add Colón Day, National Mourning Day and Flag Day

### DIFF
--- a/data/countries/PA.yaml
+++ b/data/countries/PA.yaml
@@ -2,6 +2,7 @@ holidays:
   # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Panama
   # @attrib https://es.wikipedia.org/wiki/Anexo:Festividades_y_celebraciones#Panam.C3.A1
   # @source http://www.legalinfo-panama.com/legislacion/laboral/codtrabA1.pdf
+  # @source https://www.organojudicial.gob.pa/cendoj/documentacion-cendoj/ordenamiento-juridico/area-jurisdiccional/contencioso-administrativo/otras-leyes/ley-291-de-2022-que-adopta-medidas-de-concientizacion-nacional-sobre-el-20-de-diciembre-de-1989
   PA:
     names:
       es: Panamá
@@ -38,6 +39,16 @@ holidays:
         name:
           en: Separation Day (from Columbia)
           es: Día de la Separación (de Colombia)
+      11-04:
+        name:
+          en: Flag Day
+          es: Día de la Bandera
+        type: observance
+      11-05 and if sunday then next monday:
+        substitute: true
+        name:
+          en: Colón Day
+          es: Día de Colón
       11-10 and if sunday then next monday:
         substitute: true
         name:
@@ -48,6 +59,13 @@ holidays:
       12-08 and if sunday then next monday:
         substitute: true
         _name: Mothers Day
+      12-20 and if sunday then next monday:
+        substitute: true
+        active:
+          - from: "2022-03-31"
+        name:
+          en: National Mourning Day
+          es: Día de Duelo Nacional
       12-25 and if sunday then next monday:
         substitute: true
         _name: 12-25

--- a/test/fixtures/PA-2015.json
+++ b/test/fixtures/PA-2015.json
@@ -63,6 +63,24 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2015-11-04 00:00:00",
+    "start": "2015-11-04T05:00:00.000Z",
+    "end": "2015-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2015-11-05 00:00:00",
+    "start": "2015-11-05T05:00:00.000Z",
+    "end": "2015-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2015-11-10 00:00:00",
     "start": "2015-11-10T05:00:00.000Z",
     "end": "2015-11-11T05:00:00.000Z",

--- a/test/fixtures/PA-2016.json
+++ b/test/fixtures/PA-2016.json
@@ -73,6 +73,24 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2016-11-04 00:00:00",
+    "start": "2016-11-04T05:00:00.000Z",
+    "end": "2016-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2016-11-05 00:00:00",
+    "start": "2016-11-05T05:00:00.000Z",
+    "end": "2016-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2016-11-10 00:00:00",
     "start": "2016-11-10T05:00:00.000Z",
     "end": "2016-11-11T05:00:00.000Z",

--- a/test/fixtures/PA-2017.json
+++ b/test/fixtures/PA-2017.json
@@ -73,6 +73,34 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2017-11-04 00:00:00",
+    "start": "2017-11-04T05:00:00.000Z",
+    "end": "2017-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2017-11-05 00:00:00",
+    "start": "2017-11-05T05:00:00.000Z",
+    "end": "2017-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2017-11-06 00:00:00",
+    "start": "2017-11-06T05:00:00.000Z",
+    "end": "2017-11-07T05:00:00.000Z",
+    "name": "Día de Colón (día sustituto)",
+    "type": "public",
+    "substitute": true,
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2017-11-10 00:00:00",
     "start": "2017-11-10T05:00:00.000Z",
     "end": "2017-11-11T05:00:00.000Z",

--- a/test/fixtures/PA-2018.json
+++ b/test/fixtures/PA-2018.json
@@ -63,6 +63,24 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2018-11-04 00:00:00",
+    "start": "2018-11-04T05:00:00.000Z",
+    "end": "2018-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2018-11-05 00:00:00",
+    "start": "2018-11-05T05:00:00.000Z",
+    "end": "2018-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2018-11-10 00:00:00",
     "start": "2018-11-10T05:00:00.000Z",
     "end": "2018-11-11T05:00:00.000Z",

--- a/test/fixtures/PA-2019.json
+++ b/test/fixtures/PA-2019.json
@@ -75,11 +75,29 @@
     "date": "2019-11-04 00:00:00",
     "start": "2019-11-04T05:00:00.000Z",
     "end": "2019-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2019-11-04 00:00:00",
+    "start": "2019-11-04T05:00:00.000Z",
+    "end": "2019-11-05T05:00:00.000Z",
     "name": "Día de la Separación (de Colombia) (día sustituto)",
     "type": "public",
     "substitute": true,
     "rule": "11-03 and if sunday then next monday",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2019-11-05 00:00:00",
+    "start": "2019-11-05T05:00:00.000Z",
+    "end": "2019-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Tue"
   },
   {
     "date": "2019-11-10 00:00:00",

--- a/test/fixtures/PA-2020.json
+++ b/test/fixtures/PA-2020.json
@@ -63,6 +63,24 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2020-11-04 00:00:00",
+    "start": "2020-11-04T05:00:00.000Z",
+    "end": "2020-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2020-11-05 00:00:00",
+    "start": "2020-11-05T05:00:00.000Z",
+    "end": "2020-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2020-11-10 00:00:00",
     "start": "2020-11-10T05:00:00.000Z",
     "end": "2020-11-11T05:00:00.000Z",

--- a/test/fixtures/PA-2021.json
+++ b/test/fixtures/PA-2021.json
@@ -63,6 +63,24 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2021-11-04 00:00:00",
+    "start": "2021-11-04T05:00:00.000Z",
+    "end": "2021-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2021-11-05 00:00:00",
+    "start": "2021-11-05T05:00:00.000Z",
+    "end": "2021-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2021-11-10 00:00:00",
     "start": "2021-11-10T05:00:00.000Z",
     "end": "2021-11-11T05:00:00.000Z",

--- a/test/fixtures/PA-2022.json
+++ b/test/fixtures/PA-2022.json
@@ -83,6 +83,24 @@
     "_weekday": "Thu"
   },
   {
+    "date": "2022-11-04 00:00:00",
+    "start": "2022-11-04T05:00:00.000Z",
+    "end": "2022-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Fri"
+  },
+  {
+    "date": "2022-11-05 00:00:00",
+    "start": "2022-11-05T05:00:00.000Z",
+    "end": "2022-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Sat"
+  },
+  {
     "date": "2022-11-10 00:00:00",
     "start": "2022-11-10T05:00:00.000Z",
     "end": "2022-11-11T05:00:00.000Z",
@@ -108,6 +126,15 @@
     "type": "public",
     "rule": "12-08 and if sunday then next monday",
     "_weekday": "Thu"
+  },
+  {
+    "date": "2022-12-20 00:00:00",
+    "start": "2022-12-20T05:00:00.000Z",
+    "end": "2022-12-21T05:00:00.000Z",
+    "name": "Día de Duelo Nacional",
+    "type": "public",
+    "rule": "12-20 and if sunday then next monday",
+    "_weekday": "Tue"
   },
   {
     "date": "2022-12-25 00:00:00",

--- a/test/fixtures/PA-2023.json
+++ b/test/fixtures/PA-2023.json
@@ -73,6 +73,34 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2023-11-04 00:00:00",
+    "start": "2023-11-04T05:00:00.000Z",
+    "end": "2023-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2023-11-05 00:00:00",
+    "start": "2023-11-05T05:00:00.000Z",
+    "end": "2023-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2023-11-06 00:00:00",
+    "start": "2023-11-06T05:00:00.000Z",
+    "end": "2023-11-07T05:00:00.000Z",
+    "name": "Día de Colón (día sustituto)",
+    "type": "public",
+    "substitute": true,
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2023-11-10 00:00:00",
     "start": "2023-11-10T05:00:00.000Z",
     "end": "2023-11-11T05:00:00.000Z",
@@ -98,6 +126,15 @@
     "type": "public",
     "rule": "12-08 and if sunday then next monday",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2023-12-20 00:00:00",
+    "start": "2023-12-20T05:00:00.000Z",
+    "end": "2023-12-21T05:00:00.000Z",
+    "name": "Día de Duelo Nacional",
+    "type": "public",
+    "rule": "12-20 and if sunday then next monday",
+    "_weekday": "Wed"
   },
   {
     "date": "2023-12-25 00:00:00",

--- a/test/fixtures/PA-2024.json
+++ b/test/fixtures/PA-2024.json
@@ -75,11 +75,29 @@
     "date": "2024-11-04 00:00:00",
     "start": "2024-11-04T05:00:00.000Z",
     "end": "2024-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2024-11-04 00:00:00",
+    "start": "2024-11-04T05:00:00.000Z",
+    "end": "2024-11-05T05:00:00.000Z",
     "name": "Día de la Separación (de Colombia) (día sustituto)",
     "type": "public",
     "substitute": true,
     "rule": "11-03 and if sunday then next monday",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2024-11-05 00:00:00",
+    "start": "2024-11-05T05:00:00.000Z",
+    "end": "2024-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Tue"
   },
   {
     "date": "2024-11-10 00:00:00",
@@ -127,6 +145,15 @@
     "substitute": true,
     "rule": "12-08 and if sunday then next monday",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2024-12-20 00:00:00",
+    "start": "2024-12-20T05:00:00.000Z",
+    "end": "2024-12-21T05:00:00.000Z",
+    "name": "Día de Duelo Nacional",
+    "type": "public",
+    "rule": "12-20 and if sunday then next monday",
+    "_weekday": "Fri"
   },
   {
     "date": "2024-12-25 00:00:00",

--- a/test/fixtures/PA-2025.json
+++ b/test/fixtures/PA-2025.json
@@ -63,6 +63,24 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2025-11-04 00:00:00",
+    "start": "2025-11-04T05:00:00.000Z",
+    "end": "2025-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Tue"
+  },
+  {
+    "date": "2025-11-05 00:00:00",
+    "start": "2025-11-05T05:00:00.000Z",
+    "end": "2025-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Wed"
+  },
+  {
     "date": "2025-11-10 00:00:00",
     "start": "2025-11-10T05:00:00.000Z",
     "end": "2025-11-11T05:00:00.000Z",
@@ -88,6 +106,15 @@
     "type": "public",
     "rule": "12-08 and if sunday then next monday",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2025-12-20 00:00:00",
+    "start": "2025-12-20T05:00:00.000Z",
+    "end": "2025-12-21T05:00:00.000Z",
+    "name": "Día de Duelo Nacional",
+    "type": "public",
+    "rule": "12-20 and if sunday then next monday",
+    "_weekday": "Sat"
   },
   {
     "date": "2025-12-25 00:00:00",

--- a/test/fixtures/PA-2026.json
+++ b/test/fixtures/PA-2026.json
@@ -63,6 +63,24 @@
     "_weekday": "Tue"
   },
   {
+    "date": "2026-11-04 00:00:00",
+    "start": "2026-11-04T05:00:00.000Z",
+    "end": "2026-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Wed"
+  },
+  {
+    "date": "2026-11-05 00:00:00",
+    "start": "2026-11-05T05:00:00.000Z",
+    "end": "2026-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Thu"
+  },
+  {
     "date": "2026-11-10 00:00:00",
     "start": "2026-11-10T05:00:00.000Z",
     "end": "2026-11-11T05:00:00.000Z",
@@ -88,6 +106,25 @@
     "type": "public",
     "rule": "12-08 and if sunday then next monday",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2026-12-20 00:00:00",
+    "start": "2026-12-20T05:00:00.000Z",
+    "end": "2026-12-21T05:00:00.000Z",
+    "name": "Día de Duelo Nacional",
+    "type": "public",
+    "rule": "12-20 and if sunday then next monday",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2026-12-21 00:00:00",
+    "start": "2026-12-21T05:00:00.000Z",
+    "end": "2026-12-22T05:00:00.000Z",
+    "name": "Día de Duelo Nacional (día sustituto)",
+    "type": "public",
+    "substitute": true,
+    "rule": "12-20 and if sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2026-12-25 00:00:00",

--- a/test/fixtures/PA-2027.json
+++ b/test/fixtures/PA-2027.json
@@ -63,6 +63,24 @@
     "_weekday": "Wed"
   },
   {
+    "date": "2027-11-04 00:00:00",
+    "start": "2027-11-04T05:00:00.000Z",
+    "end": "2027-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Thu"
+  },
+  {
+    "date": "2027-11-05 00:00:00",
+    "start": "2027-11-05T05:00:00.000Z",
+    "end": "2027-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Fri"
+  },
+  {
     "date": "2027-11-10 00:00:00",
     "start": "2027-11-10T05:00:00.000Z",
     "end": "2027-11-11T05:00:00.000Z",
@@ -98,6 +116,15 @@
     "type": "public",
     "rule": "12-08 and if sunday then next monday",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2027-12-20 00:00:00",
+    "start": "2027-12-20T05:00:00.000Z",
+    "end": "2027-12-21T05:00:00.000Z",
+    "name": "Día de Duelo Nacional",
+    "type": "public",
+    "rule": "12-20 and if sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2027-12-25 00:00:00",

--- a/test/fixtures/PA-2028.json
+++ b/test/fixtures/PA-2028.json
@@ -73,6 +73,34 @@
     "_weekday": "Fri"
   },
   {
+    "date": "2028-11-04 00:00:00",
+    "start": "2028-11-04T05:00:00.000Z",
+    "end": "2028-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Sat"
+  },
+  {
+    "date": "2028-11-05 00:00:00",
+    "start": "2028-11-05T05:00:00.000Z",
+    "end": "2028-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2028-11-06 00:00:00",
+    "start": "2028-11-06T05:00:00.000Z",
+    "end": "2028-11-07T05:00:00.000Z",
+    "name": "Día de Colón (día sustituto)",
+    "type": "public",
+    "substitute": true,
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2028-11-10 00:00:00",
     "start": "2028-11-10T05:00:00.000Z",
     "end": "2028-11-11T05:00:00.000Z",
@@ -98,6 +126,15 @@
     "type": "public",
     "rule": "12-08 and if sunday then next monday",
     "_weekday": "Fri"
+  },
+  {
+    "date": "2028-12-20 00:00:00",
+    "start": "2028-12-20T05:00:00.000Z",
+    "end": "2028-12-21T05:00:00.000Z",
+    "name": "Día de Duelo Nacional",
+    "type": "public",
+    "rule": "12-20 and if sunday then next monday",
+    "_weekday": "Wed"
   },
   {
     "date": "2028-12-25 00:00:00",

--- a/test/fixtures/PA-2029.json
+++ b/test/fixtures/PA-2029.json
@@ -72,6 +72,24 @@
     "_weekday": "Sat"
   },
   {
+    "date": "2029-11-04 00:00:00",
+    "start": "2029-11-04T05:00:00.000Z",
+    "end": "2029-11-05T05:00:00.000Z",
+    "name": "Día de la Bandera",
+    "type": "observance",
+    "rule": "11-04",
+    "_weekday": "Sun"
+  },
+  {
+    "date": "2029-11-05 00:00:00",
+    "start": "2029-11-05T05:00:00.000Z",
+    "end": "2029-11-06T05:00:00.000Z",
+    "name": "Día de Colón",
+    "type": "public",
+    "rule": "11-05 and if sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
     "date": "2029-11-10 00:00:00",
     "start": "2029-11-10T05:00:00.000Z",
     "end": "2029-11-11T05:00:00.000Z",
@@ -97,6 +115,15 @@
     "type": "public",
     "rule": "12-08 and if sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2029-12-20 00:00:00",
+    "start": "2029-12-20T05:00:00.000Z",
+    "end": "2029-12-21T05:00:00.000Z",
+    "name": "Día de Duelo Nacional",
+    "type": "public",
+    "rule": "12-20 and if sunday then next monday",
+    "_weekday": "Thu"
   },
   {
     "date": "2029-12-25 00:00:00",


### PR DESCRIPTION
Fixes #524.

`PA.yaml` hadn't been touched since 2021, and three of the dates @Pepebuho listed were missing. I checked each one against the Labour Code rather than adding the list as-is:

| Date | Added as | Basis |
| --- | --- | --- |
| `11-05` Día de Colón | public, `substitute: true` | art. 46 lists "3 y 5 de noviembre" among the días de descanso obligatorio — national, not limited to Colón province |
| `12-20` Día de Duelo Nacional | public, `active: from 2022-03-31` | [Ley 291 de 2022](https://www.organojudicial.gob.pa/cendoj/documentacion-cendoj/ordenamiento-juridico/area-jurisdiccional/contencioso-administrativo/otras-leyes/ley-291-de-2022-que-adopta-medidas-de-concientizacion-nacional-sobre-el-20-de-diciembre-de-1989) adds it to art. 46, promulgated 31 March 2022 |
| `11-04` Día de la Bandera | `type: observance` | *not* in art. 46 — an ordinary working day for the private sector, even though many employers give it off |

`05-01` was also on the reporter's list but has been in the file since 2017, so it is untouched. The Sunday rule follows the file's existing convention: Ley 70 de 2007 moves the mandatory rest to the following Monday when a holiday falls on a Sunday. @Pepebuho confirmed both the `observance` classification for 11-04 and the Sunday rule for 12-20 in the issue thread.

Verification:

- `npm test` → 5373 passing
- fixtures regenerated with `mocha test/all.mocha.js --writetests --countries PA`
- year boundary holds: 2021 has no 12-20, 2022 onwards does
- 2026-12-20 falls on a Sunday, and the fixture shows the substitute on 2026-12-21

One thing I noticed but left alone: art. 46 also has a bridge rule for `01-09` and `11-28` (Tue/Wed → previous Monday, Thu/Fri → following Monday) that the file doesn't model. Happy to open a separate issue or PR for that if you want it.

<sub>Independently cross-reviewed by two AI models before submission.</sub>
