### PR TITLE
fix(TO): align holidays with official source

### DIFF
--- a/data/countries/TO.yaml
+++ b/data/countries/TO.yaml
@@ -1,5 +1,6 @@
 holidays:
-  # @source http://www.mic.gov.to/news-today/press-releases/7066-tonga-public-holidays-for-2018-
+  # @source https://pmo.gov.to/tonga-public-holidays-for-2026/
+  # @attrib https://en.wikipedia.org/wiki/Culture_of_Tonga#Public_holidays
   TO:
     names:
       to: Puleʻanga Fakatuʻi ʻo Tonga
@@ -26,16 +27,16 @@ holidays:
       07-04:
         name:
           en: Official Birthday of His Majesty King Tupou VI
-      09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday:
+      09-17:
         name:
           en: Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala
-      11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday:
+      11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday:
         _name: Constitution Day
         name:
           en: Constitutional Day
       12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday:
         name:
-          en: Tupou I Day
+          en: Anniversary of the Coronation of H.M. King George Tupou I
       12-25:
         _name: 12-25
       12-26:

--- a/test/fixtures/TO-2015.json
+++ b/test/fixtures/TO-2015.json
@@ -54,28 +54,28 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2015-09-21 00:00:00",
-    "start": "2015-09-20T11:00:00.000Z",
-    "end": "2015-09-21T11:00:00.000Z",
+    "date": "2015-09-17 00:00:00",
+    "start": "2015-09-16T11:00:00.000Z",
+    "end": "2015-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
+    "rule": "09-17",
+    "_weekday": "Thu"
   },
   {
-    "date": "2015-11-04 00:00:00",
-    "start": "2015-11-03T11:00:00.000Z",
-    "end": "2015-11-04T11:00:00.000Z",
+    "date": "2015-11-02 00:00:00",
+    "start": "2015-11-01T11:00:00.000Z",
+    "end": "2015-11-02T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Wed"
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2015-12-07 00:00:00",
     "start": "2015-12-06T11:00:00.000Z",
     "end": "2015-12-07T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2016.json
+++ b/test/fixtures/TO-2016.json
@@ -54,13 +54,13 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2016-09-19 00:00:00",
-    "start": "2016-09-18T11:00:00.000Z",
-    "end": "2016-09-19T11:00:00.000Z",
+    "date": "2016-09-17 00:00:00",
+    "start": "2016-09-16T11:00:00.000Z",
+    "end": "2016-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
+    "rule": "09-17",
+    "_weekday": "Sat"
   },
   {
     "date": "2016-11-07 00:00:00",
@@ -68,14 +68,14 @@
     "end": "2016-11-07T10:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2016-12-05 00:00:00",
     "start": "2016-12-04T10:00:00.000Z",
     "end": "2016-12-05T10:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2017.json
+++ b/test/fixtures/TO-2017.json
@@ -54,13 +54,13 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2017-09-18 00:00:00",
-    "start": "2017-09-17T11:00:00.000Z",
-    "end": "2017-09-18T11:00:00.000Z",
+    "date": "2017-09-17 00:00:00",
+    "start": "2017-09-16T11:00:00.000Z",
+    "end": "2017-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
+    "rule": "09-17",
+    "_weekday": "Sun"
   },
   {
     "date": "2017-11-06 00:00:00",
@@ -68,14 +68,14 @@
     "end": "2017-11-06T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2017-12-04 00:00:00",
     "start": "2017-12-03T11:00:00.000Z",
     "end": "2017-12-04T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2018.json
+++ b/test/fixtures/TO-2018.json
@@ -59,7 +59,7 @@
     "end": "2018-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "09-17",
     "_weekday": "Mon"
   },
   {
@@ -68,14 +68,14 @@
     "end": "2018-11-05T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2018-12-03 00:00:00",
     "start": "2018-12-02T11:00:00.000Z",
     "end": "2018-12-03T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"
@@ -84,7 +84,7 @@
     "date": "2018-12-04 00:00:00",
     "start": "2018-12-03T11:00:00.000Z",
     "end": "2018-12-04T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Tue"

--- a/test/fixtures/TO-2019.json
+++ b/test/fixtures/TO-2019.json
@@ -63,21 +63,12 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2019-09-16 00:00:00",
-    "start": "2019-09-15T11:00:00.000Z",
-    "end": "2019-09-16T11:00:00.000Z",
-    "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
-    "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2019-09-17 00:00:00",
     "start": "2019-09-16T11:00:00.000Z",
     "end": "2019-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "09-17",
     "_weekday": "Tue"
   },
   {
@@ -86,14 +77,14 @@
     "end": "2019-11-04T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2019-12-04 00:00:00",
     "start": "2019-12-03T11:00:00.000Z",
     "end": "2019-12-04T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Wed"

--- a/test/fixtures/TO-2020.json
+++ b/test/fixtures/TO-2020.json
@@ -54,28 +54,28 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2020-09-21 00:00:00",
-    "start": "2020-09-20T11:00:00.000Z",
-    "end": "2020-09-21T11:00:00.000Z",
+    "date": "2020-09-17 00:00:00",
+    "start": "2020-09-16T11:00:00.000Z",
+    "end": "2020-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
+    "rule": "09-17",
+    "_weekday": "Thu"
   },
   {
-    "date": "2020-11-04 00:00:00",
-    "start": "2020-11-03T11:00:00.000Z",
-    "end": "2020-11-04T11:00:00.000Z",
+    "date": "2020-11-02 00:00:00",
+    "start": "2020-11-01T11:00:00.000Z",
+    "end": "2020-11-02T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Wed"
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2020-12-07 00:00:00",
     "start": "2020-12-06T11:00:00.000Z",
     "end": "2020-12-07T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2021.json
+++ b/test/fixtures/TO-2021.json
@@ -54,13 +54,13 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2021-09-20 00:00:00",
-    "start": "2021-09-19T11:00:00.000Z",
-    "end": "2021-09-20T11:00:00.000Z",
+    "date": "2021-09-17 00:00:00",
+    "start": "2021-09-16T11:00:00.000Z",
+    "end": "2021-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
+    "rule": "09-17",
+    "_weekday": "Fri"
   },
   {
     "date": "2021-11-08 00:00:00",
@@ -68,14 +68,14 @@
     "end": "2021-11-08T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2021-12-06 00:00:00",
     "start": "2021-12-05T11:00:00.000Z",
     "end": "2021-12-06T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2022.json
+++ b/test/fixtures/TO-2022.json
@@ -54,13 +54,13 @@
     "_weekday": "Mon"
   },
   {
-    "date": "2022-09-19 00:00:00",
-    "start": "2022-09-18T11:00:00.000Z",
-    "end": "2022-09-19T11:00:00.000Z",
+    "date": "2022-09-17 00:00:00",
+    "start": "2022-09-16T11:00:00.000Z",
+    "end": "2022-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
+    "rule": "09-17",
+    "_weekday": "Sat"
   },
   {
     "date": "2022-11-07 00:00:00",
@@ -68,14 +68,14 @@
     "end": "2022-11-07T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2022-12-05 00:00:00",
     "start": "2022-12-04T11:00:00.000Z",
     "end": "2022-12-05T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2023.json
+++ b/test/fixtures/TO-2023.json
@@ -54,13 +54,13 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2023-09-18 00:00:00",
-    "start": "2023-09-17T11:00:00.000Z",
-    "end": "2023-09-18T11:00:00.000Z",
+    "date": "2023-09-17 00:00:00",
+    "start": "2023-09-16T11:00:00.000Z",
+    "end": "2023-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
+    "rule": "09-17",
+    "_weekday": "Sun"
   },
   {
     "date": "2023-11-06 00:00:00",
@@ -68,14 +68,14 @@
     "end": "2023-11-06T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2023-12-04 00:00:00",
     "start": "2023-12-03T11:00:00.000Z",
     "end": "2023-12-04T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2024.json
+++ b/test/fixtures/TO-2024.json
@@ -63,21 +63,12 @@
     "_weekday": "Thu"
   },
   {
-    "date": "2024-09-16 00:00:00",
-    "start": "2024-09-15T11:00:00.000Z",
-    "end": "2024-09-16T11:00:00.000Z",
-    "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
-    "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
-  },
-  {
     "date": "2024-09-17 00:00:00",
     "start": "2024-09-16T11:00:00.000Z",
     "end": "2024-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "09-17",
     "_weekday": "Tue"
   },
   {
@@ -86,14 +77,14 @@
     "end": "2024-11-04T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2024-12-04 00:00:00",
     "start": "2024-12-03T11:00:00.000Z",
     "end": "2024-12-04T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Wed"

--- a/test/fixtures/TO-2025.json
+++ b/test/fixtures/TO-2025.json
@@ -59,7 +59,7 @@
     "end": "2025-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "09-17",
     "_weekday": "Wed"
   },
   {
@@ -68,23 +68,14 @@
     "end": "2025-11-03T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
-  },
-  {
-    "date": "2025-11-04 00:00:00",
-    "start": "2025-11-03T11:00:00.000Z",
-    "end": "2025-11-04T11:00:00.000Z",
-    "name": "Constitutional Day",
-    "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Tue"
   },
   {
     "date": "2025-12-08 00:00:00",
     "start": "2025-12-07T11:00:00.000Z",
     "end": "2025-12-08T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2026.json
+++ b/test/fixtures/TO-2026.json
@@ -54,28 +54,28 @@
     "_weekday": "Sat"
   },
   {
-    "date": "2026-09-21 00:00:00",
-    "start": "2026-09-20T11:00:00.000Z",
-    "end": "2026-09-21T11:00:00.000Z",
+    "date": "2026-09-17 00:00:00",
+    "start": "2026-09-16T11:00:00.000Z",
+    "end": "2026-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
+    "rule": "09-17",
+    "_weekday": "Thu"
   },
   {
-    "date": "2026-11-04 00:00:00",
-    "start": "2026-11-03T11:00:00.000Z",
-    "end": "2026-11-04T11:00:00.000Z",
+    "date": "2026-11-02 00:00:00",
+    "start": "2026-11-01T11:00:00.000Z",
+    "end": "2026-11-02T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Wed"
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2026-12-07 00:00:00",
     "start": "2026-12-06T11:00:00.000Z",
     "end": "2026-12-07T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2027.json
+++ b/test/fixtures/TO-2027.json
@@ -54,13 +54,13 @@
     "_weekday": "Sun"
   },
   {
-    "date": "2027-09-20 00:00:00",
-    "start": "2027-09-19T11:00:00.000Z",
-    "end": "2027-09-20T11:00:00.000Z",
+    "date": "2027-09-17 00:00:00",
+    "start": "2027-09-16T11:00:00.000Z",
+    "end": "2027-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
+    "rule": "09-17",
+    "_weekday": "Fri"
   },
   {
     "date": "2027-11-08 00:00:00",
@@ -68,14 +68,14 @@
     "end": "2027-11-08T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2027-12-06 00:00:00",
     "start": "2027-12-05T11:00:00.000Z",
     "end": "2027-12-06T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2028.json
+++ b/test/fixtures/TO-2028.json
@@ -54,13 +54,13 @@
     "_weekday": "Tue"
   },
   {
-    "date": "2028-09-18 00:00:00",
-    "start": "2028-09-17T11:00:00.000Z",
-    "end": "2028-09-18T11:00:00.000Z",
+    "date": "2028-09-17 00:00:00",
+    "start": "2028-09-16T11:00:00.000Z",
+    "end": "2028-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
-    "_weekday": "Mon"
+    "rule": "09-17",
+    "_weekday": "Sun"
   },
   {
     "date": "2028-11-06 00:00:00",
@@ -68,14 +68,14 @@
     "end": "2028-11-06T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2028-12-04 00:00:00",
     "start": "2028-12-03T11:00:00.000Z",
     "end": "2028-12-04T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"

--- a/test/fixtures/TO-2029.json
+++ b/test/fixtures/TO-2029.json
@@ -59,7 +59,7 @@
     "end": "2029-09-17T11:00:00.000Z",
     "name": "Birthday of His Royal Highness The Crown Prince Tupotoʻa-ʻUlukalala",
     "type": "public",
-    "rule": "09-17 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "09-17",
     "_weekday": "Mon"
   },
   {
@@ -68,14 +68,14 @@
     "end": "2029-11-05T11:00:00.000Z",
     "name": "Constitutional Day",
     "type": "public",
-    "rule": "11-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
+    "rule": "11-04 if thursday,friday,saturday,sunday then next monday if tuesday,wednesday then previous monday",
     "_weekday": "Mon"
   },
   {
     "date": "2029-12-03 00:00:00",
     "start": "2029-12-02T11:00:00.000Z",
     "end": "2029-12-03T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Mon"
@@ -84,7 +84,7 @@
     "date": "2029-12-04 00:00:00",
     "start": "2029-12-03T11:00:00.000Z",
     "end": "2029-12-04T11:00:00.000Z",
-    "name": "Tupou I Day",
+    "name": "Anniversary of the Coronation of H.M. King George Tupou I",
     "type": "public",
     "rule": "12-04 if thursday,friday,saturday,sunday then next monday and if tuesday then previous monday",
     "_weekday": "Tue"


### PR DESCRIPTION
Updated Tonga’s public holidays using a current official government source (https://pmo.gov.to/tonga-public-holidays-for-2026/) and added the relevant Wikipedia reference. Fixed the incorrect September 17 rule, adjusted November 4, and updated the December 4 holiday name.