### PR TITLE
fix(AX): use official Finnish/Åland sources, fix flag day types and casing

### DIFF
--- a/data/countries/AX.yaml
+++ b/data/countries/AX.yaml
@@ -1,4 +1,6 @@
-# @source http://www.sparhallen.ax/oppettider
+# @source https://almanakka.helsinki.fi/sv/flagg-och-festdagar
+# @source https://www.regeringen.ax/alandsk-lagstiftning/alex/199241
+# @attrib https://sv.wikipedia.org/wiki/Flaggdagar_i_Finland
 holidays:
   AX:
     names:
@@ -18,6 +20,12 @@ holidays:
         name:
           sv: Ålands demilitariseringsdag
           en: Demilitarization Day
+        type: observance
+      sunday before May:
+        name:
+          sv: Ålands flaggas dag
+          en: Åland Flag Day
+        type: observance
       easter -2:
         _name: easter -2
       easter:
@@ -34,16 +42,17 @@ holidays:
         type: observance
       06-09:
         name:
-          sv: Självstyrelsedagen
+          sv: Ålands självstyrelsedag
           en: Autonomy Day
+        type: observance
       friday after 06-19:
         name:
-          sv: Midsommarafton
+          sv: midsommarafton
           en: Midsummer Eve
         type: bank
       saturday after 06-20:
         name:
-          sv: Midsommardagen
+          sv: midsommardagen
           en: Midsummer Day
       12-06:
         _name: Independence Day

--- a/test/fixtures/AX-2015.json
+++ b/test/fixtures/AX-2015.json
@@ -22,7 +22,7 @@
     "start": "2015-03-29T21:00:00.000Z",
     "end": "2015-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Mon"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2015-04-26 00:00:00",
+    "start": "2015-04-25T21:00:00.000Z",
+    "end": "2015-04-26T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2015-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2015-06-09 00:00:00",
     "start": "2015-06-08T21:00:00.000Z",
     "end": "2015-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Tue"
   },
@@ -93,7 +102,7 @@
     "date": "2015-06-19 00:00:00",
     "start": "2015-06-18T21:00:00.000Z",
     "end": "2015-06-19T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2015-06-20 00:00:00",
     "start": "2015-06-19T21:00:00.000Z",
     "end": "2015-06-20T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2016.json
+++ b/test/fixtures/AX-2016.json
@@ -49,9 +49,18 @@
     "start": "2016-03-29T21:00:00.000Z",
     "end": "2016-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Wed"
+  },
+  {
+    "date": "2016-04-24 00:00:00",
+    "start": "2016-04-23T21:00:00.000Z",
+    "end": "2016-04-24T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2016-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2016-06-09 00:00:00",
     "start": "2016-06-08T21:00:00.000Z",
     "end": "2016-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Thu"
   },
@@ -93,7 +102,7 @@
     "date": "2016-06-24 00:00:00",
     "start": "2016-06-23T21:00:00.000Z",
     "end": "2016-06-24T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2016-06-25 00:00:00",
     "start": "2016-06-24T21:00:00.000Z",
     "end": "2016-06-25T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2017.json
+++ b/test/fixtures/AX-2017.json
@@ -22,7 +22,7 @@
     "start": "2017-03-29T21:00:00.000Z",
     "end": "2017-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Thu"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2017-04-30 00:00:00",
+    "start": "2017-04-29T21:00:00.000Z",
+    "end": "2017-04-30T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2017-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2017-06-09 00:00:00",
     "start": "2017-06-08T21:00:00.000Z",
     "end": "2017-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Fri"
   },
@@ -93,7 +102,7 @@
     "date": "2017-06-23 00:00:00",
     "start": "2017-06-22T21:00:00.000Z",
     "end": "2017-06-23T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2017-06-24 00:00:00",
     "start": "2017-06-23T21:00:00.000Z",
     "end": "2017-06-24T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2018.json
+++ b/test/fixtures/AX-2018.json
@@ -22,7 +22,7 @@
     "start": "2018-03-29T21:00:00.000Z",
     "end": "2018-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Fri"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2018-04-29 00:00:00",
+    "start": "2018-04-28T21:00:00.000Z",
+    "end": "2018-04-29T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2018-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2018-06-09 00:00:00",
     "start": "2018-06-08T21:00:00.000Z",
     "end": "2018-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Sat"
   },
@@ -93,7 +102,7 @@
     "date": "2018-06-22 00:00:00",
     "start": "2018-06-21T21:00:00.000Z",
     "end": "2018-06-22T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2018-06-23 00:00:00",
     "start": "2018-06-22T21:00:00.000Z",
     "end": "2018-06-23T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2019.json
+++ b/test/fixtures/AX-2019.json
@@ -22,7 +22,7 @@
     "start": "2019-03-29T22:00:00.000Z",
     "end": "2019-03-30T22:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Sat"
   },
@@ -54,6 +54,15 @@
     "_weekday": "Mon"
   },
   {
+    "date": "2019-04-28 00:00:00",
+    "start": "2019-04-27T21:00:00.000Z",
+    "end": "2019-04-28T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
+  },
+  {
     "date": "2019-05-01 00:00:00",
     "start": "2019-04-30T21:00:00.000Z",
     "end": "2019-05-01T21:00:00.000Z",
@@ -75,25 +84,25 @@
     "date": "2019-06-09 00:00:00",
     "start": "2019-06-08T21:00:00.000Z",
     "end": "2019-06-09T21:00:00.000Z",
-    "name": "pingstdagen",
+    "name": "Ålands självstyrelsedag",
     "type": "observance",
-    "rule": "easter 49",
+    "rule": "06-09",
     "_weekday": "Sun"
   },
   {
     "date": "2019-06-09 00:00:00",
     "start": "2019-06-08T21:00:00.000Z",
     "end": "2019-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
-    "rule": "06-09",
+    "name": "pingstdagen",
+    "type": "observance",
+    "rule": "easter 49",
     "_weekday": "Sun"
   },
   {
     "date": "2019-06-21 00:00:00",
     "start": "2019-06-20T21:00:00.000Z",
     "end": "2019-06-21T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2019-06-22 00:00:00",
     "start": "2019-06-21T21:00:00.000Z",
     "end": "2019-06-22T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2020.json
+++ b/test/fixtures/AX-2020.json
@@ -22,7 +22,7 @@
     "start": "2020-03-29T21:00:00.000Z",
     "end": "2020-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Mon"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2020-04-26 00:00:00",
+    "start": "2020-04-25T21:00:00.000Z",
+    "end": "2020-04-26T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2020-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2020-06-09 00:00:00",
     "start": "2020-06-08T21:00:00.000Z",
     "end": "2020-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Tue"
   },
@@ -93,7 +102,7 @@
     "date": "2020-06-19 00:00:00",
     "start": "2020-06-18T21:00:00.000Z",
     "end": "2020-06-19T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2020-06-20 00:00:00",
     "start": "2020-06-19T21:00:00.000Z",
     "end": "2020-06-20T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2021.json
+++ b/test/fixtures/AX-2021.json
@@ -22,7 +22,7 @@
     "start": "2021-03-29T21:00:00.000Z",
     "end": "2021-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Tue"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2021-04-25 00:00:00",
+    "start": "2021-04-24T21:00:00.000Z",
+    "end": "2021-04-25T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2021-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2021-06-09 00:00:00",
     "start": "2021-06-08T21:00:00.000Z",
     "end": "2021-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Wed"
   },
@@ -93,7 +102,7 @@
     "date": "2021-06-25 00:00:00",
     "start": "2021-06-24T21:00:00.000Z",
     "end": "2021-06-25T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2021-06-26 00:00:00",
     "start": "2021-06-25T21:00:00.000Z",
     "end": "2021-06-26T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2022.json
+++ b/test/fixtures/AX-2022.json
@@ -22,7 +22,7 @@
     "start": "2022-03-29T21:00:00.000Z",
     "end": "2022-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Wed"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2022-04-24 00:00:00",
+    "start": "2022-04-23T21:00:00.000Z",
+    "end": "2022-04-24T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2022-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2022-06-09 00:00:00",
     "start": "2022-06-08T21:00:00.000Z",
     "end": "2022-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Thu"
   },
@@ -93,7 +102,7 @@
     "date": "2022-06-24 00:00:00",
     "start": "2022-06-23T21:00:00.000Z",
     "end": "2022-06-24T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2022-06-25 00:00:00",
     "start": "2022-06-24T21:00:00.000Z",
     "end": "2022-06-25T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2023.json
+++ b/test/fixtures/AX-2023.json
@@ -22,7 +22,7 @@
     "start": "2023-03-29T21:00:00.000Z",
     "end": "2023-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Thu"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2023-04-30 00:00:00",
+    "start": "2023-04-29T21:00:00.000Z",
+    "end": "2023-04-30T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2023-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2023-06-09 00:00:00",
     "start": "2023-06-08T21:00:00.000Z",
     "end": "2023-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Fri"
   },
@@ -93,7 +102,7 @@
     "date": "2023-06-23 00:00:00",
     "start": "2023-06-22T21:00:00.000Z",
     "end": "2023-06-23T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2023-06-24 00:00:00",
     "start": "2023-06-23T21:00:00.000Z",
     "end": "2023-06-24T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2024.json
+++ b/test/fixtures/AX-2024.json
@@ -31,7 +31,7 @@
     "start": "2024-03-29T22:00:00.000Z",
     "end": "2024-03-30T22:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Sat"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2024-04-28 00:00:00",
+    "start": "2024-04-27T21:00:00.000Z",
+    "end": "2024-04-28T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2024-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2024-06-09 00:00:00",
     "start": "2024-06-08T21:00:00.000Z",
     "end": "2024-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Sun"
   },
@@ -93,7 +102,7 @@
     "date": "2024-06-21 00:00:00",
     "start": "2024-06-20T21:00:00.000Z",
     "end": "2024-06-21T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2024-06-22 00:00:00",
     "start": "2024-06-21T21:00:00.000Z",
     "end": "2024-06-22T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2025.json
+++ b/test/fixtures/AX-2025.json
@@ -22,7 +22,7 @@
     "start": "2025-03-29T22:00:00.000Z",
     "end": "2025-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Sun"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2025-04-27 00:00:00",
+    "start": "2025-04-26T21:00:00.000Z",
+    "end": "2025-04-27T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2025-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T21:00:00.000Z",
     "end": "2025-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Mon"
   },
@@ -93,7 +102,7 @@
     "date": "2025-06-20 00:00:00",
     "start": "2025-06-19T21:00:00.000Z",
     "end": "2025-06-20T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2025-06-21 00:00:00",
     "start": "2025-06-20T21:00:00.000Z",
     "end": "2025-06-21T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2026.json
+++ b/test/fixtures/AX-2026.json
@@ -22,7 +22,7 @@
     "start": "2026-03-29T21:00:00.000Z",
     "end": "2026-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Mon"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2026-04-26 00:00:00",
+    "start": "2026-04-25T21:00:00.000Z",
+    "end": "2026-04-26T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2026-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2026-06-09 00:00:00",
     "start": "2026-06-08T21:00:00.000Z",
     "end": "2026-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Tue"
   },
@@ -93,7 +102,7 @@
     "date": "2026-06-19 00:00:00",
     "start": "2026-06-18T21:00:00.000Z",
     "end": "2026-06-19T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2026-06-20 00:00:00",
     "start": "2026-06-19T21:00:00.000Z",
     "end": "2026-06-20T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2027.json
+++ b/test/fixtures/AX-2027.json
@@ -49,9 +49,18 @@
     "start": "2027-03-29T21:00:00.000Z",
     "end": "2027-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Tue"
+  },
+  {
+    "date": "2027-04-25 00:00:00",
+    "start": "2027-04-24T21:00:00.000Z",
+    "end": "2027-04-25T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2027-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2027-06-09 00:00:00",
     "start": "2027-06-08T21:00:00.000Z",
     "end": "2027-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Wed"
   },
@@ -93,7 +102,7 @@
     "date": "2027-06-25 00:00:00",
     "start": "2027-06-24T21:00:00.000Z",
     "end": "2027-06-25T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2027-06-26 00:00:00",
     "start": "2027-06-25T21:00:00.000Z",
     "end": "2027-06-26T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2028.json
+++ b/test/fixtures/AX-2028.json
@@ -22,7 +22,7 @@
     "start": "2028-03-29T21:00:00.000Z",
     "end": "2028-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Thu"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2028-04-30 00:00:00",
+    "start": "2028-04-29T21:00:00.000Z",
+    "end": "2028-04-30T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2028-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2028-06-09 00:00:00",
     "start": "2028-06-08T21:00:00.000Z",
     "end": "2028-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Fri"
   },
@@ -93,7 +102,7 @@
     "date": "2028-06-23 00:00:00",
     "start": "2028-06-22T21:00:00.000Z",
     "end": "2028-06-23T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2028-06-24 00:00:00",
     "start": "2028-06-23T21:00:00.000Z",
     "end": "2028-06-24T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2029.json
+++ b/test/fixtures/AX-2029.json
@@ -22,7 +22,7 @@
     "start": "2029-03-29T21:00:00.000Z",
     "end": "2029-03-30T21:00:00.000Z",
     "name": "Ålands demilitariseringsdag",
-    "type": "public",
+    "type": "observance",
     "rule": "03-30",
     "_weekday": "Fri"
   },
@@ -52,6 +52,15 @@
     "type": "public",
     "rule": "easter 1",
     "_weekday": "Mon"
+  },
+  {
+    "date": "2029-04-29 00:00:00",
+    "start": "2029-04-28T21:00:00.000Z",
+    "end": "2029-04-29T21:00:00.000Z",
+    "name": "Ålands flaggas dag",
+    "type": "observance",
+    "rule": "sunday before May",
+    "_weekday": "Sun"
   },
   {
     "date": "2029-05-01 00:00:00",
@@ -84,8 +93,8 @@
     "date": "2029-06-09 00:00:00",
     "start": "2029-06-08T21:00:00.000Z",
     "end": "2029-06-09T21:00:00.000Z",
-    "name": "Självstyrelsedagen",
-    "type": "public",
+    "name": "Ålands självstyrelsedag",
+    "type": "observance",
     "rule": "06-09",
     "_weekday": "Sat"
   },
@@ -93,7 +102,7 @@
     "date": "2029-06-22 00:00:00",
     "start": "2029-06-21T21:00:00.000Z",
     "end": "2029-06-22T21:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -102,7 +111,7 @@
     "date": "2029-06-23 00:00:00",
     "start": "2029-06-22T21:00:00.000Z",
     "end": "2029-06-23T21:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"


### PR DESCRIPTION
Replaced `@source` (a supermarket's opening-hours page) with two proper sources: the University of Helsinki almanac office for the general Finnish holidays, and Åland's own flag law (landskapslag 1992:41 om Ålands flagga, §4) for the Åland-specific ones. Added Wikipedia's "Flaggdagar i Finland" as `@attrib`, since it helped confirm the flag day dates and their basis in that law.

That law only classifies 03-30 and 06-09 as official flag days - neither the law nor Wikipedia mention any work-free status. Marked both as observance accordingly, and added the third flag day the law defines but which was missing here (Ålands flaggas dag, last Sunday in April). Also renamed 06-09 from "Självstyrelsedagen" to "Ålands självstyrelsedag" to match the law's wording.

Lowercased Midsommarafton/Midsommardagen too - the almanac source capitalizes them only in its headings (like a title), but writes them lowercase in running text, matching standard Swedish orthography for non-proper-noun holiday names.