### PR TITLE
fix(SI): fix Slovenian capitalization + align wording with gov.si

### DIFF
--- a/data/countries/SI.yaml
+++ b/data/countries/SI.yaml
@@ -1,3 +1,4 @@
+# @source https://www.gov.si/teme/drzavni-prazniki-in-dela-prosti-dnevi/
 # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Slovenia
 holidays:
   SI:
@@ -42,7 +43,7 @@ holidays:
         _name: easter 1
       04-27:
         name:
-          sl: Dan upora proti okupatorju
+          sl: dan upora proti okupatorju
           en: Day of Uprising Against Occupation
       05-01:
         _name: 05-01
@@ -60,14 +61,14 @@ holidays:
         _name: easter 49
       06-08:
         name:
-          sl: Dan Primoža Trubarja
+          sl: dan Primoža Trubarja
           en: Primož Trubar Day
         type: observance
         active:
           - from: 2010
       06-25:
         name:
-          sl: Dan državnosti
+          sl: dan državnosti
           en: Statehood Day
         active:
           - from: 1991
@@ -77,39 +78,39 @@ holidays:
           - from: 1992
       08-17:
         name:
-          sl: Združitev prekmurskih Slovencev z matičnim narodom
+          sl: združitev prekmurskih Slovencev z matičnim narodom
           en: Unification of Prekmurje Slovenes with the Mother Nation
         type: observance
         active:
           - from: 2006
       09-15:
         name:
-          sl: Vrnitev Primorske k matični domovini
+          sl: priključitev Primorske k matični domovini
           en: Return of Primorska to the Motherland
         type: observance
         active:
           - from: 2005
       09-23:
         name:
-          sl: Dan slovenskega športa
+          sl: dan slovenskega športa
           en: Slovenian Sports Day
         type: observance
         active:
           - from: 2020
       10-25:
         name:
-          sl: Dan suverenosti
+          sl: dan suverenosti
           en: Sovereignty Day
         type: observance
         active:
           - from: 2015
       10-31:
         name:
-          sl: Dan reformacije
+          sl: dan reformacije
           en: Reformation Day
       11-01:
         name:
-          sl: Dan spomina na mrtve
+          sl: dan spomina na mrtve
           en: Day of Remembrance for the Dead
       11-11:
         name:
@@ -118,7 +119,7 @@ holidays:
         type: observance
       11-23:
         name:
-          sl: Dan Rudolfa Maistra
+          sl: dan Rudolfa Maistra
           en: Rudolf Maister Day
         type: observance
         active:
@@ -135,7 +136,7 @@ holidays:
           - from: 1991
       12-26:
         name:
-          sl: Dan samostojnosti in enotnosti
+          sl: dan samostojnosti in enotnosti
           en: Independence and Unity Day
     # regions:
     # '001':

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -54,7 +54,7 @@ names:
       pt: Ano Novo
       ro: Anul nou
       ru: Новый год
-      sl: Novo leto
+      sl: novo leto
       sq: Viti i Ri
       sr: Нова година
       sv: nyårsdagen
@@ -193,7 +193,7 @@ names:
       pt: Dia do trabalhador
       ro: Ziua muncii
       sk: Sviatok práce
-      sl: Praznik dela
+      sl: praznik dela
       sq: Dita Ndërkombëtare e Punonjësve
       sr: Празник рада
       sv: första maj
@@ -419,7 +419,7 @@ names:
       ro: Crăciunul
       ru: Рождество Христово
       sk: Prvý sviatok vianočný
-      sl: Božič
+      sl: božič
       sq: Krishtlindja
       sr: Католички Божић
       sv: juldagen
@@ -650,7 +650,7 @@ names:
       pt: Páscoa
       ro: Paștele
       sk: Veľká noc
-      sl: Velika noč
+      sl: velikonočna nedelja
       sq: Pashkët Katolike
       sr: Католички Васкрс
       sv: påskdagen
@@ -687,7 +687,7 @@ names:
       pl: Drugi dzień Wielkanocy
       ro: A doua zi de Pasti
       sk: Veľkonočný pondelok
-      sl: Velikonočni ponedeljek
+      sl: velikonočni ponedeljek
       sr: Католички Васкрсни понедељак
       sv: annandag påsk
       sw: Jumatatu ya Pasaka
@@ -735,7 +735,7 @@ names:
       mk: Духовден
       pl: Zielone Świątki
       ro: Rusaliile
-      sl: Binkošti
+      sl: binkošti
       sv: pingstdagen
       uk: Трійця
       vi: Lễ Chúa Thánh Thần Hiện Xuống

--- a/test/fixtures/SI-2015.json
+++ b/test/fixtures/SI-2015.json
@@ -3,7 +3,7 @@
     "date": "2015-01-01 00:00:00",
     "start": "2014-12-31T23:00:00.000Z",
     "end": "2015-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"
@@ -39,7 +39,7 @@
     "date": "2015-04-05 00:00:00",
     "start": "2015-04-04T22:00:00.000Z",
     "end": "2015-04-05T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2015-04-06 00:00:00",
     "start": "2015-04-05T22:00:00.000Z",
     "end": "2015-04-06T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2015-04-27 00:00:00",
     "start": "2015-04-26T22:00:00.000Z",
     "end": "2015-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2015-05-01 00:00:00",
     "start": "2015-04-30T22:00:00.000Z",
     "end": "2015-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -84,7 +84,7 @@
     "date": "2015-05-02 00:00:00",
     "start": "2015-05-01T22:00:00.000Z",
     "end": "2015-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2015-05-24 00:00:00",
     "start": "2015-05-23T22:00:00.000Z",
     "end": "2015-05-24T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2015-06-08 00:00:00",
     "start": "2015-06-07T22:00:00.000Z",
     "end": "2015-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2015-06-25 00:00:00",
     "start": "2015-06-24T22:00:00.000Z",
     "end": "2015-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Thu"
@@ -129,7 +129,7 @@
     "date": "2015-08-17 00:00:00",
     "start": "2015-08-16T22:00:00.000Z",
     "end": "2015-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Mon"
@@ -138,7 +138,7 @@
     "date": "2015-09-15 00:00:00",
     "start": "2015-09-14T22:00:00.000Z",
     "end": "2015-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Tue"
@@ -147,7 +147,7 @@
     "date": "2015-10-25 00:00:00",
     "start": "2015-10-24T22:00:00.000Z",
     "end": "2015-10-25T23:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2015-10-31 00:00:00",
     "start": "2015-10-30T23:00:00.000Z",
     "end": "2015-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Sat"
@@ -165,7 +165,7 @@
     "date": "2015-11-01 00:00:00",
     "start": "2015-10-31T23:00:00.000Z",
     "end": "2015-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Sun"
@@ -183,7 +183,7 @@
     "date": "2015-11-23 00:00:00",
     "start": "2015-11-22T23:00:00.000Z",
     "end": "2015-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Mon"
@@ -201,7 +201,7 @@
     "date": "2015-12-25 00:00:00",
     "start": "2015-12-24T23:00:00.000Z",
     "end": "2015-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -210,7 +210,7 @@
     "date": "2015-12-26 00:00:00",
     "start": "2015-12-25T23:00:00.000Z",
     "end": "2015-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/SI-2016.json
+++ b/test/fixtures/SI-2016.json
@@ -3,7 +3,7 @@
     "date": "2016-01-01 00:00:00",
     "start": "2015-12-31T23:00:00.000Z",
     "end": "2016-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -39,7 +39,7 @@
     "date": "2016-03-27 00:00:00",
     "start": "2016-03-26T23:00:00.000Z",
     "end": "2016-03-27T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2016-03-28 00:00:00",
     "start": "2016-03-27T22:00:00.000Z",
     "end": "2016-03-28T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2016-04-27 00:00:00",
     "start": "2016-04-26T22:00:00.000Z",
     "end": "2016-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Wed"
@@ -75,7 +75,7 @@
     "date": "2016-05-01 00:00:00",
     "start": "2016-04-30T22:00:00.000Z",
     "end": "2016-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2016-05-02 00:00:00",
     "start": "2016-05-01T22:00:00.000Z",
     "end": "2016-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2016-05-15 00:00:00",
     "start": "2016-05-14T22:00:00.000Z",
     "end": "2016-05-15T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2016-06-08 00:00:00",
     "start": "2016-06-07T22:00:00.000Z",
     "end": "2016-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Wed"
@@ -111,7 +111,7 @@
     "date": "2016-06-25 00:00:00",
     "start": "2016-06-24T22:00:00.000Z",
     "end": "2016-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Sat"
@@ -129,7 +129,7 @@
     "date": "2016-08-17 00:00:00",
     "start": "2016-08-16T22:00:00.000Z",
     "end": "2016-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Wed"
@@ -138,7 +138,7 @@
     "date": "2016-09-15 00:00:00",
     "start": "2016-09-14T22:00:00.000Z",
     "end": "2016-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Thu"
@@ -147,7 +147,7 @@
     "date": "2016-10-25 00:00:00",
     "start": "2016-10-24T22:00:00.000Z",
     "end": "2016-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Tue"
@@ -156,7 +156,7 @@
     "date": "2016-10-31 00:00:00",
     "start": "2016-10-30T23:00:00.000Z",
     "end": "2016-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2016-11-01 00:00:00",
     "start": "2016-10-31T23:00:00.000Z",
     "end": "2016-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Tue"
@@ -183,7 +183,7 @@
     "date": "2016-11-23 00:00:00",
     "start": "2016-11-22T23:00:00.000Z",
     "end": "2016-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Wed"
@@ -201,7 +201,7 @@
     "date": "2016-12-25 00:00:00",
     "start": "2016-12-24T23:00:00.000Z",
     "end": "2016-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
@@ -210,7 +210,7 @@
     "date": "2016-12-26 00:00:00",
     "start": "2016-12-25T23:00:00.000Z",
     "end": "2016-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"

--- a/test/fixtures/SI-2017.json
+++ b/test/fixtures/SI-2017.json
@@ -3,7 +3,7 @@
     "date": "2017-01-01 00:00:00",
     "start": "2016-12-31T23:00:00.000Z",
     "end": "2017-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"
@@ -12,7 +12,7 @@
     "date": "2017-01-02 00:00:00",
     "start": "2017-01-01T23:00:00.000Z",
     "end": "2017-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2017-04-16 00:00:00",
     "start": "2017-04-15T22:00:00.000Z",
     "end": "2017-04-16T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T22:00:00.000Z",
     "end": "2017-04-17T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2017-04-27 00:00:00",
     "start": "2017-04-26T22:00:00.000Z",
     "end": "2017-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T22:00:00.000Z",
     "end": "2017-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2017-05-02 00:00:00",
     "start": "2017-05-01T22:00:00.000Z",
     "end": "2017-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2017-06-04 00:00:00",
     "start": "2017-06-03T22:00:00.000Z",
     "end": "2017-06-04T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2017-06-08 00:00:00",
     "start": "2017-06-07T22:00:00.000Z",
     "end": "2017-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Thu"
@@ -120,7 +120,7 @@
     "date": "2017-06-25 00:00:00",
     "start": "2017-06-24T22:00:00.000Z",
     "end": "2017-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Sun"
@@ -138,7 +138,7 @@
     "date": "2017-08-17 00:00:00",
     "start": "2017-08-16T22:00:00.000Z",
     "end": "2017-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Thu"
@@ -147,7 +147,7 @@
     "date": "2017-09-15 00:00:00",
     "start": "2017-09-14T22:00:00.000Z",
     "end": "2017-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Fri"
@@ -156,7 +156,7 @@
     "date": "2017-10-25 00:00:00",
     "start": "2017-10-24T22:00:00.000Z",
     "end": "2017-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Wed"
@@ -165,7 +165,7 @@
     "date": "2017-10-31 00:00:00",
     "start": "2017-10-30T23:00:00.000Z",
     "end": "2017-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Tue"
@@ -174,7 +174,7 @@
     "date": "2017-11-01 00:00:00",
     "start": "2017-10-31T23:00:00.000Z",
     "end": "2017-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Wed"
@@ -192,7 +192,7 @@
     "date": "2017-11-23 00:00:00",
     "start": "2017-11-22T23:00:00.000Z",
     "end": "2017-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Thu"
@@ -210,7 +210,7 @@
     "date": "2017-12-25 00:00:00",
     "start": "2017-12-24T23:00:00.000Z",
     "end": "2017-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -219,7 +219,7 @@
     "date": "2017-12-26 00:00:00",
     "start": "2017-12-25T23:00:00.000Z",
     "end": "2017-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/SI-2018.json
+++ b/test/fixtures/SI-2018.json
@@ -3,7 +3,7 @@
     "date": "2018-01-01 00:00:00",
     "start": "2017-12-31T23:00:00.000Z",
     "end": "2018-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -12,7 +12,7 @@
     "date": "2018-01-02 00:00:00",
     "start": "2018-01-01T23:00:00.000Z",
     "end": "2018-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2018-04-01 00:00:00",
     "start": "2018-03-31T22:00:00.000Z",
     "end": "2018-04-01T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2018-04-02 00:00:00",
     "start": "2018-04-01T22:00:00.000Z",
     "end": "2018-04-02T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2018-04-27 00:00:00",
     "start": "2018-04-26T22:00:00.000Z",
     "end": "2018-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Fri"
@@ -84,7 +84,7 @@
     "date": "2018-05-01 00:00:00",
     "start": "2018-04-30T22:00:00.000Z",
     "end": "2018-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -93,7 +93,7 @@
     "date": "2018-05-02 00:00:00",
     "start": "2018-05-01T22:00:00.000Z",
     "end": "2018-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Wed"
@@ -102,7 +102,7 @@
     "date": "2018-05-20 00:00:00",
     "start": "2018-05-19T22:00:00.000Z",
     "end": "2018-05-20T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2018-06-08 00:00:00",
     "start": "2018-06-07T22:00:00.000Z",
     "end": "2018-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Fri"
@@ -120,7 +120,7 @@
     "date": "2018-06-25 00:00:00",
     "start": "2018-06-24T22:00:00.000Z",
     "end": "2018-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Mon"
@@ -138,7 +138,7 @@
     "date": "2018-08-17 00:00:00",
     "start": "2018-08-16T22:00:00.000Z",
     "end": "2018-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Fri"
@@ -147,7 +147,7 @@
     "date": "2018-09-15 00:00:00",
     "start": "2018-09-14T22:00:00.000Z",
     "end": "2018-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Sat"
@@ -156,7 +156,7 @@
     "date": "2018-10-25 00:00:00",
     "start": "2018-10-24T22:00:00.000Z",
     "end": "2018-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Thu"
@@ -165,7 +165,7 @@
     "date": "2018-10-31 00:00:00",
     "start": "2018-10-30T23:00:00.000Z",
     "end": "2018-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Wed"
@@ -174,7 +174,7 @@
     "date": "2018-11-01 00:00:00",
     "start": "2018-10-31T23:00:00.000Z",
     "end": "2018-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Thu"
@@ -192,7 +192,7 @@
     "date": "2018-11-23 00:00:00",
     "start": "2018-11-22T23:00:00.000Z",
     "end": "2018-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Fri"
@@ -210,7 +210,7 @@
     "date": "2018-12-25 00:00:00",
     "start": "2018-12-24T23:00:00.000Z",
     "end": "2018-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
@@ -219,7 +219,7 @@
     "date": "2018-12-26 00:00:00",
     "start": "2018-12-25T23:00:00.000Z",
     "end": "2018-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"

--- a/test/fixtures/SI-2019.json
+++ b/test/fixtures/SI-2019.json
@@ -3,7 +3,7 @@
     "date": "2019-01-01 00:00:00",
     "start": "2018-12-31T23:00:00.000Z",
     "end": "2019-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Tue"
@@ -12,7 +12,7 @@
     "date": "2019-01-02 00:00:00",
     "start": "2019-01-01T23:00:00.000Z",
     "end": "2019-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2019-04-21 00:00:00",
     "start": "2019-04-20T22:00:00.000Z",
     "end": "2019-04-21T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2019-04-22 00:00:00",
     "start": "2019-04-21T22:00:00.000Z",
     "end": "2019-04-22T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2019-04-27 00:00:00",
     "start": "2019-04-26T22:00:00.000Z",
     "end": "2019-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T22:00:00.000Z",
     "end": "2019-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -93,7 +93,7 @@
     "date": "2019-05-02 00:00:00",
     "start": "2019-05-01T22:00:00.000Z",
     "end": "2019-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2019-06-08 00:00:00",
     "start": "2019-06-07T22:00:00.000Z",
     "end": "2019-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Sat"
@@ -111,7 +111,7 @@
     "date": "2019-06-09 00:00:00",
     "start": "2019-06-08T22:00:00.000Z",
     "end": "2019-06-09T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -120,7 +120,7 @@
     "date": "2019-06-25 00:00:00",
     "start": "2019-06-24T22:00:00.000Z",
     "end": "2019-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Tue"
@@ -138,7 +138,7 @@
     "date": "2019-08-17 00:00:00",
     "start": "2019-08-16T22:00:00.000Z",
     "end": "2019-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2019-09-15 00:00:00",
     "start": "2019-09-14T22:00:00.000Z",
     "end": "2019-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2019-10-25 00:00:00",
     "start": "2019-10-24T22:00:00.000Z",
     "end": "2019-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Fri"
@@ -165,7 +165,7 @@
     "date": "2019-10-31 00:00:00",
     "start": "2019-10-30T23:00:00.000Z",
     "end": "2019-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Thu"
@@ -174,7 +174,7 @@
     "date": "2019-11-01 00:00:00",
     "start": "2019-10-31T23:00:00.000Z",
     "end": "2019-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Fri"
@@ -192,7 +192,7 @@
     "date": "2019-11-23 00:00:00",
     "start": "2019-11-22T23:00:00.000Z",
     "end": "2019-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Sat"
@@ -210,7 +210,7 @@
     "date": "2019-12-25 00:00:00",
     "start": "2019-12-24T23:00:00.000Z",
     "end": "2019-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
@@ -219,7 +219,7 @@
     "date": "2019-12-26 00:00:00",
     "start": "2019-12-25T23:00:00.000Z",
     "end": "2019-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"

--- a/test/fixtures/SI-2020.json
+++ b/test/fixtures/SI-2020.json
@@ -3,7 +3,7 @@
     "date": "2020-01-01 00:00:00",
     "start": "2019-12-31T23:00:00.000Z",
     "end": "2020-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"
@@ -12,7 +12,7 @@
     "date": "2020-01-02 00:00:00",
     "start": "2020-01-01T23:00:00.000Z",
     "end": "2020-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2020-04-12 00:00:00",
     "start": "2020-04-11T22:00:00.000Z",
     "end": "2020-04-12T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2020-04-13 00:00:00",
     "start": "2020-04-12T22:00:00.000Z",
     "end": "2020-04-13T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2020-04-27 00:00:00",
     "start": "2020-04-26T22:00:00.000Z",
     "end": "2020-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Mon"
@@ -84,7 +84,7 @@
     "date": "2020-05-01 00:00:00",
     "start": "2020-04-30T22:00:00.000Z",
     "end": "2020-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2020-05-02 00:00:00",
     "start": "2020-05-01T22:00:00.000Z",
     "end": "2020-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2020-05-31 00:00:00",
     "start": "2020-05-30T22:00:00.000Z",
     "end": "2020-05-31T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2020-06-08 00:00:00",
     "start": "2020-06-07T22:00:00.000Z",
     "end": "2020-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Mon"
@@ -120,7 +120,7 @@
     "date": "2020-06-25 00:00:00",
     "start": "2020-06-24T22:00:00.000Z",
     "end": "2020-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2020-08-17 00:00:00",
     "start": "2020-08-16T22:00:00.000Z",
     "end": "2020-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Mon"
@@ -147,7 +147,7 @@
     "date": "2020-09-15 00:00:00",
     "start": "2020-09-14T22:00:00.000Z",
     "end": "2020-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Tue"
@@ -156,7 +156,7 @@
     "date": "2020-09-23 00:00:00",
     "start": "2020-09-22T22:00:00.000Z",
     "end": "2020-09-23T22:00:00.000Z",
-    "name": "Dan slovenskega športa",
+    "name": "dan slovenskega športa",
     "type": "observance",
     "rule": "09-23",
     "_weekday": "Wed"
@@ -165,7 +165,7 @@
     "date": "2020-10-25 00:00:00",
     "start": "2020-10-24T22:00:00.000Z",
     "end": "2020-10-25T23:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Sun"
@@ -174,7 +174,7 @@
     "date": "2020-10-31 00:00:00",
     "start": "2020-10-30T23:00:00.000Z",
     "end": "2020-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2020-11-01 00:00:00",
     "start": "2020-10-31T23:00:00.000Z",
     "end": "2020-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Sun"
@@ -201,7 +201,7 @@
     "date": "2020-11-23 00:00:00",
     "start": "2020-11-22T23:00:00.000Z",
     "end": "2020-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Mon"
@@ -219,7 +219,7 @@
     "date": "2020-12-25 00:00:00",
     "start": "2020-12-24T23:00:00.000Z",
     "end": "2020-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -228,7 +228,7 @@
     "date": "2020-12-26 00:00:00",
     "start": "2020-12-25T23:00:00.000Z",
     "end": "2020-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/SI-2021.json
+++ b/test/fixtures/SI-2021.json
@@ -3,7 +3,7 @@
     "date": "2021-01-01 00:00:00",
     "start": "2020-12-31T23:00:00.000Z",
     "end": "2021-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -12,7 +12,7 @@
     "date": "2021-01-02 00:00:00",
     "start": "2021-01-01T23:00:00.000Z",
     "end": "2021-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2021-04-04 00:00:00",
     "start": "2021-04-03T22:00:00.000Z",
     "end": "2021-04-04T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2021-04-05 00:00:00",
     "start": "2021-04-04T22:00:00.000Z",
     "end": "2021-04-05T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2021-04-27 00:00:00",
     "start": "2021-04-26T22:00:00.000Z",
     "end": "2021-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2021-05-01 00:00:00",
     "start": "2021-04-30T22:00:00.000Z",
     "end": "2021-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2021-05-02 00:00:00",
     "start": "2021-05-01T22:00:00.000Z",
     "end": "2021-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2021-05-23 00:00:00",
     "start": "2021-05-22T22:00:00.000Z",
     "end": "2021-05-23T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2021-06-08 00:00:00",
     "start": "2021-06-07T22:00:00.000Z",
     "end": "2021-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Tue"
@@ -120,7 +120,7 @@
     "date": "2021-06-25 00:00:00",
     "start": "2021-06-24T22:00:00.000Z",
     "end": "2021-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Fri"
@@ -138,7 +138,7 @@
     "date": "2021-08-17 00:00:00",
     "start": "2021-08-16T22:00:00.000Z",
     "end": "2021-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Tue"
@@ -147,7 +147,7 @@
     "date": "2021-09-15 00:00:00",
     "start": "2021-09-14T22:00:00.000Z",
     "end": "2021-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Wed"
@@ -156,7 +156,7 @@
     "date": "2021-09-23 00:00:00",
     "start": "2021-09-22T22:00:00.000Z",
     "end": "2021-09-23T22:00:00.000Z",
-    "name": "Dan slovenskega športa",
+    "name": "dan slovenskega športa",
     "type": "observance",
     "rule": "09-23",
     "_weekday": "Thu"
@@ -165,7 +165,7 @@
     "date": "2021-10-25 00:00:00",
     "start": "2021-10-24T22:00:00.000Z",
     "end": "2021-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Mon"
@@ -174,7 +174,7 @@
     "date": "2021-10-31 00:00:00",
     "start": "2021-10-30T22:00:00.000Z",
     "end": "2021-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Sun"
@@ -183,7 +183,7 @@
     "date": "2021-11-01 00:00:00",
     "start": "2021-10-31T23:00:00.000Z",
     "end": "2021-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Mon"
@@ -201,7 +201,7 @@
     "date": "2021-11-23 00:00:00",
     "start": "2021-11-22T23:00:00.000Z",
     "end": "2021-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Tue"
@@ -219,7 +219,7 @@
     "date": "2021-12-25 00:00:00",
     "start": "2021-12-24T23:00:00.000Z",
     "end": "2021-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
@@ -228,7 +228,7 @@
     "date": "2021-12-26 00:00:00",
     "start": "2021-12-25T23:00:00.000Z",
     "end": "2021-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"

--- a/test/fixtures/SI-2022.json
+++ b/test/fixtures/SI-2022.json
@@ -3,7 +3,7 @@
     "date": "2022-01-01 00:00:00",
     "start": "2021-12-31T23:00:00.000Z",
     "end": "2022-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"
@@ -12,7 +12,7 @@
     "date": "2022-01-02 00:00:00",
     "start": "2022-01-01T23:00:00.000Z",
     "end": "2022-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2022-04-17 00:00:00",
     "start": "2022-04-16T22:00:00.000Z",
     "end": "2022-04-17T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2022-04-18 00:00:00",
     "start": "2022-04-17T22:00:00.000Z",
     "end": "2022-04-18T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2022-04-27 00:00:00",
     "start": "2022-04-26T22:00:00.000Z",
     "end": "2022-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Wed"
@@ -84,7 +84,7 @@
     "date": "2022-05-01 00:00:00",
     "start": "2022-04-30T22:00:00.000Z",
     "end": "2022-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sun"
@@ -93,7 +93,7 @@
     "date": "2022-05-02 00:00:00",
     "start": "2022-05-01T22:00:00.000Z",
     "end": "2022-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2022-06-05 00:00:00",
     "start": "2022-06-04T22:00:00.000Z",
     "end": "2022-06-05T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2022-06-08 00:00:00",
     "start": "2022-06-07T22:00:00.000Z",
     "end": "2022-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Wed"
@@ -120,7 +120,7 @@
     "date": "2022-06-25 00:00:00",
     "start": "2022-06-24T22:00:00.000Z",
     "end": "2022-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2022-08-17 00:00:00",
     "start": "2022-08-16T22:00:00.000Z",
     "end": "2022-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Wed"
@@ -147,7 +147,7 @@
     "date": "2022-09-15 00:00:00",
     "start": "2022-09-14T22:00:00.000Z",
     "end": "2022-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Thu"
@@ -156,7 +156,7 @@
     "date": "2022-09-23 00:00:00",
     "start": "2022-09-22T22:00:00.000Z",
     "end": "2022-09-23T22:00:00.000Z",
-    "name": "Dan slovenskega športa",
+    "name": "dan slovenskega športa",
     "type": "observance",
     "rule": "09-23",
     "_weekday": "Fri"
@@ -165,7 +165,7 @@
     "date": "2022-10-25 00:00:00",
     "start": "2022-10-24T22:00:00.000Z",
     "end": "2022-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Tue"
@@ -174,7 +174,7 @@
     "date": "2022-10-31 00:00:00",
     "start": "2022-10-30T23:00:00.000Z",
     "end": "2022-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Mon"
@@ -183,7 +183,7 @@
     "date": "2022-11-01 00:00:00",
     "start": "2022-10-31T23:00:00.000Z",
     "end": "2022-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Tue"
@@ -201,7 +201,7 @@
     "date": "2022-11-23 00:00:00",
     "start": "2022-11-22T23:00:00.000Z",
     "end": "2022-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Wed"
@@ -219,7 +219,7 @@
     "date": "2022-12-25 00:00:00",
     "start": "2022-12-24T23:00:00.000Z",
     "end": "2022-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sun"
@@ -228,7 +228,7 @@
     "date": "2022-12-26 00:00:00",
     "start": "2022-12-25T23:00:00.000Z",
     "end": "2022-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"

--- a/test/fixtures/SI-2023.json
+++ b/test/fixtures/SI-2023.json
@@ -3,7 +3,7 @@
     "date": "2023-01-01 00:00:00",
     "start": "2022-12-31T23:00:00.000Z",
     "end": "2023-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sun"
@@ -12,7 +12,7 @@
     "date": "2023-01-02 00:00:00",
     "start": "2023-01-01T23:00:00.000Z",
     "end": "2023-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2023-04-09 00:00:00",
     "start": "2023-04-08T22:00:00.000Z",
     "end": "2023-04-09T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2023-04-10 00:00:00",
     "start": "2023-04-09T22:00:00.000Z",
     "end": "2023-04-10T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2023-04-27 00:00:00",
     "start": "2023-04-26T22:00:00.000Z",
     "end": "2023-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T22:00:00.000Z",
     "end": "2023-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2023-05-02 00:00:00",
     "start": "2023-05-01T22:00:00.000Z",
     "end": "2023-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2023-05-28 00:00:00",
     "start": "2023-05-27T22:00:00.000Z",
     "end": "2023-05-28T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2023-06-08 00:00:00",
     "start": "2023-06-07T22:00:00.000Z",
     "end": "2023-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Thu"
@@ -120,7 +120,7 @@
     "date": "2023-06-25 00:00:00",
     "start": "2023-06-24T22:00:00.000Z",
     "end": "2023-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Sun"
@@ -138,7 +138,7 @@
     "date": "2023-08-17 00:00:00",
     "start": "2023-08-16T22:00:00.000Z",
     "end": "2023-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Thu"
@@ -147,7 +147,7 @@
     "date": "2023-09-15 00:00:00",
     "start": "2023-09-14T22:00:00.000Z",
     "end": "2023-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Fri"
@@ -156,7 +156,7 @@
     "date": "2023-09-23 00:00:00",
     "start": "2023-09-22T22:00:00.000Z",
     "end": "2023-09-23T22:00:00.000Z",
-    "name": "Dan slovenskega športa",
+    "name": "dan slovenskega športa",
     "type": "observance",
     "rule": "09-23",
     "_weekday": "Sat"
@@ -165,7 +165,7 @@
     "date": "2023-10-25 00:00:00",
     "start": "2023-10-24T22:00:00.000Z",
     "end": "2023-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Wed"
@@ -174,7 +174,7 @@
     "date": "2023-10-31 00:00:00",
     "start": "2023-10-30T23:00:00.000Z",
     "end": "2023-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Tue"
@@ -183,7 +183,7 @@
     "date": "2023-11-01 00:00:00",
     "start": "2023-10-31T23:00:00.000Z",
     "end": "2023-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Wed"
@@ -201,7 +201,7 @@
     "date": "2023-11-23 00:00:00",
     "start": "2023-11-22T23:00:00.000Z",
     "end": "2023-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Thu"
@@ -219,7 +219,7 @@
     "date": "2023-12-25 00:00:00",
     "start": "2023-12-24T23:00:00.000Z",
     "end": "2023-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -228,7 +228,7 @@
     "date": "2023-12-26 00:00:00",
     "start": "2023-12-25T23:00:00.000Z",
     "end": "2023-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/SI-2024.json
+++ b/test/fixtures/SI-2024.json
@@ -3,7 +3,7 @@
     "date": "2024-01-01 00:00:00",
     "start": "2023-12-31T23:00:00.000Z",
     "end": "2024-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -12,7 +12,7 @@
     "date": "2024-01-02 00:00:00",
     "start": "2024-01-01T23:00:00.000Z",
     "end": "2024-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2024-03-31 00:00:00",
     "start": "2024-03-30T23:00:00.000Z",
     "end": "2024-03-31T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2024-04-01 00:00:00",
     "start": "2024-03-31T22:00:00.000Z",
     "end": "2024-04-01T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2024-04-27 00:00:00",
     "start": "2024-04-26T22:00:00.000Z",
     "end": "2024-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Sat"
@@ -84,7 +84,7 @@
     "date": "2024-05-01 00:00:00",
     "start": "2024-04-30T22:00:00.000Z",
     "end": "2024-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Wed"
@@ -93,7 +93,7 @@
     "date": "2024-05-02 00:00:00",
     "start": "2024-05-01T22:00:00.000Z",
     "end": "2024-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Thu"
@@ -102,7 +102,7 @@
     "date": "2024-05-19 00:00:00",
     "start": "2024-05-18T22:00:00.000Z",
     "end": "2024-05-19T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2024-06-08 00:00:00",
     "start": "2024-06-07T22:00:00.000Z",
     "end": "2024-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2024-06-25 00:00:00",
     "start": "2024-06-24T22:00:00.000Z",
     "end": "2024-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Tue"
@@ -138,7 +138,7 @@
     "date": "2024-08-17 00:00:00",
     "start": "2024-08-16T22:00:00.000Z",
     "end": "2024-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2024-09-15 00:00:00",
     "start": "2024-09-14T22:00:00.000Z",
     "end": "2024-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Sun"
@@ -156,7 +156,7 @@
     "date": "2024-09-23 00:00:00",
     "start": "2024-09-22T22:00:00.000Z",
     "end": "2024-09-23T22:00:00.000Z",
-    "name": "Dan slovenskega športa",
+    "name": "dan slovenskega športa",
     "type": "observance",
     "rule": "09-23",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2024-10-25 00:00:00",
     "start": "2024-10-24T22:00:00.000Z",
     "end": "2024-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2024-10-31 00:00:00",
     "start": "2024-10-30T23:00:00.000Z",
     "end": "2024-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Thu"
@@ -183,7 +183,7 @@
     "date": "2024-11-01 00:00:00",
     "start": "2024-10-31T23:00:00.000Z",
     "end": "2024-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Fri"
@@ -201,7 +201,7 @@
     "date": "2024-11-23 00:00:00",
     "start": "2024-11-22T23:00:00.000Z",
     "end": "2024-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Sat"
@@ -219,7 +219,7 @@
     "date": "2024-12-25 00:00:00",
     "start": "2024-12-24T23:00:00.000Z",
     "end": "2024-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Wed"
@@ -228,7 +228,7 @@
     "date": "2024-12-26 00:00:00",
     "start": "2024-12-25T23:00:00.000Z",
     "end": "2024-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"

--- a/test/fixtures/SI-2025.json
+++ b/test/fixtures/SI-2025.json
@@ -3,7 +3,7 @@
     "date": "2025-01-01 00:00:00",
     "start": "2024-12-31T23:00:00.000Z",
     "end": "2025-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Wed"
@@ -12,7 +12,7 @@
     "date": "2025-01-02 00:00:00",
     "start": "2025-01-01T23:00:00.000Z",
     "end": "2025-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2025-04-20 00:00:00",
     "start": "2025-04-19T22:00:00.000Z",
     "end": "2025-04-20T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T22:00:00.000Z",
     "end": "2025-04-21T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2025-04-27 00:00:00",
     "start": "2025-04-26T22:00:00.000Z",
     "end": "2025-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Sun"
@@ -84,7 +84,7 @@
     "date": "2025-05-01 00:00:00",
     "start": "2025-04-30T22:00:00.000Z",
     "end": "2025-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Thu"
@@ -93,7 +93,7 @@
     "date": "2025-05-02 00:00:00",
     "start": "2025-05-01T22:00:00.000Z",
     "end": "2025-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Fri"
@@ -102,7 +102,7 @@
     "date": "2025-06-08 00:00:00",
     "start": "2025-06-07T22:00:00.000Z",
     "end": "2025-06-08T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2025-06-08 00:00:00",
     "start": "2025-06-07T22:00:00.000Z",
     "end": "2025-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Sun"
@@ -120,7 +120,7 @@
     "date": "2025-06-25 00:00:00",
     "start": "2025-06-24T22:00:00.000Z",
     "end": "2025-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Wed"
@@ -138,7 +138,7 @@
     "date": "2025-08-17 00:00:00",
     "start": "2025-08-16T22:00:00.000Z",
     "end": "2025-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Sun"
@@ -147,7 +147,7 @@
     "date": "2025-09-15 00:00:00",
     "start": "2025-09-14T22:00:00.000Z",
     "end": "2025-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Mon"
@@ -156,7 +156,7 @@
     "date": "2025-09-23 00:00:00",
     "start": "2025-09-22T22:00:00.000Z",
     "end": "2025-09-23T22:00:00.000Z",
-    "name": "Dan slovenskega športa",
+    "name": "dan slovenskega športa",
     "type": "observance",
     "rule": "09-23",
     "_weekday": "Tue"
@@ -165,7 +165,7 @@
     "date": "2025-10-25 00:00:00",
     "start": "2025-10-24T22:00:00.000Z",
     "end": "2025-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Sat"
@@ -174,7 +174,7 @@
     "date": "2025-10-31 00:00:00",
     "start": "2025-10-30T23:00:00.000Z",
     "end": "2025-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Fri"
@@ -183,7 +183,7 @@
     "date": "2025-11-01 00:00:00",
     "start": "2025-10-31T23:00:00.000Z",
     "end": "2025-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Sat"
@@ -201,7 +201,7 @@
     "date": "2025-11-23 00:00:00",
     "start": "2025-11-22T23:00:00.000Z",
     "end": "2025-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Sun"
@@ -219,7 +219,7 @@
     "date": "2025-12-25 00:00:00",
     "start": "2025-12-24T23:00:00.000Z",
     "end": "2025-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Thu"
@@ -228,7 +228,7 @@
     "date": "2025-12-26 00:00:00",
     "start": "2025-12-25T23:00:00.000Z",
     "end": "2025-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Fri"

--- a/test/fixtures/SI-2026.json
+++ b/test/fixtures/SI-2026.json
@@ -3,7 +3,7 @@
     "date": "2026-01-01 00:00:00",
     "start": "2025-12-31T23:00:00.000Z",
     "end": "2026-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Thu"
@@ -12,7 +12,7 @@
     "date": "2026-01-02 00:00:00",
     "start": "2026-01-01T23:00:00.000Z",
     "end": "2026-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2026-04-05 00:00:00",
     "start": "2026-04-04T22:00:00.000Z",
     "end": "2026-04-05T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2026-04-06 00:00:00",
     "start": "2026-04-05T22:00:00.000Z",
     "end": "2026-04-06T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2026-04-27 00:00:00",
     "start": "2026-04-26T22:00:00.000Z",
     "end": "2026-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Mon"
@@ -84,7 +84,7 @@
     "date": "2026-05-01 00:00:00",
     "start": "2026-04-30T22:00:00.000Z",
     "end": "2026-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Fri"
@@ -93,7 +93,7 @@
     "date": "2026-05-02 00:00:00",
     "start": "2026-05-01T22:00:00.000Z",
     "end": "2026-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Sat"
@@ -102,7 +102,7 @@
     "date": "2026-05-24 00:00:00",
     "start": "2026-05-23T22:00:00.000Z",
     "end": "2026-05-24T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2026-06-08 00:00:00",
     "start": "2026-06-07T22:00:00.000Z",
     "end": "2026-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Mon"
@@ -120,7 +120,7 @@
     "date": "2026-06-25 00:00:00",
     "start": "2026-06-24T22:00:00.000Z",
     "end": "2026-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Thu"
@@ -138,7 +138,7 @@
     "date": "2026-08-17 00:00:00",
     "start": "2026-08-16T22:00:00.000Z",
     "end": "2026-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Mon"
@@ -147,7 +147,7 @@
     "date": "2026-09-15 00:00:00",
     "start": "2026-09-14T22:00:00.000Z",
     "end": "2026-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Tue"
@@ -156,7 +156,7 @@
     "date": "2026-09-23 00:00:00",
     "start": "2026-09-22T22:00:00.000Z",
     "end": "2026-09-23T22:00:00.000Z",
-    "name": "Dan slovenskega športa",
+    "name": "dan slovenskega športa",
     "type": "observance",
     "rule": "09-23",
     "_weekday": "Wed"
@@ -165,7 +165,7 @@
     "date": "2026-10-25 00:00:00",
     "start": "2026-10-24T22:00:00.000Z",
     "end": "2026-10-25T23:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Sun"
@@ -174,7 +174,7 @@
     "date": "2026-10-31 00:00:00",
     "start": "2026-10-30T23:00:00.000Z",
     "end": "2026-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2026-11-01 00:00:00",
     "start": "2026-10-31T23:00:00.000Z",
     "end": "2026-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Sun"
@@ -201,7 +201,7 @@
     "date": "2026-11-23 00:00:00",
     "start": "2026-11-22T23:00:00.000Z",
     "end": "2026-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Mon"
@@ -219,7 +219,7 @@
     "date": "2026-12-25 00:00:00",
     "start": "2026-12-24T23:00:00.000Z",
     "end": "2026-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Fri"
@@ -228,7 +228,7 @@
     "date": "2026-12-26 00:00:00",
     "start": "2026-12-25T23:00:00.000Z",
     "end": "2026-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"

--- a/test/fixtures/SI-2027.json
+++ b/test/fixtures/SI-2027.json
@@ -3,7 +3,7 @@
     "date": "2027-01-01 00:00:00",
     "start": "2026-12-31T23:00:00.000Z",
     "end": "2027-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Fri"
@@ -12,7 +12,7 @@
     "date": "2027-01-02 00:00:00",
     "start": "2027-01-01T23:00:00.000Z",
     "end": "2027-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2027-03-28 00:00:00",
     "start": "2027-03-27T23:00:00.000Z",
     "end": "2027-03-28T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2027-03-29 00:00:00",
     "start": "2027-03-28T22:00:00.000Z",
     "end": "2027-03-29T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2027-04-27 00:00:00",
     "start": "2027-04-26T22:00:00.000Z",
     "end": "2027-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Tue"
@@ -84,7 +84,7 @@
     "date": "2027-05-01 00:00:00",
     "start": "2027-04-30T22:00:00.000Z",
     "end": "2027-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2027-05-02 00:00:00",
     "start": "2027-05-01T22:00:00.000Z",
     "end": "2027-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Sun"
@@ -102,7 +102,7 @@
     "date": "2027-05-16 00:00:00",
     "start": "2027-05-15T22:00:00.000Z",
     "end": "2027-05-16T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2027-06-08 00:00:00",
     "start": "2027-06-07T22:00:00.000Z",
     "end": "2027-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Tue"
@@ -120,7 +120,7 @@
     "date": "2027-06-25 00:00:00",
     "start": "2027-06-24T22:00:00.000Z",
     "end": "2027-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Fri"
@@ -138,7 +138,7 @@
     "date": "2027-08-17 00:00:00",
     "start": "2027-08-16T22:00:00.000Z",
     "end": "2027-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Tue"
@@ -147,7 +147,7 @@
     "date": "2027-09-15 00:00:00",
     "start": "2027-09-14T22:00:00.000Z",
     "end": "2027-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Wed"
@@ -156,7 +156,7 @@
     "date": "2027-09-23 00:00:00",
     "start": "2027-09-22T22:00:00.000Z",
     "end": "2027-09-23T22:00:00.000Z",
-    "name": "Dan slovenskega športa",
+    "name": "dan slovenskega športa",
     "type": "observance",
     "rule": "09-23",
     "_weekday": "Thu"
@@ -165,7 +165,7 @@
     "date": "2027-10-25 00:00:00",
     "start": "2027-10-24T22:00:00.000Z",
     "end": "2027-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Mon"
@@ -174,7 +174,7 @@
     "date": "2027-10-31 00:00:00",
     "start": "2027-10-30T22:00:00.000Z",
     "end": "2027-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Sun"
@@ -183,7 +183,7 @@
     "date": "2027-11-01 00:00:00",
     "start": "2027-10-31T23:00:00.000Z",
     "end": "2027-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Mon"
@@ -201,7 +201,7 @@
     "date": "2027-11-23 00:00:00",
     "start": "2027-11-22T23:00:00.000Z",
     "end": "2027-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Tue"
@@ -219,7 +219,7 @@
     "date": "2027-12-25 00:00:00",
     "start": "2027-12-24T23:00:00.000Z",
     "end": "2027-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Sat"
@@ -228,7 +228,7 @@
     "date": "2027-12-26 00:00:00",
     "start": "2027-12-25T23:00:00.000Z",
     "end": "2027-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"

--- a/test/fixtures/SI-2028.json
+++ b/test/fixtures/SI-2028.json
@@ -3,7 +3,7 @@
     "date": "2028-01-01 00:00:00",
     "start": "2027-12-31T23:00:00.000Z",
     "end": "2028-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Sat"
@@ -12,7 +12,7 @@
     "date": "2028-01-02 00:00:00",
     "start": "2028-01-01T23:00:00.000Z",
     "end": "2028-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2028-04-16 00:00:00",
     "start": "2028-04-15T22:00:00.000Z",
     "end": "2028-04-16T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T22:00:00.000Z",
     "end": "2028-04-17T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2028-04-27 00:00:00",
     "start": "2028-04-26T22:00:00.000Z",
     "end": "2028-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Thu"
@@ -84,7 +84,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T22:00:00.000Z",
     "end": "2028-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2028-05-02 00:00:00",
     "start": "2028-05-01T22:00:00.000Z",
     "end": "2028-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Tue"
@@ -102,7 +102,7 @@
     "date": "2028-06-04 00:00:00",
     "start": "2028-06-03T22:00:00.000Z",
     "end": "2028-06-04T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2028-06-08 00:00:00",
     "start": "2028-06-07T22:00:00.000Z",
     "end": "2028-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Thu"
@@ -120,7 +120,7 @@
     "date": "2028-06-25 00:00:00",
     "start": "2028-06-24T22:00:00.000Z",
     "end": "2028-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Sun"
@@ -138,7 +138,7 @@
     "date": "2028-08-17 00:00:00",
     "start": "2028-08-16T22:00:00.000Z",
     "end": "2028-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Thu"
@@ -147,7 +147,7 @@
     "date": "2028-09-15 00:00:00",
     "start": "2028-09-14T22:00:00.000Z",
     "end": "2028-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Fri"
@@ -156,7 +156,7 @@
     "date": "2028-09-23 00:00:00",
     "start": "2028-09-22T22:00:00.000Z",
     "end": "2028-09-23T22:00:00.000Z",
-    "name": "Dan slovenskega športa",
+    "name": "dan slovenskega športa",
     "type": "observance",
     "rule": "09-23",
     "_weekday": "Sat"
@@ -165,7 +165,7 @@
     "date": "2028-10-25 00:00:00",
     "start": "2028-10-24T22:00:00.000Z",
     "end": "2028-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Wed"
@@ -174,7 +174,7 @@
     "date": "2028-10-31 00:00:00",
     "start": "2028-10-30T23:00:00.000Z",
     "end": "2028-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Tue"
@@ -183,7 +183,7 @@
     "date": "2028-11-01 00:00:00",
     "start": "2028-10-31T23:00:00.000Z",
     "end": "2028-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Wed"
@@ -201,7 +201,7 @@
     "date": "2028-11-23 00:00:00",
     "start": "2028-11-22T23:00:00.000Z",
     "end": "2028-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Thu"
@@ -219,7 +219,7 @@
     "date": "2028-12-25 00:00:00",
     "start": "2028-12-24T23:00:00.000Z",
     "end": "2028-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Mon"
@@ -228,7 +228,7 @@
     "date": "2028-12-26 00:00:00",
     "start": "2028-12-25T23:00:00.000Z",
     "end": "2028-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/SI-2029.json
+++ b/test/fixtures/SI-2029.json
@@ -3,7 +3,7 @@
     "date": "2029-01-01 00:00:00",
     "start": "2028-12-31T23:00:00.000Z",
     "end": "2029-01-01T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-01",
     "_weekday": "Mon"
@@ -12,7 +12,7 @@
     "date": "2029-01-02 00:00:00",
     "start": "2029-01-01T23:00:00.000Z",
     "end": "2029-01-02T23:00:00.000Z",
-    "name": "Novo leto",
+    "name": "novo leto",
     "type": "public",
     "rule": "01-02",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2029-04-01 00:00:00",
     "start": "2029-03-31T22:00:00.000Z",
     "end": "2029-04-01T22:00:00.000Z",
-    "name": "Velika noč",
+    "name": "velikonočna nedelja",
     "type": "public",
     "rule": "easter",
     "_weekday": "Sun"
@@ -57,7 +57,7 @@
     "date": "2029-04-02 00:00:00",
     "start": "2029-04-01T22:00:00.000Z",
     "end": "2029-04-02T22:00:00.000Z",
-    "name": "Velikonočni ponedeljek",
+    "name": "velikonočni ponedeljek",
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
@@ -75,7 +75,7 @@
     "date": "2029-04-27 00:00:00",
     "start": "2029-04-26T22:00:00.000Z",
     "end": "2029-04-27T22:00:00.000Z",
-    "name": "Dan upora proti okupatorju",
+    "name": "dan upora proti okupatorju",
     "type": "public",
     "rule": "04-27",
     "_weekday": "Fri"
@@ -84,7 +84,7 @@
     "date": "2029-05-01 00:00:00",
     "start": "2029-04-30T22:00:00.000Z",
     "end": "2029-05-01T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-01",
     "_weekday": "Tue"
@@ -93,7 +93,7 @@
     "date": "2029-05-02 00:00:00",
     "start": "2029-05-01T22:00:00.000Z",
     "end": "2029-05-02T22:00:00.000Z",
-    "name": "Praznik dela",
+    "name": "praznik dela",
     "type": "public",
     "rule": "05-02",
     "_weekday": "Wed"
@@ -102,7 +102,7 @@
     "date": "2029-05-20 00:00:00",
     "start": "2029-05-19T22:00:00.000Z",
     "end": "2029-05-20T22:00:00.000Z",
-    "name": "Binkošti",
+    "name": "binkošti",
     "type": "public",
     "rule": "easter 49",
     "_weekday": "Sun"
@@ -111,7 +111,7 @@
     "date": "2029-06-08 00:00:00",
     "start": "2029-06-07T22:00:00.000Z",
     "end": "2029-06-08T22:00:00.000Z",
-    "name": "Dan Primoža Trubarja",
+    "name": "dan Primoža Trubarja",
     "type": "observance",
     "rule": "06-08",
     "_weekday": "Fri"
@@ -120,7 +120,7 @@
     "date": "2029-06-25 00:00:00",
     "start": "2029-06-24T22:00:00.000Z",
     "end": "2029-06-25T22:00:00.000Z",
-    "name": "Dan državnosti",
+    "name": "dan državnosti",
     "type": "public",
     "rule": "06-25",
     "_weekday": "Mon"
@@ -138,7 +138,7 @@
     "date": "2029-08-17 00:00:00",
     "start": "2029-08-16T22:00:00.000Z",
     "end": "2029-08-17T22:00:00.000Z",
-    "name": "Združitev prekmurskih Slovencev z matičnim narodom",
+    "name": "združitev prekmurskih Slovencev z matičnim narodom",
     "type": "observance",
     "rule": "08-17",
     "_weekday": "Fri"
@@ -147,7 +147,7 @@
     "date": "2029-09-15 00:00:00",
     "start": "2029-09-14T22:00:00.000Z",
     "end": "2029-09-15T22:00:00.000Z",
-    "name": "Vrnitev Primorske k matični domovini",
+    "name": "priključitev Primorske k matični domovini",
     "type": "observance",
     "rule": "09-15",
     "_weekday": "Sat"
@@ -156,7 +156,7 @@
     "date": "2029-09-23 00:00:00",
     "start": "2029-09-22T22:00:00.000Z",
     "end": "2029-09-23T22:00:00.000Z",
-    "name": "Dan slovenskega športa",
+    "name": "dan slovenskega športa",
     "type": "observance",
     "rule": "09-23",
     "_weekday": "Sun"
@@ -165,7 +165,7 @@
     "date": "2029-10-25 00:00:00",
     "start": "2029-10-24T22:00:00.000Z",
     "end": "2029-10-25T22:00:00.000Z",
-    "name": "Dan suverenosti",
+    "name": "dan suverenosti",
     "type": "observance",
     "rule": "10-25",
     "_weekday": "Thu"
@@ -174,7 +174,7 @@
     "date": "2029-10-31 00:00:00",
     "start": "2029-10-30T23:00:00.000Z",
     "end": "2029-10-31T23:00:00.000Z",
-    "name": "Dan reformacije",
+    "name": "dan reformacije",
     "type": "public",
     "rule": "10-31",
     "_weekday": "Wed"
@@ -183,7 +183,7 @@
     "date": "2029-11-01 00:00:00",
     "start": "2029-10-31T23:00:00.000Z",
     "end": "2029-11-01T23:00:00.000Z",
-    "name": "Dan spomina na mrtve",
+    "name": "dan spomina na mrtve",
     "type": "public",
     "rule": "11-01",
     "_weekday": "Thu"
@@ -201,7 +201,7 @@
     "date": "2029-11-23 00:00:00",
     "start": "2029-11-22T23:00:00.000Z",
     "end": "2029-11-23T23:00:00.000Z",
-    "name": "Dan Rudolfa Maistra",
+    "name": "dan Rudolfa Maistra",
     "type": "observance",
     "rule": "11-23",
     "_weekday": "Fri"
@@ -219,7 +219,7 @@
     "date": "2029-12-25 00:00:00",
     "start": "2029-12-24T23:00:00.000Z",
     "end": "2029-12-25T23:00:00.000Z",
-    "name": "Božič",
+    "name": "božič",
     "type": "public",
     "rule": "12-25",
     "_weekday": "Tue"
@@ -228,7 +228,7 @@
     "date": "2029-12-26 00:00:00",
     "start": "2029-12-25T23:00:00.000Z",
     "end": "2029-12-26T23:00:00.000Z",
-    "name": "Dan samostojnosti in enotnosti",
+    "name": "dan samostojnosti in enotnosti",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"


### PR DESCRIPTION
Added `gov.si` as `@source`. While comparing against it and the law, I noticed most Slovenian names were capitalized, but Slovenian orthography only capitalizes proper nouns here. Fixed those, keeping genuine proper nouns like "Prešernov dan" and "Marijino vnebovzetje" as they were.

Also renamed "Velika noč" to "velikonočna nedelja" and "vrnitev Primorske..." to "priključitev Primorske k matični domovini", matching the exact wording gov.si use.