### PR TITLE
fix(IT): align holiday names with official sources

### DIFF
--- a/data/countries/IT.yaml
+++ b/data/countries/IT.yaml
@@ -1,6 +1,6 @@
 holidays:
+  # @source https://presidenza.governo.it/ufficio_cerimoniale/cerimoniale/giornate.html
   # @attrib https://de.wikipedia.org/wiki/Feiertage_in_Italien
-  # @source https://www.quirinale.it/elementi/141022
   IT:
     names:
       it: Italia
@@ -21,8 +21,8 @@ holidays:
         _name: easter 1
       04-25:
         name:
-          it: Anniversario della Liberazione
-          en: Liberation Day
+          it: Liberazione dal nazifascismo (1945)
+          en: Liberation from Nazi-Fascism (1945)
       05-01:
         _name: 05-01
       2nd sunday in May:
@@ -35,9 +35,10 @@ holidays:
       08-15:
         _name: 08-15
       10-04 since 2026:
+        # @source https://www.quirinale.it/elementi/141022
         name:
-          it: San Francesco d'Assisi
-          en: Francis of Assisi
+          it: Festa nazionale di San Francesco d'Assisi
+          en: National Day of Saint Francis of Assisi
       11-01:
         _name: 11-01
       12-08:

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -81,8 +81,7 @@ names:
       el: Θεοφάνεια
       hr: Bogojavljenje, Sveta tri kralja
       hu: Vízkereszt
-      it: Befana
-      # it: Epifania
+      it: Epifania
       is: Þrettándinn
       lb: Dräikinneksdag
       nl: Driekoningen
@@ -178,7 +177,7 @@ names:
       hu: A munka ünnepe
       hy: Աշխատանքի օր
       id: Hari Buruh Internasional
-      it: Festa del Lavoro
+      it: Festa del lavoro
       is: Hátíðisdagur Verkamanna
       lb: Éischte Mee
       lt: Tarptautinė darbo diena
@@ -249,8 +248,7 @@ names:
       fr: Assomption
       el: Κοίμηση της Θεοτόκου
       hr: Velika Gospa
-      it: Ferragosto
-      # it: Assunzione di Maria Virgine
+      it: Assunzione di Maria
       lb: Léiffrawëschdag
       lt: Žolinė
       mg: Asompsiona
@@ -401,7 +399,7 @@ names:
       hu: Karácsony
       hy: Սուրբ Ծնունդ
       id: Hari Raya Natal
-      it: Natale
+      it: Natale di Gesù
       is: Jóladagur
       jp: クリスマス
       kl: juullerujussuaq

--- a/test/fixtures/CH-TI-2015.json
+++ b/test/fixtures/CH-TI-2015.json
@@ -66,7 +66,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/CH-TI-2016.json
+++ b/test/fixtures/CH-TI-2016.json
@@ -66,7 +66,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -174,7 +174,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/CH-TI-2017.json
+++ b/test/fixtures/CH-TI-2017.json
@@ -66,7 +66,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -174,7 +174,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/CH-TI-2018.json
+++ b/test/fixtures/CH-TI-2018.json
@@ -66,7 +66,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -174,7 +174,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/CH-TI-2019.json
+++ b/test/fixtures/CH-TI-2019.json
@@ -66,7 +66,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -174,7 +174,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/CH-TI-2020.json
+++ b/test/fixtures/CH-TI-2020.json
@@ -66,7 +66,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/CH-TI-2021.json
+++ b/test/fixtures/CH-TI-2021.json
@@ -66,7 +66,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -174,7 +174,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/CH-TI-2022.json
+++ b/test/fixtures/CH-TI-2022.json
@@ -66,7 +66,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -174,7 +174,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/CH-TI-2023.json
+++ b/test/fixtures/CH-TI-2023.json
@@ -66,7 +66,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -174,7 +174,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/CH-TI-2024.json
+++ b/test/fixtures/CH-TI-2024.json
@@ -66,7 +66,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -174,7 +174,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/CH-TI-2025.json
+++ b/test/fixtures/CH-TI-2025.json
@@ -66,7 +66,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -174,7 +174,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/CH-TI-2026.json
+++ b/test/fixtures/CH-TI-2026.json
@@ -66,7 +66,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/CH-TI-2027.json
+++ b/test/fixtures/CH-TI-2027.json
@@ -66,7 +66,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -174,7 +174,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/CH-TI-2028.json
+++ b/test/fixtures/CH-TI-2028.json
@@ -66,7 +66,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -174,7 +174,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/CH-TI-2029.json
+++ b/test/fixtures/CH-TI-2029.json
@@ -66,7 +66,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -174,7 +174,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-2015.json
+++ b/test/fixtures/IT-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-2016.json
+++ b/test/fixtures/IT-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-2017.json
+++ b/test/fixtures/IT-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-2018.json
+++ b/test/fixtures/IT-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -102,7 +102,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-2019.json
+++ b/test/fixtures/IT-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-2020.json
+++ b/test/fixtures/IT-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-2021.json
+++ b/test/fixtures/IT-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-2022.json
+++ b/test/fixtures/IT-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-2023.json
+++ b/test/fixtures/IT-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-2024.json
+++ b/test/fixtures/IT-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-2025.json
+++ b/test/fixtures/IT-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -102,7 +102,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-2026.json
+++ b/test/fixtures/IT-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-2027.json
+++ b/test/fixtures/IT-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-2028.json
+++ b/test/fixtures/IT-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -111,7 +111,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-2029.json
+++ b/test/fixtures/IT-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -111,7 +111,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-21-2015.json
+++ b/test/fixtures/IT-21-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-21-2016.json
+++ b/test/fixtures/IT-21-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-21-2017.json
+++ b/test/fixtures/IT-21-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-21-2018.json
+++ b/test/fixtures/IT-21-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -102,7 +102,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-21-2019.json
+++ b/test/fixtures/IT-21-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-21-2020.json
+++ b/test/fixtures/IT-21-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-21-2021.json
+++ b/test/fixtures/IT-21-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-21-2022.json
+++ b/test/fixtures/IT-21-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-21-2023.json
+++ b/test/fixtures/IT-21-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-21-2024.json
+++ b/test/fixtures/IT-21-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-21-2025.json
+++ b/test/fixtures/IT-21-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -102,7 +102,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-21-2026.json
+++ b/test/fixtures/IT-21-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-21-2027.json
+++ b/test/fixtures/IT-21-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-21-2028.json
+++ b/test/fixtures/IT-21-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -111,7 +111,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-21-2029.json
+++ b/test/fixtures/IT-21-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -111,7 +111,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-21-TO-2015.json
+++ b/test/fixtures/IT-21-TO-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -112,7 +112,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-21-TO-2016.json
+++ b/test/fixtures/IT-21-TO-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -85,7 +85,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-21-TO-2017.json
+++ b/test/fixtures/IT-21-TO-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -112,7 +112,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-21-TO-2018.json
+++ b/test/fixtures/IT-21-TO-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -85,7 +85,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -112,7 +112,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-21-TO-2019.json
+++ b/test/fixtures/IT-21-TO-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -85,7 +85,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -112,7 +112,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-21-TO-2020.json
+++ b/test/fixtures/IT-21-TO-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -112,7 +112,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-21-TO-2021.json
+++ b/test/fixtures/IT-21-TO-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -85,7 +85,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -112,7 +112,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-21-TO-2022.json
+++ b/test/fixtures/IT-21-TO-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -85,7 +85,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-21-TO-2023.json
+++ b/test/fixtures/IT-21-TO-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -112,7 +112,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-21-TO-2024.json
+++ b/test/fixtures/IT-21-TO-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -85,7 +85,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -112,7 +112,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-21-TO-2025.json
+++ b/test/fixtures/IT-21-TO-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -85,7 +85,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -112,7 +112,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-21-TO-2026.json
+++ b/test/fixtures/IT-21-TO-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -94,7 +94,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -121,7 +121,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-21-TO-2027.json
+++ b/test/fixtures/IT-21-TO-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -85,7 +85,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -94,7 +94,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -121,7 +121,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-21-TO-2028.json
+++ b/test/fixtures/IT-21-TO-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -94,7 +94,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -121,7 +121,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-21-TO-2029.json
+++ b/test/fixtures/IT-21-TO-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -85,7 +85,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -94,7 +94,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -121,7 +121,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-25-2015.json
+++ b/test/fixtures/IT-25-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-25-2016.json
+++ b/test/fixtures/IT-25-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-25-2017.json
+++ b/test/fixtures/IT-25-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-25-2018.json
+++ b/test/fixtures/IT-25-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -102,7 +102,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-25-2019.json
+++ b/test/fixtures/IT-25-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-25-2020.json
+++ b/test/fixtures/IT-25-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-25-2021.json
+++ b/test/fixtures/IT-25-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-25-2022.json
+++ b/test/fixtures/IT-25-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-25-2023.json
+++ b/test/fixtures/IT-25-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-25-2024.json
+++ b/test/fixtures/IT-25-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-25-2025.json
+++ b/test/fixtures/IT-25-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -102,7 +102,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-25-2026.json
+++ b/test/fixtures/IT-25-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-25-2027.json
+++ b/test/fixtures/IT-25-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-25-2028.json
+++ b/test/fixtures/IT-25-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -111,7 +111,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-25-2029.json
+++ b/test/fixtures/IT-25-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -111,7 +111,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-25-MI-2015.json
+++ b/test/fixtures/IT-25-MI-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -112,7 +112,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-25-MI-2016.json
+++ b/test/fixtures/IT-25-MI-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-25-MI-2017.json
+++ b/test/fixtures/IT-25-MI-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -112,7 +112,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-25-MI-2018.json
+++ b/test/fixtures/IT-25-MI-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -112,7 +112,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-25-MI-2019.json
+++ b/test/fixtures/IT-25-MI-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -112,7 +112,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-25-MI-2020.json
+++ b/test/fixtures/IT-25-MI-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -112,7 +112,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-25-MI-2021.json
+++ b/test/fixtures/IT-25-MI-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -112,7 +112,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-25-MI-2022.json
+++ b/test/fixtures/IT-25-MI-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-25-MI-2023.json
+++ b/test/fixtures/IT-25-MI-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -112,7 +112,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-25-MI-2024.json
+++ b/test/fixtures/IT-25-MI-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -112,7 +112,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-25-MI-2025.json
+++ b/test/fixtures/IT-25-MI-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -112,7 +112,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-25-MI-2026.json
+++ b/test/fixtures/IT-25-MI-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -121,7 +121,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-25-MI-2027.json
+++ b/test/fixtures/IT-25-MI-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -121,7 +121,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-25-MI-2028.json
+++ b/test/fixtures/IT-25-MI-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -121,7 +121,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-25-MI-2029.json
+++ b/test/fixtures/IT-25-MI-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -121,7 +121,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-32-2015.json
+++ b/test/fixtures/IT-32-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -84,7 +84,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -111,7 +111,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-32-2016.json
+++ b/test/fixtures/IT-32-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-32-2017.json
+++ b/test/fixtures/IT-32-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -84,7 +84,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -111,7 +111,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-32-2018.json
+++ b/test/fixtures/IT-32-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -111,7 +111,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-32-2019.json
+++ b/test/fixtures/IT-32-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -111,7 +111,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-32-2020.json
+++ b/test/fixtures/IT-32-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -84,7 +84,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -111,7 +111,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-32-2021.json
+++ b/test/fixtures/IT-32-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-32-2022.json
+++ b/test/fixtures/IT-32-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-32-2023.json
+++ b/test/fixtures/IT-32-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -84,7 +84,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -111,7 +111,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-32-2024.json
+++ b/test/fixtures/IT-32-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -111,7 +111,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-32-2025.json
+++ b/test/fixtures/IT-32-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -111,7 +111,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-32-2026.json
+++ b/test/fixtures/IT-32-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -84,7 +84,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -120,7 +120,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-32-2027.json
+++ b/test/fixtures/IT-32-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -93,7 +93,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -120,7 +120,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-32-2028.json
+++ b/test/fixtures/IT-32-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -84,7 +84,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -93,7 +93,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -120,7 +120,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-32-2029.json
+++ b/test/fixtures/IT-32-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -93,7 +93,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -120,7 +120,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-52-2015.json
+++ b/test/fixtures/IT-52-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-52-2016.json
+++ b/test/fixtures/IT-52-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-52-2017.json
+++ b/test/fixtures/IT-52-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-52-2018.json
+++ b/test/fixtures/IT-52-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -102,7 +102,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-52-2019.json
+++ b/test/fixtures/IT-52-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-52-2020.json
+++ b/test/fixtures/IT-52-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-52-2021.json
+++ b/test/fixtures/IT-52-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-52-2022.json
+++ b/test/fixtures/IT-52-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-52-2023.json
+++ b/test/fixtures/IT-52-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-52-2024.json
+++ b/test/fixtures/IT-52-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-52-2025.json
+++ b/test/fixtures/IT-52-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -102,7 +102,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-52-2026.json
+++ b/test/fixtures/IT-52-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-52-2027.json
+++ b/test/fixtures/IT-52-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-52-2028.json
+++ b/test/fixtures/IT-52-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -111,7 +111,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-52-2029.json
+++ b/test/fixtures/IT-52-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -111,7 +111,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-52-FI-2015.json
+++ b/test/fixtures/IT-52-FI-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -112,7 +112,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-52-FI-2016.json
+++ b/test/fixtures/IT-52-FI-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -85,7 +85,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-52-FI-2017.json
+++ b/test/fixtures/IT-52-FI-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -112,7 +112,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-52-FI-2018.json
+++ b/test/fixtures/IT-52-FI-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -85,7 +85,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -112,7 +112,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-52-FI-2019.json
+++ b/test/fixtures/IT-52-FI-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -85,7 +85,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -112,7 +112,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-52-FI-2020.json
+++ b/test/fixtures/IT-52-FI-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -112,7 +112,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-52-FI-2021.json
+++ b/test/fixtures/IT-52-FI-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -85,7 +85,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -112,7 +112,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-52-FI-2022.json
+++ b/test/fixtures/IT-52-FI-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -85,7 +85,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-52-FI-2023.json
+++ b/test/fixtures/IT-52-FI-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -112,7 +112,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-52-FI-2024.json
+++ b/test/fixtures/IT-52-FI-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -85,7 +85,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -112,7 +112,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-52-FI-2025.json
+++ b/test/fixtures/IT-52-FI-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -85,7 +85,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -112,7 +112,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-52-FI-2026.json
+++ b/test/fixtures/IT-52-FI-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -94,7 +94,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -121,7 +121,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-52-FI-2027.json
+++ b/test/fixtures/IT-52-FI-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -85,7 +85,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -94,7 +94,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -121,7 +121,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-52-FI-2028.json
+++ b/test/fixtures/IT-52-FI-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -94,7 +94,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -121,7 +121,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-52-FI-2029.json
+++ b/test/fixtures/IT-52-FI-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -85,7 +85,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -94,7 +94,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -121,7 +121,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-62-2015.json
+++ b/test/fixtures/IT-62-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-62-2016.json
+++ b/test/fixtures/IT-62-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-62-2017.json
+++ b/test/fixtures/IT-62-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-62-2018.json
+++ b/test/fixtures/IT-62-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -102,7 +102,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-62-2019.json
+++ b/test/fixtures/IT-62-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-62-2020.json
+++ b/test/fixtures/IT-62-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-62-2021.json
+++ b/test/fixtures/IT-62-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-62-2022.json
+++ b/test/fixtures/IT-62-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-62-2023.json
+++ b/test/fixtures/IT-62-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-62-2024.json
+++ b/test/fixtures/IT-62-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-62-2025.json
+++ b/test/fixtures/IT-62-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -102,7 +102,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-62-2026.json
+++ b/test/fixtures/IT-62-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-62-2027.json
+++ b/test/fixtures/IT-62-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-62-2028.json
+++ b/test/fixtures/IT-62-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -111,7 +111,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-62-2029.json
+++ b/test/fixtures/IT-62-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -111,7 +111,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-62-RM-2015.json
+++ b/test/fixtures/IT-62-RM-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -112,7 +112,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-62-RM-2016.json
+++ b/test/fixtures/IT-62-RM-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -85,7 +85,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-62-RM-2017.json
+++ b/test/fixtures/IT-62-RM-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -112,7 +112,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-62-RM-2018.json
+++ b/test/fixtures/IT-62-RM-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -85,7 +85,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -112,7 +112,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-62-RM-2019.json
+++ b/test/fixtures/IT-62-RM-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -85,7 +85,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -112,7 +112,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-62-RM-2020.json
+++ b/test/fixtures/IT-62-RM-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -112,7 +112,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-62-RM-2021.json
+++ b/test/fixtures/IT-62-RM-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -85,7 +85,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -112,7 +112,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-62-RM-2022.json
+++ b/test/fixtures/IT-62-RM-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -85,7 +85,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-62-RM-2023.json
+++ b/test/fixtures/IT-62-RM-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -112,7 +112,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-62-RM-2024.json
+++ b/test/fixtures/IT-62-RM-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -85,7 +85,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -112,7 +112,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-62-RM-2025.json
+++ b/test/fixtures/IT-62-RM-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -85,7 +85,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -112,7 +112,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-62-RM-2026.json
+++ b/test/fixtures/IT-62-RM-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -94,7 +94,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -121,7 +121,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-62-RM-2027.json
+++ b/test/fixtures/IT-62-RM-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -85,7 +85,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -94,7 +94,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -121,7 +121,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-62-RM-2028.json
+++ b/test/fixtures/IT-62-RM-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -94,7 +94,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -121,7 +121,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-62-RM-2029.json
+++ b/test/fixtures/IT-62-RM-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -85,7 +85,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -94,7 +94,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -121,7 +121,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-82-2015.json
+++ b/test/fixtures/IT-82-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-82-2016.json
+++ b/test/fixtures/IT-82-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-82-2017.json
+++ b/test/fixtures/IT-82-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-82-2018.json
+++ b/test/fixtures/IT-82-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -102,7 +102,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-82-2019.json
+++ b/test/fixtures/IT-82-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-82-2020.json
+++ b/test/fixtures/IT-82-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-82-2021.json
+++ b/test/fixtures/IT-82-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-82-2022.json
+++ b/test/fixtures/IT-82-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-82-2023.json
+++ b/test/fixtures/IT-82-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-82-2024.json
+++ b/test/fixtures/IT-82-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-82-2025.json
+++ b/test/fixtures/IT-82-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -102,7 +102,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-82-2026.json
+++ b/test/fixtures/IT-82-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -75,7 +75,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-82-2027.json
+++ b/test/fixtures/IT-82-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -75,7 +75,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-82-2028.json
+++ b/test/fixtures/IT-82-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -111,7 +111,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-82-2029.json
+++ b/test/fixtures/IT-82-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -75,7 +75,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -111,7 +111,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-82-PA-2015.json
+++ b/test/fixtures/IT-82-PA-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2015-04-25 00:00:00",
     "start": "2015-04-24T22:00:00.000Z",
     "end": "2015-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -112,7 +112,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-82-PA-2016.json
+++ b/test/fixtures/IT-82-PA-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2016-04-25 00:00:00",
     "start": "2016-04-24T22:00:00.000Z",
     "end": "2016-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -85,7 +85,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-82-PA-2017.json
+++ b/test/fixtures/IT-82-PA-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2017-04-25 00:00:00",
     "start": "2017-04-24T22:00:00.000Z",
     "end": "2017-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -112,7 +112,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-82-PA-2018.json
+++ b/test/fixtures/IT-82-PA-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2018-04-25 00:00:00",
     "start": "2018-04-24T22:00:00.000Z",
     "end": "2018-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -85,7 +85,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -112,7 +112,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/IT-82-PA-2019.json
+++ b/test/fixtures/IT-82-PA-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sun"
@@ -39,7 +39,7 @@
     "date": "2019-04-25 00:00:00",
     "start": "2019-04-24T22:00:00.000Z",
     "end": "2019-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -85,7 +85,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -112,7 +112,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-82-PA-2020.json
+++ b/test/fixtures/IT-82-PA-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2020-04-25 00:00:00",
     "start": "2020-04-24T22:00:00.000Z",
     "end": "2020-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -112,7 +112,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-82-PA-2021.json
+++ b/test/fixtures/IT-82-PA-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2021-04-25 00:00:00",
     "start": "2021-04-24T22:00:00.000Z",
     "end": "2021-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -85,7 +85,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -112,7 +112,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-82-PA-2022.json
+++ b/test/fixtures/IT-82-PA-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T22:00:00.000Z",
     "end": "2022-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -85,7 +85,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/IT-82-PA-2023.json
+++ b/test/fixtures/IT-82-PA-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2023-04-25 00:00:00",
     "start": "2023-04-24T22:00:00.000Z",
     "end": "2023-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -112,7 +112,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-82-PA-2024.json
+++ b/test/fixtures/IT-82-PA-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2024-04-25 00:00:00",
     "start": "2024-04-24T22:00:00.000Z",
     "end": "2024-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -85,7 +85,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -112,7 +112,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/IT-82-PA-2025.json
+++ b/test/fixtures/IT-82-PA-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Mon"
@@ -39,7 +39,7 @@
     "date": "2025-04-25 00:00:00",
     "start": "2025-04-24T22:00:00.000Z",
     "end": "2025-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -85,7 +85,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -112,7 +112,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/IT-82-PA-2026.json
+++ b/test/fixtures/IT-82-PA-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Tue"
@@ -39,7 +39,7 @@
     "date": "2026-04-25 00:00:00",
     "start": "2026-04-24T22:00:00.000Z",
     "end": "2026-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -85,7 +85,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -94,7 +94,7 @@
     "date": "2026-10-04 00:00:00",
     "start": "2026-10-03T22:00:00.000Z",
     "end": "2026-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Sun"
@@ -121,7 +121,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/IT-82-PA-2027.json
+++ b/test/fixtures/IT-82-PA-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Wed"
@@ -39,7 +39,7 @@
     "date": "2027-04-25 00:00:00",
     "start": "2027-04-24T22:00:00.000Z",
     "end": "2027-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -85,7 +85,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -94,7 +94,7 @@
     "date": "2027-10-04 00:00:00",
     "start": "2027-10-03T22:00:00.000Z",
     "end": "2027-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Mon"
@@ -121,7 +121,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/IT-82-PA-2028.json
+++ b/test/fixtures/IT-82-PA-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2028-04-25 00:00:00",
     "start": "2028-04-24T22:00:00.000Z",
     "end": "2028-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -85,7 +85,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -94,7 +94,7 @@
     "date": "2028-10-04 00:00:00",
     "start": "2028-10-03T22:00:00.000Z",
     "end": "2028-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Wed"
@@ -121,7 +121,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/IT-82-PA-2029.json
+++ b/test/fixtures/IT-82-PA-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "Befana",
+    "name": "Epifania",
     "type": "public",
     "rule": "01-06",
     "_weekday": "Sat"
@@ -39,7 +39,7 @@
     "date": "2029-04-25 00:00:00",
     "start": "2029-04-24T22:00:00.000Z",
     "end": "2029-04-25T22:00:00.000Z",
-    "name": "Anniversario della Liberazione",
+    "name": "Liberazione dal nazifascismo (1945)",
     "type": "public",
     "rule": "04-25",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -85,7 +85,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -94,7 +94,7 @@
     "date": "2029-10-04 00:00:00",
     "start": "2029-10-03T22:00:00.000Z",
     "end": "2029-10-04T22:00:00.000Z",
-    "name": "San Francesco d'Assisi",
+    "name": "Festa nazionale di San Francesco d'Assisi",
     "type": "public",
     "rule": "10-04 since 2026",
     "_weekday": "Thu"
@@ -121,7 +121,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/SM-2015.json
+++ b/test/fixtures/SM-2015.json
@@ -66,7 +66,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -102,7 +102,7 @@
     "date": "2015-08-15 00:00:00",
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -156,7 +156,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/SM-2016.json
+++ b/test/fixtures/SM-2016.json
@@ -66,7 +66,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2016-08-15 00:00:00",
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -156,7 +156,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/SM-2017.json
+++ b/test/fixtures/SM-2017.json
@@ -66,7 +66,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2017-08-15 00:00:00",
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -156,7 +156,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/SM-2018.json
+++ b/test/fixtures/SM-2018.json
@@ -66,7 +66,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2018-08-15 00:00:00",
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -156,7 +156,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/SM-2019.json
+++ b/test/fixtures/SM-2019.json
@@ -66,7 +66,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -102,7 +102,7 @@
     "date": "2019-08-15 00:00:00",
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -156,7 +156,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/SM-2020.json
+++ b/test/fixtures/SM-2020.json
@@ -66,7 +66,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -102,7 +102,7 @@
     "date": "2020-08-15 00:00:00",
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -156,7 +156,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/SM-2021.json
+++ b/test/fixtures/SM-2021.json
@@ -66,7 +66,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2021-08-15 00:00:00",
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/SM-2022.json
+++ b/test/fixtures/SM-2022.json
@@ -66,7 +66,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2022-08-15 00:00:00",
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
@@ -156,7 +156,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/SM-2023.json
+++ b/test/fixtures/SM-2023.json
@@ -66,7 +66,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2023-08-15 00:00:00",
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -156,7 +156,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/SM-2024.json
+++ b/test/fixtures/SM-2024.json
@@ -66,7 +66,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -102,7 +102,7 @@
     "date": "2024-08-15 00:00:00",
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
@@ -156,7 +156,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/SM-2025.json
+++ b/test/fixtures/SM-2025.json
@@ -66,7 +66,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2025-08-15 00:00:00",
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
@@ -156,7 +156,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/SM-2026.json
+++ b/test/fixtures/SM-2026.json
@@ -66,7 +66,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -102,7 +102,7 @@
     "date": "2026-08-15 00:00:00",
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
@@ -156,7 +156,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/SM-2027.json
+++ b/test/fixtures/SM-2027.json
@@ -66,7 +66,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2027-08-15 00:00:00",
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/SM-2028.json
+++ b/test/fixtures/SM-2028.json
@@ -66,7 +66,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2028-08-15 00:00:00",
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
@@ -156,7 +156,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/SM-2029.json
+++ b/test/fixtures/SM-2029.json
@@ -66,7 +66,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Festa del Lavoro",
+    "name": "Festa del lavoro",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2029-08-15 00:00:00",
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
-    "name": "Ferragosto",
+    "name": "Assunzione di Maria",
     "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
@@ -156,7 +156,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/VA-2015.json
+++ b/test/fixtures/VA-2015.json
@@ -211,7 +211,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/VA-2016.json
+++ b/test/fixtures/VA-2016.json
@@ -211,7 +211,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/VA-2017.json
+++ b/test/fixtures/VA-2017.json
@@ -211,7 +211,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/VA-2018.json
+++ b/test/fixtures/VA-2018.json
@@ -211,7 +211,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"

--- a/test/fixtures/VA-2019.json
+++ b/test/fixtures/VA-2019.json
@@ -211,7 +211,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/VA-2020.json
+++ b/test/fixtures/VA-2020.json
@@ -211,7 +211,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/VA-2021.json
+++ b/test/fixtures/VA-2021.json
@@ -211,7 +211,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/VA-2022.json
+++ b/test/fixtures/VA-2022.json
@@ -211,7 +211,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"

--- a/test/fixtures/VA-2023.json
+++ b/test/fixtures/VA-2023.json
@@ -211,7 +211,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/VA-2024.json
+++ b/test/fixtures/VA-2024.json
@@ -211,7 +211,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"

--- a/test/fixtures/VA-2025.json
+++ b/test/fixtures/VA-2025.json
@@ -221,7 +221,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"

--- a/test/fixtures/VA-2026.json
+++ b/test/fixtures/VA-2026.json
@@ -211,7 +211,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"

--- a/test/fixtures/VA-2027.json
+++ b/test/fixtures/VA-2027.json
@@ -211,7 +211,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"

--- a/test/fixtures/VA-2028.json
+++ b/test/fixtures/VA-2028.json
@@ -211,7 +211,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"

--- a/test/fixtures/VA-2029.json
+++ b/test/fixtures/VA-2029.json
@@ -211,7 +211,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Natale",
+    "name": "Natale di Gesù",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"


### PR DESCRIPTION
Updated the Italian holiday names to match the official terminology used by the Italian government: https://presidenza.governo.it/ufficio_cerimoniale/cerimoniale/giornate.html