### PR TITLE
fix(FR): normalize French holiday apostrophes

### DIFF
--- a/data/countries/MF.yaml
+++ b/data/countries/MF.yaml
@@ -13,6 +13,4 @@ holidays:
     _days: FR
     days:
       05-27:
-        name:
-          fr: Abolition de l'esclavage
-          en: abolition of slavery
+        _name: Abolition of Slavery

--- a/data/countries/PF.yaml
+++ b/data/countries/PF.yaml
@@ -13,19 +13,19 @@ holidays:
     days:
       03-05:
         name:
-          fr: Arrivée de l'Évangile
+          fr: Arrivée de l’Évangile
           en: Missionary Day
       easter -2:
         _name: easter -2
       06-29:
         name:
-          fr: Fête de l'Autonomie
+          fr: Fête de l’Autonomie
           en: Internal Autonomy Day
         active:
           - to: "2026-01-01"
       11-20:
         name:
-          fr: Matari'i
+          fr: Matari’i
           en: Maori New Year
         active:
           - from: "2026-01-01"

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -77,7 +77,7 @@ names:
       # es: Epifanía del Señor
       et: kolmekuningapäev
       fi: loppiainen
-      fr: l'Épiphanie
+      fr: l’Épiphanie
       el: Θεοφάνεια
       hr: Bogojavljenje, Sveta tri kralja
       hu: Vízkereszt
@@ -214,7 +214,7 @@ names:
       es: Día de Europa
       et: Euroopa päev
       fi: Eurooppa-päivä
-      fr: Journée de l'Europe
+      fr: Journée de l’Europe
       ga: Lá na hEorpa
       hr: Dan Europe
       hu: Európa-nap
@@ -1068,7 +1068,7 @@ names:
       et: iseseisvuspäev
       fi: itsenäisyyspäivä
       fil: Araw ng Kalayaan
-      fr: Jour de l'Indépendance
+      fr: Jour de l’Indépendance
       hr: Dan neovisnosti
       hy: Անկախության օր
       id: Hari Ulang Tahun Kemerdekaan Republik Indonesia

--- a/test/fixtures/BE-2015.json
+++ b/test/fixtures/BE-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Tue"

--- a/test/fixtures/BE-2016.json
+++ b/test/fixtures/BE-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Wed"

--- a/test/fixtures/BE-2017.json
+++ b/test/fixtures/BE-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Fri"

--- a/test/fixtures/BE-2018.json
+++ b/test/fixtures/BE-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sat"

--- a/test/fixtures/BE-2019.json
+++ b/test/fixtures/BE-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sun"

--- a/test/fixtures/BE-2020.json
+++ b/test/fixtures/BE-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Mon"

--- a/test/fixtures/BE-2021.json
+++ b/test/fixtures/BE-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Wed"

--- a/test/fixtures/BE-2022.json
+++ b/test/fixtures/BE-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Thu"

--- a/test/fixtures/BE-2023.json
+++ b/test/fixtures/BE-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Fri"

--- a/test/fixtures/BE-2024.json
+++ b/test/fixtures/BE-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sat"

--- a/test/fixtures/BE-2025.json
+++ b/test/fixtures/BE-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Mon"

--- a/test/fixtures/BE-2026.json
+++ b/test/fixtures/BE-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Tue"

--- a/test/fixtures/BE-2027.json
+++ b/test/fixtures/BE-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Wed"

--- a/test/fixtures/BE-2028.json
+++ b/test/fixtures/BE-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Thu"

--- a/test/fixtures/BE-2029.json
+++ b/test/fixtures/BE-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sat"

--- a/test/fixtures/BE-BRU-2015.json
+++ b/test/fixtures/BE-BRU-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Tue"

--- a/test/fixtures/BE-BRU-2016.json
+++ b/test/fixtures/BE-BRU-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Wed"

--- a/test/fixtures/BE-BRU-2017.json
+++ b/test/fixtures/BE-BRU-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Fri"

--- a/test/fixtures/BE-BRU-2018.json
+++ b/test/fixtures/BE-BRU-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sat"

--- a/test/fixtures/BE-BRU-2019.json
+++ b/test/fixtures/BE-BRU-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sun"

--- a/test/fixtures/BE-BRU-2020.json
+++ b/test/fixtures/BE-BRU-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Mon"

--- a/test/fixtures/BE-BRU-2021.json
+++ b/test/fixtures/BE-BRU-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Wed"

--- a/test/fixtures/BE-BRU-2022.json
+++ b/test/fixtures/BE-BRU-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Thu"

--- a/test/fixtures/BE-BRU-2023.json
+++ b/test/fixtures/BE-BRU-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Fri"

--- a/test/fixtures/BE-BRU-2024.json
+++ b/test/fixtures/BE-BRU-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sat"

--- a/test/fixtures/BE-BRU-2025.json
+++ b/test/fixtures/BE-BRU-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Mon"

--- a/test/fixtures/BE-BRU-2026.json
+++ b/test/fixtures/BE-BRU-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Tue"

--- a/test/fixtures/BE-BRU-2027.json
+++ b/test/fixtures/BE-BRU-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Wed"

--- a/test/fixtures/BE-BRU-2028.json
+++ b/test/fixtures/BE-BRU-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Thu"

--- a/test/fixtures/BE-BRU-2029.json
+++ b/test/fixtures/BE-BRU-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sat"

--- a/test/fixtures/BE-WAL-2015.json
+++ b/test/fixtures/BE-WAL-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-06 00:00:00",
     "start": "2015-01-05T23:00:00.000Z",
     "end": "2015-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Tue"

--- a/test/fixtures/BE-WAL-2016.json
+++ b/test/fixtures/BE-WAL-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-06 00:00:00",
     "start": "2016-01-05T23:00:00.000Z",
     "end": "2016-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Wed"

--- a/test/fixtures/BE-WAL-2017.json
+++ b/test/fixtures/BE-WAL-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-06 00:00:00",
     "start": "2017-01-05T23:00:00.000Z",
     "end": "2017-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Fri"

--- a/test/fixtures/BE-WAL-2018.json
+++ b/test/fixtures/BE-WAL-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-06 00:00:00",
     "start": "2018-01-05T23:00:00.000Z",
     "end": "2018-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sat"

--- a/test/fixtures/BE-WAL-2019.json
+++ b/test/fixtures/BE-WAL-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-06 00:00:00",
     "start": "2019-01-05T23:00:00.000Z",
     "end": "2019-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sun"

--- a/test/fixtures/BE-WAL-2020.json
+++ b/test/fixtures/BE-WAL-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-06 00:00:00",
     "start": "2020-01-05T23:00:00.000Z",
     "end": "2020-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Mon"

--- a/test/fixtures/BE-WAL-2021.json
+++ b/test/fixtures/BE-WAL-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-06 00:00:00",
     "start": "2021-01-05T23:00:00.000Z",
     "end": "2021-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Wed"

--- a/test/fixtures/BE-WAL-2022.json
+++ b/test/fixtures/BE-WAL-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-06 00:00:00",
     "start": "2022-01-05T23:00:00.000Z",
     "end": "2022-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Thu"

--- a/test/fixtures/BE-WAL-2023.json
+++ b/test/fixtures/BE-WAL-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-06 00:00:00",
     "start": "2023-01-05T23:00:00.000Z",
     "end": "2023-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Fri"

--- a/test/fixtures/BE-WAL-2024.json
+++ b/test/fixtures/BE-WAL-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-06 00:00:00",
     "start": "2024-01-05T23:00:00.000Z",
     "end": "2024-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sat"

--- a/test/fixtures/BE-WAL-2025.json
+++ b/test/fixtures/BE-WAL-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-06 00:00:00",
     "start": "2025-01-05T23:00:00.000Z",
     "end": "2025-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Mon"

--- a/test/fixtures/BE-WAL-2026.json
+++ b/test/fixtures/BE-WAL-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-06 00:00:00",
     "start": "2026-01-05T23:00:00.000Z",
     "end": "2026-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Tue"

--- a/test/fixtures/BE-WAL-2027.json
+++ b/test/fixtures/BE-WAL-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-06 00:00:00",
     "start": "2027-01-05T23:00:00.000Z",
     "end": "2027-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Wed"

--- a/test/fixtures/BE-WAL-2028.json
+++ b/test/fixtures/BE-WAL-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-06 00:00:00",
     "start": "2028-01-05T23:00:00.000Z",
     "end": "2028-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Thu"

--- a/test/fixtures/BE-WAL-2029.json
+++ b/test/fixtures/BE-WAL-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-06 00:00:00",
     "start": "2029-01-05T23:00:00.000Z",
     "end": "2029-01-06T23:00:00.000Z",
-    "name": "l'Épiphanie",
+    "name": "l’Épiphanie",
     "type": "observance",
     "rule": "01-06",
     "_weekday": "Sat"

--- a/test/fixtures/BF-2015.json
+++ b/test/fixtures/BF-2015.json
@@ -93,7 +93,7 @@
     "date": "2015-08-05 00:00:00",
     "start": "2015-08-05T00:00:00.000Z",
     "end": "2015-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Wed"

--- a/test/fixtures/BF-2016.json
+++ b/test/fixtures/BF-2016.json
@@ -84,7 +84,7 @@
     "date": "2016-08-05 00:00:00",
     "start": "2016-08-05T00:00:00.000Z",
     "end": "2016-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Fri"

--- a/test/fixtures/BF-2017.json
+++ b/test/fixtures/BF-2017.json
@@ -84,7 +84,7 @@
     "date": "2017-08-05 00:00:00",
     "start": "2017-08-05T00:00:00.000Z",
     "end": "2017-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Sat"

--- a/test/fixtures/BF-2018.json
+++ b/test/fixtures/BF-2018.json
@@ -84,7 +84,7 @@
     "date": "2018-08-05 00:00:00",
     "start": "2018-08-05T00:00:00.000Z",
     "end": "2018-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Sun"

--- a/test/fixtures/BF-2019.json
+++ b/test/fixtures/BF-2019.json
@@ -84,7 +84,7 @@
     "date": "2019-08-05 00:00:00",
     "start": "2019-08-05T00:00:00.000Z",
     "end": "2019-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Mon"

--- a/test/fixtures/BF-2020.json
+++ b/test/fixtures/BF-2020.json
@@ -93,7 +93,7 @@
     "date": "2020-08-05 00:00:00",
     "start": "2020-08-05T00:00:00.000Z",
     "end": "2020-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Wed"

--- a/test/fixtures/BF-2021.json
+++ b/test/fixtures/BF-2021.json
@@ -93,7 +93,7 @@
     "date": "2021-08-05 00:00:00",
     "start": "2021-08-05T00:00:00.000Z",
     "end": "2021-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Thu"

--- a/test/fixtures/BF-2022.json
+++ b/test/fixtures/BF-2022.json
@@ -93,7 +93,7 @@
     "date": "2022-08-05 00:00:00",
     "start": "2022-08-05T00:00:00.000Z",
     "end": "2022-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Fri"

--- a/test/fixtures/BF-2023.json
+++ b/test/fixtures/BF-2023.json
@@ -93,7 +93,7 @@
     "date": "2023-08-05 00:00:00",
     "start": "2023-08-05T00:00:00.000Z",
     "end": "2023-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Sat"

--- a/test/fixtures/BF-2024.json
+++ b/test/fixtures/BF-2024.json
@@ -93,7 +93,7 @@
     "date": "2024-08-05 00:00:00",
     "start": "2024-08-05T00:00:00.000Z",
     "end": "2024-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Mon"

--- a/test/fixtures/BF-2025.json
+++ b/test/fixtures/BF-2025.json
@@ -93,7 +93,7 @@
     "date": "2025-08-05 00:00:00",
     "start": "2025-08-05T00:00:00.000Z",
     "end": "2025-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Tue"

--- a/test/fixtures/BF-2026.json
+++ b/test/fixtures/BF-2026.json
@@ -93,7 +93,7 @@
     "date": "2026-08-05 00:00:00",
     "start": "2026-08-05T00:00:00.000Z",
     "end": "2026-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Wed"

--- a/test/fixtures/BF-2027.json
+++ b/test/fixtures/BF-2027.json
@@ -93,7 +93,7 @@
     "date": "2027-08-05 00:00:00",
     "start": "2027-08-05T00:00:00.000Z",
     "end": "2027-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Thu"

--- a/test/fixtures/BF-2028.json
+++ b/test/fixtures/BF-2028.json
@@ -102,7 +102,7 @@
     "date": "2028-08-05 00:00:00",
     "start": "2028-08-05T00:00:00.000Z",
     "end": "2028-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Sat"

--- a/test/fixtures/BF-2029.json
+++ b/test/fixtures/BF-2029.json
@@ -102,7 +102,7 @@
     "date": "2029-08-05 00:00:00",
     "start": "2029-08-05T00:00:00.000Z",
     "end": "2029-08-06T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-05",
     "_weekday": "Sun"

--- a/test/fixtures/BI-2015.json
+++ b/test/fixtures/BI-2015.json
@@ -48,7 +48,7 @@
     "date": "2015-07-01 00:00:00",
     "start": "2015-06-30T22:00:00.000Z",
     "end": "2015-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Wed"

--- a/test/fixtures/BI-2016.json
+++ b/test/fixtures/BI-2016.json
@@ -48,7 +48,7 @@
     "date": "2016-07-01 00:00:00",
     "start": "2016-06-30T22:00:00.000Z",
     "end": "2016-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Fri"

--- a/test/fixtures/BI-2017.json
+++ b/test/fixtures/BI-2017.json
@@ -57,7 +57,7 @@
     "date": "2017-07-01 00:00:00",
     "start": "2017-06-30T22:00:00.000Z",
     "end": "2017-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sat"

--- a/test/fixtures/BI-2018.json
+++ b/test/fixtures/BI-2018.json
@@ -57,7 +57,7 @@
     "date": "2018-07-01 00:00:00",
     "start": "2018-06-30T22:00:00.000Z",
     "end": "2018-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sun"

--- a/test/fixtures/BI-2019.json
+++ b/test/fixtures/BI-2019.json
@@ -57,7 +57,7 @@
     "date": "2019-07-01 00:00:00",
     "start": "2019-06-30T22:00:00.000Z",
     "end": "2019-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Mon"

--- a/test/fixtures/BI-2020.json
+++ b/test/fixtures/BI-2020.json
@@ -57,7 +57,7 @@
     "date": "2020-07-01 00:00:00",
     "start": "2020-06-30T22:00:00.000Z",
     "end": "2020-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Wed"

--- a/test/fixtures/BI-2021.json
+++ b/test/fixtures/BI-2021.json
@@ -57,7 +57,7 @@
     "date": "2021-07-01 00:00:00",
     "start": "2021-06-30T22:00:00.000Z",
     "end": "2021-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Thu"

--- a/test/fixtures/BI-2022.json
+++ b/test/fixtures/BI-2022.json
@@ -57,7 +57,7 @@
     "date": "2022-07-01 00:00:00",
     "start": "2022-06-30T22:00:00.000Z",
     "end": "2022-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Fri"

--- a/test/fixtures/BI-2023.json
+++ b/test/fixtures/BI-2023.json
@@ -66,7 +66,7 @@
     "date": "2023-07-01 00:00:00",
     "start": "2023-06-30T22:00:00.000Z",
     "end": "2023-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sat"

--- a/test/fixtures/BI-2024.json
+++ b/test/fixtures/BI-2024.json
@@ -66,7 +66,7 @@
     "date": "2024-07-01 00:00:00",
     "start": "2024-06-30T22:00:00.000Z",
     "end": "2024-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Mon"

--- a/test/fixtures/BI-2025.json
+++ b/test/fixtures/BI-2025.json
@@ -66,7 +66,7 @@
     "date": "2025-07-01 00:00:00",
     "start": "2025-06-30T22:00:00.000Z",
     "end": "2025-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Tue"

--- a/test/fixtures/BI-2026.json
+++ b/test/fixtures/BI-2026.json
@@ -66,7 +66,7 @@
     "date": "2026-07-01 00:00:00",
     "start": "2026-06-30T22:00:00.000Z",
     "end": "2026-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Wed"

--- a/test/fixtures/BI-2027.json
+++ b/test/fixtures/BI-2027.json
@@ -66,7 +66,7 @@
     "date": "2027-07-01 00:00:00",
     "start": "2027-06-30T22:00:00.000Z",
     "end": "2027-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Thu"

--- a/test/fixtures/BI-2028.json
+++ b/test/fixtures/BI-2028.json
@@ -66,7 +66,7 @@
     "date": "2028-07-01 00:00:00",
     "start": "2028-06-30T22:00:00.000Z",
     "end": "2028-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sat"

--- a/test/fixtures/BI-2029.json
+++ b/test/fixtures/BI-2029.json
@@ -66,7 +66,7 @@
     "date": "2029-07-01 00:00:00",
     "start": "2029-06-30T22:00:00.000Z",
     "end": "2029-07-01T22:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-01",
     "_weekday": "Sun"

--- a/test/fixtures/CF-2015.json
+++ b/test/fixtures/CF-2015.json
@@ -75,7 +75,7 @@
     "date": "2015-08-13 00:00:00",
     "start": "2015-08-12T23:00:00.000Z",
     "end": "2015-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Thu"

--- a/test/fixtures/CF-2016.json
+++ b/test/fixtures/CF-2016.json
@@ -75,7 +75,7 @@
     "date": "2016-08-13 00:00:00",
     "start": "2016-08-12T23:00:00.000Z",
     "end": "2016-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Sat"

--- a/test/fixtures/CF-2017.json
+++ b/test/fixtures/CF-2017.json
@@ -75,7 +75,7 @@
     "date": "2017-08-13 00:00:00",
     "start": "2017-08-12T23:00:00.000Z",
     "end": "2017-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Sun"

--- a/test/fixtures/CF-2018.json
+++ b/test/fixtures/CF-2018.json
@@ -75,7 +75,7 @@
     "date": "2018-08-13 00:00:00",
     "start": "2018-08-12T23:00:00.000Z",
     "end": "2018-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Mon"

--- a/test/fixtures/CF-2019.json
+++ b/test/fixtures/CF-2019.json
@@ -84,7 +84,7 @@
     "date": "2019-08-13 00:00:00",
     "start": "2019-08-12T23:00:00.000Z",
     "end": "2019-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Tue"

--- a/test/fixtures/CF-2020.json
+++ b/test/fixtures/CF-2020.json
@@ -84,7 +84,7 @@
     "date": "2020-08-13 00:00:00",
     "start": "2020-08-12T23:00:00.000Z",
     "end": "2020-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Thu"

--- a/test/fixtures/CF-2021.json
+++ b/test/fixtures/CF-2021.json
@@ -84,7 +84,7 @@
     "date": "2021-08-13 00:00:00",
     "start": "2021-08-12T23:00:00.000Z",
     "end": "2021-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Fri"

--- a/test/fixtures/CF-2022.json
+++ b/test/fixtures/CF-2022.json
@@ -84,7 +84,7 @@
     "date": "2022-08-13 00:00:00",
     "start": "2022-08-12T23:00:00.000Z",
     "end": "2022-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Sat"

--- a/test/fixtures/CF-2023.json
+++ b/test/fixtures/CF-2023.json
@@ -84,7 +84,7 @@
     "date": "2023-08-13 00:00:00",
     "start": "2023-08-12T23:00:00.000Z",
     "end": "2023-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Sun"

--- a/test/fixtures/CF-2024.json
+++ b/test/fixtures/CF-2024.json
@@ -84,7 +84,7 @@
     "date": "2024-08-13 00:00:00",
     "start": "2024-08-12T23:00:00.000Z",
     "end": "2024-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Tue"

--- a/test/fixtures/CF-2025.json
+++ b/test/fixtures/CF-2025.json
@@ -84,7 +84,7 @@
     "date": "2025-08-13 00:00:00",
     "start": "2025-08-12T23:00:00.000Z",
     "end": "2025-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Wed"

--- a/test/fixtures/CF-2026.json
+++ b/test/fixtures/CF-2026.json
@@ -84,7 +84,7 @@
     "date": "2026-08-13 00:00:00",
     "start": "2026-08-12T23:00:00.000Z",
     "end": "2026-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Thu"

--- a/test/fixtures/CF-2027.json
+++ b/test/fixtures/CF-2027.json
@@ -84,7 +84,7 @@
     "date": "2027-08-13 00:00:00",
     "start": "2027-08-12T23:00:00.000Z",
     "end": "2027-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Fri"

--- a/test/fixtures/CF-2028.json
+++ b/test/fixtures/CF-2028.json
@@ -84,7 +84,7 @@
     "date": "2028-08-13 00:00:00",
     "start": "2028-08-12T23:00:00.000Z",
     "end": "2028-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Sun"

--- a/test/fixtures/CF-2029.json
+++ b/test/fixtures/CF-2029.json
@@ -84,7 +84,7 @@
     "date": "2029-08-13 00:00:00",
     "start": "2029-08-12T23:00:00.000Z",
     "end": "2029-08-13T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-13",
     "_weekday": "Mon"

--- a/test/fixtures/CI-2015.json
+++ b/test/fixtures/CI-2015.json
@@ -75,7 +75,7 @@
     "date": "2015-08-07 00:00:00",
     "start": "2015-08-07T00:00:00.000Z",
     "end": "2015-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Fri"

--- a/test/fixtures/CI-2016.json
+++ b/test/fixtures/CI-2016.json
@@ -66,7 +66,7 @@
     "date": "2016-08-07 00:00:00",
     "start": "2016-08-07T00:00:00.000Z",
     "end": "2016-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Sun"

--- a/test/fixtures/CI-2017.json
+++ b/test/fixtures/CI-2017.json
@@ -66,7 +66,7 @@
     "date": "2017-08-07 00:00:00",
     "start": "2017-08-07T00:00:00.000Z",
     "end": "2017-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Mon"

--- a/test/fixtures/CI-2018.json
+++ b/test/fixtures/CI-2018.json
@@ -66,7 +66,7 @@
     "date": "2018-08-07 00:00:00",
     "start": "2018-08-07T00:00:00.000Z",
     "end": "2018-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Tue"

--- a/test/fixtures/CI-2019.json
+++ b/test/fixtures/CI-2019.json
@@ -66,7 +66,7 @@
     "date": "2019-08-07 00:00:00",
     "start": "2019-08-07T00:00:00.000Z",
     "end": "2019-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Wed"

--- a/test/fixtures/CI-2020.json
+++ b/test/fixtures/CI-2020.json
@@ -75,7 +75,7 @@
     "date": "2020-08-07 00:00:00",
     "start": "2020-08-07T00:00:00.000Z",
     "end": "2020-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Fri"

--- a/test/fixtures/CI-2021.json
+++ b/test/fixtures/CI-2021.json
@@ -75,7 +75,7 @@
     "date": "2021-08-07 00:00:00",
     "start": "2021-08-07T00:00:00.000Z",
     "end": "2021-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Sat"

--- a/test/fixtures/CI-2022.json
+++ b/test/fixtures/CI-2022.json
@@ -75,7 +75,7 @@
     "date": "2022-08-07 00:00:00",
     "start": "2022-08-07T00:00:00.000Z",
     "end": "2022-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Sun"

--- a/test/fixtures/CI-2023.json
+++ b/test/fixtures/CI-2023.json
@@ -75,7 +75,7 @@
     "date": "2023-08-07 00:00:00",
     "start": "2023-08-07T00:00:00.000Z",
     "end": "2023-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Mon"

--- a/test/fixtures/CI-2024.json
+++ b/test/fixtures/CI-2024.json
@@ -75,7 +75,7 @@
     "date": "2024-08-07 00:00:00",
     "start": "2024-08-07T00:00:00.000Z",
     "end": "2024-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Wed"

--- a/test/fixtures/CI-2025.json
+++ b/test/fixtures/CI-2025.json
@@ -75,7 +75,7 @@
     "date": "2025-08-07 00:00:00",
     "start": "2025-08-07T00:00:00.000Z",
     "end": "2025-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Thu"

--- a/test/fixtures/CI-2026.json
+++ b/test/fixtures/CI-2026.json
@@ -75,7 +75,7 @@
     "date": "2026-08-07 00:00:00",
     "start": "2026-08-07T00:00:00.000Z",
     "end": "2026-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Fri"

--- a/test/fixtures/CI-2027.json
+++ b/test/fixtures/CI-2027.json
@@ -75,7 +75,7 @@
     "date": "2027-08-07 00:00:00",
     "start": "2027-08-07T00:00:00.000Z",
     "end": "2027-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Sat"

--- a/test/fixtures/CI-2028.json
+++ b/test/fixtures/CI-2028.json
@@ -84,7 +84,7 @@
     "date": "2028-08-07 00:00:00",
     "start": "2028-08-07T00:00:00.000Z",
     "end": "2028-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Mon"

--- a/test/fixtures/CI-2029.json
+++ b/test/fixtures/CI-2029.json
@@ -84,7 +84,7 @@
     "date": "2029-08-07 00:00:00",
     "start": "2029-08-07T00:00:00.000Z",
     "end": "2029-08-08T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-07 since 1960",
     "_weekday": "Tue"

--- a/test/fixtures/DJ-2015.json
+++ b/test/fixtures/DJ-2015.json
@@ -39,7 +39,7 @@
     "date": "2015-06-27 00:00:00",
     "start": "2015-06-26T21:00:00.000Z",
     "end": "2015-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Sat"

--- a/test/fixtures/DJ-2016.json
+++ b/test/fixtures/DJ-2016.json
@@ -30,7 +30,7 @@
     "date": "2016-06-27 00:00:00",
     "start": "2016-06-26T21:00:00.000Z",
     "end": "2016-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Mon"

--- a/test/fixtures/DJ-2017.json
+++ b/test/fixtures/DJ-2017.json
@@ -39,7 +39,7 @@
     "date": "2017-06-27 00:00:00",
     "start": "2017-06-26T21:00:00.000Z",
     "end": "2017-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Tue"

--- a/test/fixtures/DJ-2018.json
+++ b/test/fixtures/DJ-2018.json
@@ -39,7 +39,7 @@
     "date": "2018-06-27 00:00:00",
     "start": "2018-06-26T21:00:00.000Z",
     "end": "2018-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Wed"

--- a/test/fixtures/DJ-2019.json
+++ b/test/fixtures/DJ-2019.json
@@ -39,7 +39,7 @@
     "date": "2019-06-27 00:00:00",
     "start": "2019-06-26T21:00:00.000Z",
     "end": "2019-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Thu"

--- a/test/fixtures/DJ-2020.json
+++ b/test/fixtures/DJ-2020.json
@@ -39,7 +39,7 @@
     "date": "2020-06-27 00:00:00",
     "start": "2020-06-26T21:00:00.000Z",
     "end": "2020-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Sat"

--- a/test/fixtures/DJ-2021.json
+++ b/test/fixtures/DJ-2021.json
@@ -39,7 +39,7 @@
     "date": "2021-06-27 00:00:00",
     "start": "2021-06-26T21:00:00.000Z",
     "end": "2021-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Sun"

--- a/test/fixtures/DJ-2022.json
+++ b/test/fixtures/DJ-2022.json
@@ -39,7 +39,7 @@
     "date": "2022-06-27 00:00:00",
     "start": "2022-06-26T21:00:00.000Z",
     "end": "2022-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Mon"

--- a/test/fixtures/DJ-2023.json
+++ b/test/fixtures/DJ-2023.json
@@ -48,7 +48,7 @@
     "date": "2023-06-27 00:00:00",
     "start": "2023-06-26T21:00:00.000Z",
     "end": "2023-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Tue"

--- a/test/fixtures/DJ-2024.json
+++ b/test/fixtures/DJ-2024.json
@@ -57,7 +57,7 @@
     "date": "2024-06-27 00:00:00",
     "start": "2024-06-26T21:00:00.000Z",
     "end": "2024-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Thu"

--- a/test/fixtures/DJ-2025.json
+++ b/test/fixtures/DJ-2025.json
@@ -66,7 +66,7 @@
     "date": "2025-06-27 00:00:00",
     "start": "2025-06-26T21:00:00.000Z",
     "end": "2025-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Fri"

--- a/test/fixtures/DJ-2026.json
+++ b/test/fixtures/DJ-2026.json
@@ -66,7 +66,7 @@
     "date": "2026-06-27 00:00:00",
     "start": "2026-06-26T21:00:00.000Z",
     "end": "2026-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Sat"

--- a/test/fixtures/DJ-2027.json
+++ b/test/fixtures/DJ-2027.json
@@ -66,7 +66,7 @@
     "date": "2027-06-27 00:00:00",
     "start": "2027-06-26T21:00:00.000Z",
     "end": "2027-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Sun"

--- a/test/fixtures/DJ-2028.json
+++ b/test/fixtures/DJ-2028.json
@@ -57,7 +57,7 @@
     "date": "2028-06-27 00:00:00",
     "start": "2028-06-26T21:00:00.000Z",
     "end": "2028-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Tue"

--- a/test/fixtures/DJ-2029.json
+++ b/test/fixtures/DJ-2029.json
@@ -57,7 +57,7 @@
     "date": "2029-06-27 00:00:00",
     "start": "2029-06-26T21:00:00.000Z",
     "end": "2029-06-27T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "06-27 since 1977",
     "_weekday": "Wed"

--- a/test/fixtures/FR-MF-2015.json
+++ b/test/fixtures/FR-MF-2015.json
@@ -66,7 +66,7 @@
     "date": "2015-05-27 00:00:00",
     "start": "2015-05-27T04:00:00.000Z",
     "end": "2015-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Wed"

--- a/test/fixtures/FR-MF-2016.json
+++ b/test/fixtures/FR-MF-2016.json
@@ -66,7 +66,7 @@
     "date": "2016-05-27 00:00:00",
     "start": "2016-05-27T04:00:00.000Z",
     "end": "2016-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Fri"

--- a/test/fixtures/FR-MF-2017.json
+++ b/test/fixtures/FR-MF-2017.json
@@ -48,7 +48,7 @@
     "date": "2017-05-27 00:00:00",
     "start": "2017-05-27T04:00:00.000Z",
     "end": "2017-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Sat"

--- a/test/fixtures/FR-MF-2018.json
+++ b/test/fixtures/FR-MF-2018.json
@@ -66,7 +66,7 @@
     "date": "2018-05-27 00:00:00",
     "start": "2018-05-27T04:00:00.000Z",
     "end": "2018-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Sun"

--- a/test/fixtures/FR-MF-2019.json
+++ b/test/fixtures/FR-MF-2019.json
@@ -48,7 +48,7 @@
     "date": "2019-05-27 00:00:00",
     "start": "2019-05-27T04:00:00.000Z",
     "end": "2019-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Mon"

--- a/test/fixtures/FR-MF-2020.json
+++ b/test/fixtures/FR-MF-2020.json
@@ -48,7 +48,7 @@
     "date": "2020-05-27 00:00:00",
     "start": "2020-05-27T04:00:00.000Z",
     "end": "2020-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Wed"

--- a/test/fixtures/FR-MF-2021.json
+++ b/test/fixtures/FR-MF-2021.json
@@ -66,7 +66,7 @@
     "date": "2021-05-27 00:00:00",
     "start": "2021-05-27T04:00:00.000Z",
     "end": "2021-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Thu"

--- a/test/fixtures/FR-MF-2022.json
+++ b/test/fixtures/FR-MF-2022.json
@@ -48,7 +48,7 @@
     "date": "2022-05-27 00:00:00",
     "start": "2022-05-27T04:00:00.000Z",
     "end": "2022-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Fri"

--- a/test/fixtures/FR-MF-2023.json
+++ b/test/fixtures/FR-MF-2023.json
@@ -48,7 +48,7 @@
     "date": "2023-05-27 00:00:00",
     "start": "2023-05-27T04:00:00.000Z",
     "end": "2023-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Sat"

--- a/test/fixtures/FR-MF-2024.json
+++ b/test/fixtures/FR-MF-2024.json
@@ -75,7 +75,7 @@
     "date": "2024-05-27 00:00:00",
     "start": "2024-05-27T04:00:00.000Z",
     "end": "2024-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Mon"

--- a/test/fixtures/FR-MF-2025.json
+++ b/test/fixtures/FR-MF-2025.json
@@ -48,7 +48,7 @@
     "date": "2025-05-27 00:00:00",
     "start": "2025-05-27T04:00:00.000Z",
     "end": "2025-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Tue"

--- a/test/fixtures/FR-MF-2026.json
+++ b/test/fixtures/FR-MF-2026.json
@@ -66,7 +66,7 @@
     "date": "2026-05-27 00:00:00",
     "start": "2026-05-27T04:00:00.000Z",
     "end": "2026-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Wed"

--- a/test/fixtures/FR-MF-2027.json
+++ b/test/fixtures/FR-MF-2027.json
@@ -66,7 +66,7 @@
     "date": "2027-05-27 00:00:00",
     "start": "2027-05-27T04:00:00.000Z",
     "end": "2027-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Thu"

--- a/test/fixtures/FR-MF-2028.json
+++ b/test/fixtures/FR-MF-2028.json
@@ -48,7 +48,7 @@
     "date": "2028-05-27 00:00:00",
     "start": "2028-05-27T04:00:00.000Z",
     "end": "2028-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Sat"

--- a/test/fixtures/FR-MF-2029.json
+++ b/test/fixtures/FR-MF-2029.json
@@ -66,7 +66,7 @@
     "date": "2029-05-27 00:00:00",
     "start": "2029-05-27T04:00:00.000Z",
     "end": "2029-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Sun"

--- a/test/fixtures/GA-2015.json
+++ b/test/fixtures/GA-2015.json
@@ -66,7 +66,7 @@
     "date": "2015-08-16 00:00:00",
     "start": "2015-08-15T23:00:00.000Z",
     "end": "2015-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Sun"

--- a/test/fixtures/GA-2016.json
+++ b/test/fixtures/GA-2016.json
@@ -66,7 +66,7 @@
     "date": "2016-08-16 00:00:00",
     "start": "2016-08-15T23:00:00.000Z",
     "end": "2016-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Tue"

--- a/test/fixtures/GA-2017.json
+++ b/test/fixtures/GA-2017.json
@@ -66,7 +66,7 @@
     "date": "2017-08-16 00:00:00",
     "start": "2017-08-15T23:00:00.000Z",
     "end": "2017-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Wed"

--- a/test/fixtures/GA-2018.json
+++ b/test/fixtures/GA-2018.json
@@ -66,7 +66,7 @@
     "date": "2018-08-16 00:00:00",
     "start": "2018-08-15T23:00:00.000Z",
     "end": "2018-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Thu"

--- a/test/fixtures/GA-2019.json
+++ b/test/fixtures/GA-2019.json
@@ -75,7 +75,7 @@
     "date": "2019-08-16 00:00:00",
     "start": "2019-08-15T23:00:00.000Z",
     "end": "2019-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Fri"

--- a/test/fixtures/GA-2020.json
+++ b/test/fixtures/GA-2020.json
@@ -75,7 +75,7 @@
     "date": "2020-08-16 00:00:00",
     "start": "2020-08-15T23:00:00.000Z",
     "end": "2020-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Sun"

--- a/test/fixtures/GA-2021.json
+++ b/test/fixtures/GA-2021.json
@@ -75,7 +75,7 @@
     "date": "2021-08-16 00:00:00",
     "start": "2021-08-15T23:00:00.000Z",
     "end": "2021-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Mon"

--- a/test/fixtures/GA-2022.json
+++ b/test/fixtures/GA-2022.json
@@ -75,7 +75,7 @@
     "date": "2022-08-16 00:00:00",
     "start": "2022-08-15T23:00:00.000Z",
     "end": "2022-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Tue"

--- a/test/fixtures/GA-2023.json
+++ b/test/fixtures/GA-2023.json
@@ -75,7 +75,7 @@
     "date": "2023-08-16 00:00:00",
     "start": "2023-08-15T23:00:00.000Z",
     "end": "2023-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Wed"

--- a/test/fixtures/GA-2024.json
+++ b/test/fixtures/GA-2024.json
@@ -75,7 +75,7 @@
     "date": "2024-08-16 00:00:00",
     "start": "2024-08-15T23:00:00.000Z",
     "end": "2024-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Fri"

--- a/test/fixtures/GA-2025.json
+++ b/test/fixtures/GA-2025.json
@@ -75,7 +75,7 @@
     "date": "2025-08-16 00:00:00",
     "start": "2025-08-15T23:00:00.000Z",
     "end": "2025-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Sat"

--- a/test/fixtures/GA-2026.json
+++ b/test/fixtures/GA-2026.json
@@ -75,7 +75,7 @@
     "date": "2026-08-16 00:00:00",
     "start": "2026-08-15T23:00:00.000Z",
     "end": "2026-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Sun"

--- a/test/fixtures/GA-2027.json
+++ b/test/fixtures/GA-2027.json
@@ -75,7 +75,7 @@
     "date": "2027-08-16 00:00:00",
     "start": "2027-08-15T23:00:00.000Z",
     "end": "2027-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Mon"

--- a/test/fixtures/GA-2028.json
+++ b/test/fixtures/GA-2028.json
@@ -75,7 +75,7 @@
     "date": "2028-08-16 00:00:00",
     "start": "2028-08-15T23:00:00.000Z",
     "end": "2028-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Wed"

--- a/test/fixtures/GA-2029.json
+++ b/test/fixtures/GA-2029.json
@@ -75,7 +75,7 @@
     "date": "2029-08-16 00:00:00",
     "start": "2029-08-15T23:00:00.000Z",
     "end": "2029-08-17T23:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "08-16 P2D",
     "_weekday": "Thu"

--- a/test/fixtures/GN-2015.json
+++ b/test/fixtures/GN-2015.json
@@ -93,7 +93,7 @@
     "date": "2015-10-02 00:00:00",
     "start": "2015-10-02T00:00:00.000Z",
     "end": "2015-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Fri"

--- a/test/fixtures/GN-2016.json
+++ b/test/fixtures/GN-2016.json
@@ -84,7 +84,7 @@
     "date": "2016-10-02 00:00:00",
     "start": "2016-10-02T00:00:00.000Z",
     "end": "2016-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Sun"

--- a/test/fixtures/GN-2017.json
+++ b/test/fixtures/GN-2017.json
@@ -84,7 +84,7 @@
     "date": "2017-10-02 00:00:00",
     "start": "2017-10-02T00:00:00.000Z",
     "end": "2017-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Mon"

--- a/test/fixtures/GN-2018.json
+++ b/test/fixtures/GN-2018.json
@@ -84,7 +84,7 @@
     "date": "2018-10-02 00:00:00",
     "start": "2018-10-02T00:00:00.000Z",
     "end": "2018-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Tue"

--- a/test/fixtures/GN-2019.json
+++ b/test/fixtures/GN-2019.json
@@ -84,7 +84,7 @@
     "date": "2019-10-02 00:00:00",
     "start": "2019-10-02T00:00:00.000Z",
     "end": "2019-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Wed"

--- a/test/fixtures/GN-2020.json
+++ b/test/fixtures/GN-2020.json
@@ -84,7 +84,7 @@
     "date": "2020-10-02 00:00:00",
     "start": "2020-10-02T00:00:00.000Z",
     "end": "2020-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Fri"

--- a/test/fixtures/GN-2021.json
+++ b/test/fixtures/GN-2021.json
@@ -84,7 +84,7 @@
     "date": "2021-10-02 00:00:00",
     "start": "2021-10-02T00:00:00.000Z",
     "end": "2021-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Sat"

--- a/test/fixtures/GN-2022.json
+++ b/test/fixtures/GN-2022.json
@@ -84,7 +84,7 @@
     "date": "2022-10-02 00:00:00",
     "start": "2022-10-02T00:00:00.000Z",
     "end": "2022-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Sun"

--- a/test/fixtures/GN-2023.json
+++ b/test/fixtures/GN-2023.json
@@ -93,7 +93,7 @@
     "date": "2023-10-02 00:00:00",
     "start": "2023-10-02T00:00:00.000Z",
     "end": "2023-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Mon"

--- a/test/fixtures/GN-2024.json
+++ b/test/fixtures/GN-2024.json
@@ -93,7 +93,7 @@
     "date": "2024-10-02 00:00:00",
     "start": "2024-10-02T00:00:00.000Z",
     "end": "2024-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Wed"

--- a/test/fixtures/GN-2025.json
+++ b/test/fixtures/GN-2025.json
@@ -93,7 +93,7 @@
     "date": "2025-10-02 00:00:00",
     "start": "2025-10-02T00:00:00.000Z",
     "end": "2025-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Thu"

--- a/test/fixtures/GN-2026.json
+++ b/test/fixtures/GN-2026.json
@@ -93,7 +93,7 @@
     "date": "2026-10-02 00:00:00",
     "start": "2026-10-02T00:00:00.000Z",
     "end": "2026-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Fri"

--- a/test/fixtures/GN-2027.json
+++ b/test/fixtures/GN-2027.json
@@ -93,7 +93,7 @@
     "date": "2027-10-02 00:00:00",
     "start": "2027-10-02T00:00:00.000Z",
     "end": "2027-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Sat"

--- a/test/fixtures/GN-2028.json
+++ b/test/fixtures/GN-2028.json
@@ -93,7 +93,7 @@
     "date": "2028-10-02 00:00:00",
     "start": "2028-10-02T00:00:00.000Z",
     "end": "2028-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Mon"

--- a/test/fixtures/GN-2029.json
+++ b/test/fixtures/GN-2029.json
@@ -93,7 +93,7 @@
     "date": "2029-10-02 00:00:00",
     "start": "2029-10-02T00:00:00.000Z",
     "end": "2029-10-03T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "10-02",
     "_weekday": "Tue"

--- a/test/fixtures/HT-2015.json
+++ b/test/fixtures/HT-2015.json
@@ -3,7 +3,7 @@
     "date": "2015-01-01 00:00:00",
     "start": "2015-01-01T05:00:00.000Z",
     "end": "2015-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"

--- a/test/fixtures/HT-2016.json
+++ b/test/fixtures/HT-2016.json
@@ -3,7 +3,7 @@
     "date": "2016-01-01 00:00:00",
     "start": "2016-01-01T05:00:00.000Z",
     "end": "2016-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"

--- a/test/fixtures/HT-2017.json
+++ b/test/fixtures/HT-2017.json
@@ -3,7 +3,7 @@
     "date": "2017-01-01 00:00:00",
     "start": "2017-01-01T05:00:00.000Z",
     "end": "2017-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"

--- a/test/fixtures/HT-2018.json
+++ b/test/fixtures/HT-2018.json
@@ -3,7 +3,7 @@
     "date": "2018-01-01 00:00:00",
     "start": "2018-01-01T05:00:00.000Z",
     "end": "2018-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"

--- a/test/fixtures/HT-2019.json
+++ b/test/fixtures/HT-2019.json
@@ -3,7 +3,7 @@
     "date": "2019-01-01 00:00:00",
     "start": "2019-01-01T05:00:00.000Z",
     "end": "2019-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Tue"

--- a/test/fixtures/HT-2020.json
+++ b/test/fixtures/HT-2020.json
@@ -3,7 +3,7 @@
     "date": "2020-01-01 00:00:00",
     "start": "2020-01-01T05:00:00.000Z",
     "end": "2020-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"

--- a/test/fixtures/HT-2021.json
+++ b/test/fixtures/HT-2021.json
@@ -3,7 +3,7 @@
     "date": "2021-01-01 00:00:00",
     "start": "2021-01-01T05:00:00.000Z",
     "end": "2021-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"

--- a/test/fixtures/HT-2022.json
+++ b/test/fixtures/HT-2022.json
@@ -3,7 +3,7 @@
     "date": "2022-01-01 00:00:00",
     "start": "2022-01-01T05:00:00.000Z",
     "end": "2022-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"

--- a/test/fixtures/HT-2023.json
+++ b/test/fixtures/HT-2023.json
@@ -3,7 +3,7 @@
     "date": "2023-01-01 00:00:00",
     "start": "2023-01-01T05:00:00.000Z",
     "end": "2023-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"

--- a/test/fixtures/HT-2024.json
+++ b/test/fixtures/HT-2024.json
@@ -3,7 +3,7 @@
     "date": "2024-01-01 00:00:00",
     "start": "2024-01-01T05:00:00.000Z",
     "end": "2024-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"

--- a/test/fixtures/HT-2025.json
+++ b/test/fixtures/HT-2025.json
@@ -3,7 +3,7 @@
     "date": "2025-01-01 00:00:00",
     "start": "2025-01-01T05:00:00.000Z",
     "end": "2025-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"

--- a/test/fixtures/HT-2026.json
+++ b/test/fixtures/HT-2026.json
@@ -3,7 +3,7 @@
     "date": "2026-01-01 00:00:00",
     "start": "2026-01-01T05:00:00.000Z",
     "end": "2026-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"

--- a/test/fixtures/HT-2027.json
+++ b/test/fixtures/HT-2027.json
@@ -3,7 +3,7 @@
     "date": "2027-01-01 00:00:00",
     "start": "2027-01-01T05:00:00.000Z",
     "end": "2027-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"

--- a/test/fixtures/HT-2028.json
+++ b/test/fixtures/HT-2028.json
@@ -3,7 +3,7 @@
     "date": "2028-01-01 00:00:00",
     "start": "2028-01-01T05:00:00.000Z",
     "end": "2028-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"

--- a/test/fixtures/HT-2029.json
+++ b/test/fixtures/HT-2029.json
@@ -3,7 +3,7 @@
     "date": "2029-01-01 00:00:00",
     "start": "2029-01-01T05:00:00.000Z",
     "end": "2029-01-02T05:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"

--- a/test/fixtures/KM-2015.json
+++ b/test/fixtures/KM-2015.json
@@ -48,7 +48,7 @@
     "date": "2015-07-06 00:00:00",
     "start": "2015-07-05T21:00:00.000Z",
     "end": "2015-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Mon"

--- a/test/fixtures/KM-2016.json
+++ b/test/fixtures/KM-2016.json
@@ -48,7 +48,7 @@
     "date": "2016-07-06 00:00:00",
     "start": "2016-07-05T21:00:00.000Z",
     "end": "2016-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Wed"

--- a/test/fixtures/KM-2017.json
+++ b/test/fixtures/KM-2017.json
@@ -48,7 +48,7 @@
     "date": "2017-07-06 00:00:00",
     "start": "2017-07-05T21:00:00.000Z",
     "end": "2017-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Thu"

--- a/test/fixtures/KM-2018.json
+++ b/test/fixtures/KM-2018.json
@@ -48,7 +48,7 @@
     "date": "2018-07-06 00:00:00",
     "start": "2018-07-05T21:00:00.000Z",
     "end": "2018-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Fri"

--- a/test/fixtures/KM-2019.json
+++ b/test/fixtures/KM-2019.json
@@ -48,7 +48,7 @@
     "date": "2019-07-06 00:00:00",
     "start": "2019-07-05T21:00:00.000Z",
     "end": "2019-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Sat"

--- a/test/fixtures/KM-2020.json
+++ b/test/fixtures/KM-2020.json
@@ -48,7 +48,7 @@
     "date": "2020-07-06 00:00:00",
     "start": "2020-07-05T21:00:00.000Z",
     "end": "2020-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Mon"

--- a/test/fixtures/KM-2021.json
+++ b/test/fixtures/KM-2021.json
@@ -48,7 +48,7 @@
     "date": "2021-07-06 00:00:00",
     "start": "2021-07-05T21:00:00.000Z",
     "end": "2021-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Tue"

--- a/test/fixtures/KM-2022.json
+++ b/test/fixtures/KM-2022.json
@@ -48,7 +48,7 @@
     "date": "2022-07-06 00:00:00",
     "start": "2022-07-05T21:00:00.000Z",
     "end": "2022-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Wed"

--- a/test/fixtures/KM-2023.json
+++ b/test/fixtures/KM-2023.json
@@ -57,7 +57,7 @@
     "date": "2023-07-06 00:00:00",
     "start": "2023-07-05T21:00:00.000Z",
     "end": "2023-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Thu"

--- a/test/fixtures/KM-2024.json
+++ b/test/fixtures/KM-2024.json
@@ -57,7 +57,7 @@
     "date": "2024-07-06 00:00:00",
     "start": "2024-07-05T21:00:00.000Z",
     "end": "2024-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Sat"

--- a/test/fixtures/KM-2025.json
+++ b/test/fixtures/KM-2025.json
@@ -66,7 +66,7 @@
     "date": "2025-07-06 00:00:00",
     "start": "2025-07-05T21:00:00.000Z",
     "end": "2025-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Sun"

--- a/test/fixtures/KM-2026.json
+++ b/test/fixtures/KM-2026.json
@@ -66,7 +66,7 @@
     "date": "2026-07-06 00:00:00",
     "start": "2026-07-05T21:00:00.000Z",
     "end": "2026-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Mon"

--- a/test/fixtures/KM-2027.json
+++ b/test/fixtures/KM-2027.json
@@ -66,7 +66,7 @@
     "date": "2027-07-06 00:00:00",
     "start": "2027-07-05T21:00:00.000Z",
     "end": "2027-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Tue"

--- a/test/fixtures/KM-2028.json
+++ b/test/fixtures/KM-2028.json
@@ -57,7 +57,7 @@
     "date": "2028-07-06 00:00:00",
     "start": "2028-07-05T21:00:00.000Z",
     "end": "2028-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Thu"

--- a/test/fixtures/KM-2029.json
+++ b/test/fixtures/KM-2029.json
@@ -57,7 +57,7 @@
     "date": "2029-07-06 00:00:00",
     "start": "2029-07-05T21:00:00.000Z",
     "end": "2029-07-06T21:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-06",
     "_weekday": "Fri"

--- a/test/fixtures/LU-2019.json
+++ b/test/fixtures/LU-2019.json
@@ -48,7 +48,7 @@
     "date": "2019-05-09 00:00:00",
     "start": "2019-05-08T22:00:00.000Z",
     "end": "2019-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Thu"

--- a/test/fixtures/LU-2020.json
+++ b/test/fixtures/LU-2020.json
@@ -48,7 +48,7 @@
     "date": "2020-05-09 00:00:00",
     "start": "2020-05-08T22:00:00.000Z",
     "end": "2020-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Sat"

--- a/test/fixtures/LU-2021.json
+++ b/test/fixtures/LU-2021.json
@@ -48,7 +48,7 @@
     "date": "2021-05-09 00:00:00",
     "start": "2021-05-08T22:00:00.000Z",
     "end": "2021-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Sun"

--- a/test/fixtures/LU-2022.json
+++ b/test/fixtures/LU-2022.json
@@ -48,7 +48,7 @@
     "date": "2022-05-09 00:00:00",
     "start": "2022-05-08T22:00:00.000Z",
     "end": "2022-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Mon"

--- a/test/fixtures/LU-2023.json
+++ b/test/fixtures/LU-2023.json
@@ -48,7 +48,7 @@
     "date": "2023-05-09 00:00:00",
     "start": "2023-05-08T22:00:00.000Z",
     "end": "2023-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Tue"

--- a/test/fixtures/LU-2024.json
+++ b/test/fixtures/LU-2024.json
@@ -57,7 +57,7 @@
     "date": "2024-05-09 00:00:00",
     "start": "2024-05-08T22:00:00.000Z",
     "end": "2024-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Thu"

--- a/test/fixtures/LU-2025.json
+++ b/test/fixtures/LU-2025.json
@@ -48,7 +48,7 @@
     "date": "2025-05-09 00:00:00",
     "start": "2025-05-08T22:00:00.000Z",
     "end": "2025-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Fri"

--- a/test/fixtures/LU-2026.json
+++ b/test/fixtures/LU-2026.json
@@ -48,7 +48,7 @@
     "date": "2026-05-09 00:00:00",
     "start": "2026-05-08T22:00:00.000Z",
     "end": "2026-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Sat"

--- a/test/fixtures/LU-2027.json
+++ b/test/fixtures/LU-2027.json
@@ -57,7 +57,7 @@
     "date": "2027-05-09 00:00:00",
     "start": "2027-05-08T22:00:00.000Z",
     "end": "2027-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Sun"

--- a/test/fixtures/LU-2028.json
+++ b/test/fixtures/LU-2028.json
@@ -48,7 +48,7 @@
     "date": "2028-05-09 00:00:00",
     "start": "2028-05-08T22:00:00.000Z",
     "end": "2028-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Tue"

--- a/test/fixtures/LU-2029.json
+++ b/test/fixtures/LU-2029.json
@@ -48,7 +48,7 @@
     "date": "2029-05-09 00:00:00",
     "start": "2029-05-08T22:00:00.000Z",
     "end": "2029-05-09T22:00:00.000Z",
-    "name": "Journée de l'Europe",
+    "name": "Journée de l’Europe",
     "type": "public",
     "rule": "05-09",
     "_weekday": "Wed"

--- a/test/fixtures/MF-2015.json
+++ b/test/fixtures/MF-2015.json
@@ -66,7 +66,7 @@
     "date": "2015-05-27 00:00:00",
     "start": "2015-05-27T04:00:00.000Z",
     "end": "2015-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Wed"

--- a/test/fixtures/MF-2016.json
+++ b/test/fixtures/MF-2016.json
@@ -66,7 +66,7 @@
     "date": "2016-05-27 00:00:00",
     "start": "2016-05-27T04:00:00.000Z",
     "end": "2016-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Fri"

--- a/test/fixtures/MF-2017.json
+++ b/test/fixtures/MF-2017.json
@@ -48,7 +48,7 @@
     "date": "2017-05-27 00:00:00",
     "start": "2017-05-27T04:00:00.000Z",
     "end": "2017-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Sat"

--- a/test/fixtures/MF-2018.json
+++ b/test/fixtures/MF-2018.json
@@ -66,7 +66,7 @@
     "date": "2018-05-27 00:00:00",
     "start": "2018-05-27T04:00:00.000Z",
     "end": "2018-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Sun"

--- a/test/fixtures/MF-2019.json
+++ b/test/fixtures/MF-2019.json
@@ -48,7 +48,7 @@
     "date": "2019-05-27 00:00:00",
     "start": "2019-05-27T04:00:00.000Z",
     "end": "2019-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Mon"

--- a/test/fixtures/MF-2020.json
+++ b/test/fixtures/MF-2020.json
@@ -48,7 +48,7 @@
     "date": "2020-05-27 00:00:00",
     "start": "2020-05-27T04:00:00.000Z",
     "end": "2020-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Wed"

--- a/test/fixtures/MF-2021.json
+++ b/test/fixtures/MF-2021.json
@@ -66,7 +66,7 @@
     "date": "2021-05-27 00:00:00",
     "start": "2021-05-27T04:00:00.000Z",
     "end": "2021-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Thu"

--- a/test/fixtures/MF-2022.json
+++ b/test/fixtures/MF-2022.json
@@ -48,7 +48,7 @@
     "date": "2022-05-27 00:00:00",
     "start": "2022-05-27T04:00:00.000Z",
     "end": "2022-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Fri"

--- a/test/fixtures/MF-2023.json
+++ b/test/fixtures/MF-2023.json
@@ -48,7 +48,7 @@
     "date": "2023-05-27 00:00:00",
     "start": "2023-05-27T04:00:00.000Z",
     "end": "2023-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Sat"

--- a/test/fixtures/MF-2024.json
+++ b/test/fixtures/MF-2024.json
@@ -75,7 +75,7 @@
     "date": "2024-05-27 00:00:00",
     "start": "2024-05-27T04:00:00.000Z",
     "end": "2024-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Mon"

--- a/test/fixtures/MF-2025.json
+++ b/test/fixtures/MF-2025.json
@@ -48,7 +48,7 @@
     "date": "2025-05-27 00:00:00",
     "start": "2025-05-27T04:00:00.000Z",
     "end": "2025-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Tue"

--- a/test/fixtures/MF-2026.json
+++ b/test/fixtures/MF-2026.json
@@ -66,7 +66,7 @@
     "date": "2026-05-27 00:00:00",
     "start": "2026-05-27T04:00:00.000Z",
     "end": "2026-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Wed"

--- a/test/fixtures/MF-2027.json
+++ b/test/fixtures/MF-2027.json
@@ -66,7 +66,7 @@
     "date": "2027-05-27 00:00:00",
     "start": "2027-05-27T04:00:00.000Z",
     "end": "2027-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Thu"

--- a/test/fixtures/MF-2028.json
+++ b/test/fixtures/MF-2028.json
@@ -48,7 +48,7 @@
     "date": "2028-05-27 00:00:00",
     "start": "2028-05-27T04:00:00.000Z",
     "end": "2028-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Sat"

--- a/test/fixtures/MF-2029.json
+++ b/test/fixtures/MF-2029.json
@@ -66,7 +66,7 @@
     "date": "2029-05-27 00:00:00",
     "start": "2029-05-27T04:00:00.000Z",
     "end": "2029-05-28T04:00:00.000Z",
-    "name": "Abolition de l'esclavage",
+    "name": "Abolition de l’esclavage",
     "type": "public",
     "rule": "05-27",
     "_weekday": "Sun"

--- a/test/fixtures/PF-2015.json
+++ b/test/fixtures/PF-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-03-05 00:00:00",
     "start": "2015-03-05T10:00:00.000Z",
     "end": "2015-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Thu"
@@ -93,7 +93,7 @@
     "date": "2015-06-29 00:00:00",
     "start": "2015-06-29T10:00:00.000Z",
     "end": "2015-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Mon"

--- a/test/fixtures/PF-2016.json
+++ b/test/fixtures/PF-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-03-05 00:00:00",
     "start": "2016-03-05T10:00:00.000Z",
     "end": "2016-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2016-06-29 00:00:00",
     "start": "2016-06-29T10:00:00.000Z",
     "end": "2016-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Wed"

--- a/test/fixtures/PF-2017.json
+++ b/test/fixtures/PF-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-03-05 00:00:00",
     "start": "2017-03-05T10:00:00.000Z",
     "end": "2017-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Sun"
@@ -93,7 +93,7 @@
     "date": "2017-06-29 00:00:00",
     "start": "2017-06-29T10:00:00.000Z",
     "end": "2017-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Thu"

--- a/test/fixtures/PF-2018.json
+++ b/test/fixtures/PF-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-03-05 00:00:00",
     "start": "2018-03-05T10:00:00.000Z",
     "end": "2018-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2018-06-29 00:00:00",
     "start": "2018-06-29T10:00:00.000Z",
     "end": "2018-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Fri"

--- a/test/fixtures/PF-2019.json
+++ b/test/fixtures/PF-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-03-05 00:00:00",
     "start": "2019-03-05T10:00:00.000Z",
     "end": "2019-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Tue"
@@ -93,7 +93,7 @@
     "date": "2019-06-29 00:00:00",
     "start": "2019-06-29T10:00:00.000Z",
     "end": "2019-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Sat"

--- a/test/fixtures/PF-2020.json
+++ b/test/fixtures/PF-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-03-05 00:00:00",
     "start": "2020-03-05T10:00:00.000Z",
     "end": "2020-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Thu"
@@ -93,7 +93,7 @@
     "date": "2020-06-29 00:00:00",
     "start": "2020-06-29T10:00:00.000Z",
     "end": "2020-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Mon"

--- a/test/fixtures/PF-2021.json
+++ b/test/fixtures/PF-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-03-05 00:00:00",
     "start": "2021-03-05T10:00:00.000Z",
     "end": "2021-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2021-06-29 00:00:00",
     "start": "2021-06-29T10:00:00.000Z",
     "end": "2021-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Tue"

--- a/test/fixtures/PF-2022.json
+++ b/test/fixtures/PF-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-03-05 00:00:00",
     "start": "2022-03-05T10:00:00.000Z",
     "end": "2022-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2022-06-29 00:00:00",
     "start": "2022-06-29T10:00:00.000Z",
     "end": "2022-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Wed"

--- a/test/fixtures/PF-2023.json
+++ b/test/fixtures/PF-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-03-05 00:00:00",
     "start": "2023-03-05T10:00:00.000Z",
     "end": "2023-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Sun"
@@ -93,7 +93,7 @@
     "date": "2023-06-29 00:00:00",
     "start": "2023-06-29T10:00:00.000Z",
     "end": "2023-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Thu"

--- a/test/fixtures/PF-2024.json
+++ b/test/fixtures/PF-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-03-05 00:00:00",
     "start": "2024-03-05T10:00:00.000Z",
     "end": "2024-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Tue"
@@ -93,7 +93,7 @@
     "date": "2024-06-29 00:00:00",
     "start": "2024-06-29T10:00:00.000Z",
     "end": "2024-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Sat"

--- a/test/fixtures/PF-2025.json
+++ b/test/fixtures/PF-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-03-05 00:00:00",
     "start": "2025-03-05T10:00:00.000Z",
     "end": "2025-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Wed"
@@ -93,7 +93,7 @@
     "date": "2025-06-29 00:00:00",
     "start": "2025-06-29T10:00:00.000Z",
     "end": "2025-06-30T10:00:00.000Z",
-    "name": "Fête de l'Autonomie",
+    "name": "Fête de l’Autonomie",
     "type": "public",
     "rule": "06-29",
     "_weekday": "Sun"

--- a/test/fixtures/PF-2026.json
+++ b/test/fixtures/PF-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-03-05 00:00:00",
     "start": "2026-03-05T10:00:00.000Z",
     "end": "2026-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2026-11-20 00:00:00",
     "start": "2026-11-20T10:00:00.000Z",
     "end": "2026-11-21T10:00:00.000Z",
-    "name": "Matari'i",
+    "name": "Matari’i",
     "type": "public",
     "rule": "11-20",
     "_weekday": "Fri"

--- a/test/fixtures/PF-2027.json
+++ b/test/fixtures/PF-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-03-05 00:00:00",
     "start": "2027-03-05T10:00:00.000Z",
     "end": "2027-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Fri"
@@ -129,7 +129,7 @@
     "date": "2027-11-20 00:00:00",
     "start": "2027-11-20T10:00:00.000Z",
     "end": "2027-11-21T10:00:00.000Z",
-    "name": "Matari'i",
+    "name": "Matari’i",
     "type": "public",
     "rule": "11-20",
     "_weekday": "Sat"

--- a/test/fixtures/PF-2028.json
+++ b/test/fixtures/PF-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-03-05 00:00:00",
     "start": "2028-03-05T10:00:00.000Z",
     "end": "2028-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2028-11-20 00:00:00",
     "start": "2028-11-20T10:00:00.000Z",
     "end": "2028-11-21T10:00:00.000Z",
-    "name": "Matari'i",
+    "name": "Matari’i",
     "type": "public",
     "rule": "11-20",
     "_weekday": "Mon"

--- a/test/fixtures/PF-2029.json
+++ b/test/fixtures/PF-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-03-05 00:00:00",
     "start": "2029-03-05T10:00:00.000Z",
     "end": "2029-03-06T10:00:00.000Z",
-    "name": "Arrivée de l'Évangile",
+    "name": "Arrivée de l’Évangile",
     "type": "public",
     "rule": "03-05",
     "_weekday": "Mon"
@@ -129,7 +129,7 @@
     "date": "2029-11-20 00:00:00",
     "start": "2029-11-20T10:00:00.000Z",
     "end": "2029-11-21T10:00:00.000Z",
-    "name": "Matari'i",
+    "name": "Matari’i",
     "type": "public",
     "rule": "11-20",
     "_weekday": "Tue"

--- a/test/fixtures/TG-2015.json
+++ b/test/fixtures/TG-2015.json
@@ -39,7 +39,7 @@
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-27T00:00:00.000Z",
     "end": "2015-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Mon"

--- a/test/fixtures/TG-2016.json
+++ b/test/fixtures/TG-2016.json
@@ -30,7 +30,7 @@
     "date": "2016-04-27 00:00:00",
     "start": "2016-04-27T00:00:00.000Z",
     "end": "2016-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Wed"

--- a/test/fixtures/TG-2017.json
+++ b/test/fixtures/TG-2017.json
@@ -30,7 +30,7 @@
     "date": "2017-04-27 00:00:00",
     "start": "2017-04-27T00:00:00.000Z",
     "end": "2017-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Thu"

--- a/test/fixtures/TG-2018.json
+++ b/test/fixtures/TG-2018.json
@@ -30,7 +30,7 @@
     "date": "2018-04-27 00:00:00",
     "start": "2018-04-27T00:00:00.000Z",
     "end": "2018-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Fri"

--- a/test/fixtures/TG-2019.json
+++ b/test/fixtures/TG-2019.json
@@ -30,7 +30,7 @@
     "date": "2019-04-27 00:00:00",
     "start": "2019-04-27T00:00:00.000Z",
     "end": "2019-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Sat"

--- a/test/fixtures/TG-2020.json
+++ b/test/fixtures/TG-2020.json
@@ -30,7 +30,7 @@
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-27T00:00:00.000Z",
     "end": "2020-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Mon"

--- a/test/fixtures/TG-2021.json
+++ b/test/fixtures/TG-2021.json
@@ -30,7 +30,7 @@
     "date": "2021-04-27 00:00:00",
     "start": "2021-04-27T00:00:00.000Z",
     "end": "2021-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Tue"

--- a/test/fixtures/TG-2022.json
+++ b/test/fixtures/TG-2022.json
@@ -30,7 +30,7 @@
     "date": "2022-04-27 00:00:00",
     "start": "2022-04-27T00:00:00.000Z",
     "end": "2022-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Wed"

--- a/test/fixtures/TG-2023.json
+++ b/test/fixtures/TG-2023.json
@@ -39,7 +39,7 @@
     "date": "2023-04-27 00:00:00",
     "start": "2023-04-27T00:00:00.000Z",
     "end": "2023-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Thu"

--- a/test/fixtures/TG-2024.json
+++ b/test/fixtures/TG-2024.json
@@ -39,7 +39,7 @@
     "date": "2024-04-27 00:00:00",
     "start": "2024-04-27T00:00:00.000Z",
     "end": "2024-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Sat"

--- a/test/fixtures/TG-2025.json
+++ b/test/fixtures/TG-2025.json
@@ -39,7 +39,7 @@
     "date": "2025-04-27 00:00:00",
     "start": "2025-04-27T00:00:00.000Z",
     "end": "2025-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Sun"

--- a/test/fixtures/TG-2026.json
+++ b/test/fixtures/TG-2026.json
@@ -39,7 +39,7 @@
     "date": "2026-04-27 00:00:00",
     "start": "2026-04-27T00:00:00.000Z",
     "end": "2026-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Mon"

--- a/test/fixtures/TG-2027.json
+++ b/test/fixtures/TG-2027.json
@@ -39,7 +39,7 @@
     "date": "2027-04-27 00:00:00",
     "start": "2027-04-27T00:00:00.000Z",
     "end": "2027-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Tue"

--- a/test/fixtures/TG-2028.json
+++ b/test/fixtures/TG-2028.json
@@ -39,7 +39,7 @@
     "date": "2028-04-27 00:00:00",
     "start": "2028-04-27T00:00:00.000Z",
     "end": "2028-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Thu"

--- a/test/fixtures/TG-2029.json
+++ b/test/fixtures/TG-2029.json
@@ -48,7 +48,7 @@
     "date": "2029-04-27 00:00:00",
     "start": "2029-04-27T00:00:00.000Z",
     "end": "2029-04-28T00:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Fri"

--- a/test/fixtures/VU-2015.json
+++ b/test/fixtures/VU-2015.json
@@ -84,7 +84,7 @@
     "date": "2015-07-30 00:00:00",
     "start": "2015-07-29T13:00:00.000Z",
     "end": "2015-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Thu"

--- a/test/fixtures/VU-2016.json
+++ b/test/fixtures/VU-2016.json
@@ -84,7 +84,7 @@
     "date": "2016-07-30 00:00:00",
     "start": "2016-07-29T13:00:00.000Z",
     "end": "2016-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Sat"

--- a/test/fixtures/VU-2017.json
+++ b/test/fixtures/VU-2017.json
@@ -84,7 +84,7 @@
     "date": "2017-07-30 00:00:00",
     "start": "2017-07-29T13:00:00.000Z",
     "end": "2017-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Sun"

--- a/test/fixtures/VU-2018.json
+++ b/test/fixtures/VU-2018.json
@@ -84,7 +84,7 @@
     "date": "2018-07-30 00:00:00",
     "start": "2018-07-29T13:00:00.000Z",
     "end": "2018-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Mon"

--- a/test/fixtures/VU-2019.json
+++ b/test/fixtures/VU-2019.json
@@ -84,7 +84,7 @@
     "date": "2019-07-30 00:00:00",
     "start": "2019-07-29T13:00:00.000Z",
     "end": "2019-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Tue"

--- a/test/fixtures/VU-2020.json
+++ b/test/fixtures/VU-2020.json
@@ -84,7 +84,7 @@
     "date": "2020-07-30 00:00:00",
     "start": "2020-07-29T13:00:00.000Z",
     "end": "2020-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Thu"

--- a/test/fixtures/VU-2021.json
+++ b/test/fixtures/VU-2021.json
@@ -84,7 +84,7 @@
     "date": "2021-07-30 00:00:00",
     "start": "2021-07-29T13:00:00.000Z",
     "end": "2021-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Fri"

--- a/test/fixtures/VU-2022.json
+++ b/test/fixtures/VU-2022.json
@@ -84,7 +84,7 @@
     "date": "2022-07-30 00:00:00",
     "start": "2022-07-29T13:00:00.000Z",
     "end": "2022-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Sat"

--- a/test/fixtures/VU-2023.json
+++ b/test/fixtures/VU-2023.json
@@ -84,7 +84,7 @@
     "date": "2023-07-30 00:00:00",
     "start": "2023-07-29T13:00:00.000Z",
     "end": "2023-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Sun"

--- a/test/fixtures/VU-2024.json
+++ b/test/fixtures/VU-2024.json
@@ -84,7 +84,7 @@
     "date": "2024-07-30 00:00:00",
     "start": "2024-07-29T13:00:00.000Z",
     "end": "2024-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Tue"

--- a/test/fixtures/VU-2025.json
+++ b/test/fixtures/VU-2025.json
@@ -84,7 +84,7 @@
     "date": "2025-07-30 00:00:00",
     "start": "2025-07-29T13:00:00.000Z",
     "end": "2025-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Wed"

--- a/test/fixtures/VU-2026.json
+++ b/test/fixtures/VU-2026.json
@@ -84,7 +84,7 @@
     "date": "2026-07-30 00:00:00",
     "start": "2026-07-29T13:00:00.000Z",
     "end": "2026-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Thu"

--- a/test/fixtures/VU-2027.json
+++ b/test/fixtures/VU-2027.json
@@ -84,7 +84,7 @@
     "date": "2027-07-30 00:00:00",
     "start": "2027-07-29T13:00:00.000Z",
     "end": "2027-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Fri"

--- a/test/fixtures/VU-2028.json
+++ b/test/fixtures/VU-2028.json
@@ -84,7 +84,7 @@
     "date": "2028-07-30 00:00:00",
     "start": "2028-07-29T13:00:00.000Z",
     "end": "2028-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Sun"

--- a/test/fixtures/VU-2029.json
+++ b/test/fixtures/VU-2029.json
@@ -84,7 +84,7 @@
     "date": "2029-07-30 00:00:00",
     "start": "2029-07-29T13:00:00.000Z",
     "end": "2029-07-30T13:00:00.000Z",
-    "name": "Jour de l'Indépendance",
+    "name": "Jour de l’Indépendance",
     "type": "public",
     "rule": "07-30",
     "_weekday": "Mon"


### PR DESCRIPTION
This update cleans up French holiday names by using the proper typographic apostrophe (`’`) instead of the straight ASCII apostrophe (`'`).

The typographic form is the standard choice in well-formatted French text and improves consistency and readability, even when older or less carefully formatted sources use the straight apostrophe.

Saint Martin now also reuses the existing shared `Abolition of Slavery` name.