### PR TITLE
fix(SK): use official sources, fix Good Friday name, mark Easter Sunday as observance

### DIFF
--- a/data/countries/SK.yaml
+++ b/data/countries/SK.yaml
@@ -22,6 +22,7 @@ holidays:
         _name: easter -2
       easter:
         _name: easter
+        type: observance
       easter 1:
         _name: easter 1
       05-01:

--- a/data/countries/SK.yaml
+++ b/data/countries/SK.yaml
@@ -1,5 +1,6 @@
 # @source https://nbs.sk/o-narodnej-banke/sviatky-v-sr/
-# @attrib https://cs.wikipedia.org/wiki/St%C3%A1tn%C3%AD_sv%C3%A1tky_Slovenska
+# @source https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1993/241
+# @attrib https://sk.wikipedia.org/wiki/Zoznam_sviatkov_na_Slovensku
 holidays:
   SK:
     names:

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -592,7 +592,7 @@ names:
       pl: Wielki Piątek
       pt: Sexta-Feira Santa
       ro: Vinerea Mare
-      sk: Veľkonočný piatok
+      sk: Veľký piatok
       sq: E Premtja e Madhe
       sr: Католички Велики петак
       sv: långfredagen

--- a/test/fixtures/SK-2015.json
+++ b/test/fixtures/SK-2015.json
@@ -21,7 +21,7 @@
     "date": "2015-04-03 00:00:00",
     "start": "2015-04-02T22:00:00.000Z",
     "end": "2015-04-03T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2015.json
+++ b/test/fixtures/SK-2015.json
@@ -31,7 +31,7 @@
     "start": "2015-04-04T22:00:00.000Z",
     "end": "2015-04-05T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2016.json
+++ b/test/fixtures/SK-2016.json
@@ -31,7 +31,7 @@
     "start": "2016-03-26T23:00:00.000Z",
     "end": "2016-03-27T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2016.json
+++ b/test/fixtures/SK-2016.json
@@ -21,7 +21,7 @@
     "date": "2016-03-25 00:00:00",
     "start": "2016-03-24T23:00:00.000Z",
     "end": "2016-03-25T23:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2017.json
+++ b/test/fixtures/SK-2017.json
@@ -21,7 +21,7 @@
     "date": "2017-04-14 00:00:00",
     "start": "2017-04-13T22:00:00.000Z",
     "end": "2017-04-14T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2017.json
+++ b/test/fixtures/SK-2017.json
@@ -31,7 +31,7 @@
     "start": "2017-04-15T22:00:00.000Z",
     "end": "2017-04-16T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2018.json
+++ b/test/fixtures/SK-2018.json
@@ -31,7 +31,7 @@
     "start": "2018-03-31T22:00:00.000Z",
     "end": "2018-04-01T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2018.json
+++ b/test/fixtures/SK-2018.json
@@ -21,7 +21,7 @@
     "date": "2018-03-30 00:00:00",
     "start": "2018-03-29T22:00:00.000Z",
     "end": "2018-03-30T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2019.json
+++ b/test/fixtures/SK-2019.json
@@ -31,7 +31,7 @@
     "start": "2019-04-20T22:00:00.000Z",
     "end": "2019-04-21T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2019.json
+++ b/test/fixtures/SK-2019.json
@@ -21,7 +21,7 @@
     "date": "2019-04-19 00:00:00",
     "start": "2019-04-18T22:00:00.000Z",
     "end": "2019-04-19T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2020.json
+++ b/test/fixtures/SK-2020.json
@@ -21,7 +21,7 @@
     "date": "2020-04-10 00:00:00",
     "start": "2020-04-09T22:00:00.000Z",
     "end": "2020-04-10T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2020.json
+++ b/test/fixtures/SK-2020.json
@@ -31,7 +31,7 @@
     "start": "2020-04-11T22:00:00.000Z",
     "end": "2020-04-12T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2021.json
+++ b/test/fixtures/SK-2021.json
@@ -31,7 +31,7 @@
     "start": "2021-04-03T22:00:00.000Z",
     "end": "2021-04-04T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2021.json
+++ b/test/fixtures/SK-2021.json
@@ -21,7 +21,7 @@
     "date": "2021-04-02 00:00:00",
     "start": "2021-04-01T22:00:00.000Z",
     "end": "2021-04-02T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2022.json
+++ b/test/fixtures/SK-2022.json
@@ -21,7 +21,7 @@
     "date": "2022-04-15 00:00:00",
     "start": "2022-04-14T22:00:00.000Z",
     "end": "2022-04-15T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2022.json
+++ b/test/fixtures/SK-2022.json
@@ -31,7 +31,7 @@
     "start": "2022-04-16T22:00:00.000Z",
     "end": "2022-04-17T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2023.json
+++ b/test/fixtures/SK-2023.json
@@ -21,7 +21,7 @@
     "date": "2023-04-07 00:00:00",
     "start": "2023-04-06T22:00:00.000Z",
     "end": "2023-04-07T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2023.json
+++ b/test/fixtures/SK-2023.json
@@ -31,7 +31,7 @@
     "start": "2023-04-08T22:00:00.000Z",
     "end": "2023-04-09T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2024.json
+++ b/test/fixtures/SK-2024.json
@@ -21,7 +21,7 @@
     "date": "2024-03-29 00:00:00",
     "start": "2024-03-28T23:00:00.000Z",
     "end": "2024-03-29T23:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2024.json
+++ b/test/fixtures/SK-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-03-30T23:00:00.000Z",
     "end": "2024-03-31T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2025.json
+++ b/test/fixtures/SK-2025.json
@@ -21,7 +21,7 @@
     "date": "2025-04-18 00:00:00",
     "start": "2025-04-17T22:00:00.000Z",
     "end": "2025-04-18T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2025.json
+++ b/test/fixtures/SK-2025.json
@@ -31,7 +31,7 @@
     "start": "2025-04-19T22:00:00.000Z",
     "end": "2025-04-20T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2026.json
+++ b/test/fixtures/SK-2026.json
@@ -31,7 +31,7 @@
     "start": "2026-04-04T22:00:00.000Z",
     "end": "2026-04-05T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2026.json
+++ b/test/fixtures/SK-2026.json
@@ -21,7 +21,7 @@
     "date": "2026-04-03 00:00:00",
     "start": "2026-04-02T22:00:00.000Z",
     "end": "2026-04-03T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2027.json
+++ b/test/fixtures/SK-2027.json
@@ -21,7 +21,7 @@
     "date": "2027-03-26 00:00:00",
     "start": "2027-03-25T23:00:00.000Z",
     "end": "2027-03-26T23:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2027.json
+++ b/test/fixtures/SK-2027.json
@@ -31,7 +31,7 @@
     "start": "2027-03-27T23:00:00.000Z",
     "end": "2027-03-28T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2028.json
+++ b/test/fixtures/SK-2028.json
@@ -31,7 +31,7 @@
     "start": "2028-04-15T22:00:00.000Z",
     "end": "2028-04-16T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },

--- a/test/fixtures/SK-2028.json
+++ b/test/fixtures/SK-2028.json
@@ -21,7 +21,7 @@
     "date": "2028-04-14 00:00:00",
     "start": "2028-04-13T22:00:00.000Z",
     "end": "2028-04-14T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2029.json
+++ b/test/fixtures/SK-2029.json
@@ -21,7 +21,7 @@
     "date": "2029-03-30 00:00:00",
     "start": "2029-03-29T22:00:00.000Z",
     "end": "2029-03-30T22:00:00.000Z",
-    "name": "Veľkonočný piatok",
+    "name": "Veľký piatok",
     "type": "public",
     "rule": "easter -2",
     "_weekday": "Fri"

--- a/test/fixtures/SK-2029.json
+++ b/test/fixtures/SK-2029.json
@@ -31,7 +31,7 @@
     "start": "2029-03-31T22:00:00.000Z",
     "end": "2029-04-01T22:00:00.000Z",
     "name": "Veľká noc",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },


### PR DESCRIPTION
I swapped the `@attrib` from the Czech Wikipedia article to the Slovak one, since it's in the right language and links directly to the actual law (241/1993 Z.z.) behind these holidays. Added that law as a second reference too.

While comparing against it and the National Bank's holiday page, I noticed Good Friday was translated as "Veľkonočný piatok" in `names.yaml` - both sources agree it should be "Veľký piatok", so fixed that.

Lastly, neither source lists Easter Sunday itself as a "sviatok" (holiday) or "deň pracovného pokoja" (non-working day) - only Good Friday and Easter Monday are called out, since Easter Sunday is always a Sunday anyway. Marked it as `observance` instead of a statutory holiday to reflect that.