### PR TITLE
fix(SE): align holiday name casing with law

### DIFF
--- a/data/countries/SE.yaml
+++ b/data/countries/SE.yaml
@@ -16,14 +16,14 @@ holidays:
         _name: 01-01
       01-05 12:00:
         name:
-          sv: Trettondagsafton
+          sv: trettondagsafton
           en: Twelfth Night
         type: optional
       01-06:
         _name: 01-06
       01-13:
         name:
-          sv: Tjugondag Knut
+          sv: tjugondag Knut
           en: Saint Knut's Day
         type: observance
       1st sunday in March:
@@ -33,13 +33,13 @@ holidays:
       # @source https://www.riksdagen.se/sv/dokument-och-lagar/dokument/svensk-forfattningssamling/lag-1989253-om-allmanna-helgdagar_sfs-1989-253/
       03-25 prior to 1990:
         name:
-          sv: Marie Bebådelsedag
+          sv: Marie bebådelsedag
           en: Annunciation Day
           lat: Annuntiatio Mariæ
         type: observance
       04-30 12:00:
         name:
-          sv: Valborgsmässoafton
+          sv: valborgsmässoafton
           en: Walpurgis Night
         type: optional
       easter -3:
@@ -60,7 +60,7 @@ holidays:
         _name: easter 39
       easter 48:
         name:
-          sv: Pingstafton
+          sv: pingstafton
           en: Whitsun Eve
         type: observance
       easter 49:
@@ -84,18 +84,18 @@ holidays:
         type: observance
       friday after 06-19:
         name:
-          sv: Midsommarafton
+          sv: midsommarafton
           en: Midsummer Eve
           fi: Juhannusaatto
         type: bank
       saturday after 06-20:
         name:
-          sv: Midsommardagen
+          sv: midsommardagen
           en: Midsummer Day
           fi: Juhannuspäivä
       friday after 10-30 12:00:
         name:
-          sv: Allhelgonaafton
+          sv: allhelgonaafton
           en: Halloween
         type: optional
       saturday after 10-31:

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -372,7 +372,7 @@ names:
       sk: Štedrý deň
       sq: Nata e Krishtlindjes
       sr: Бадњи дан
-      sv: Julafton
+      sv: julafton
       vi: Đêm Giáng Sinh
   12-25:
     name:
@@ -482,7 +482,7 @@ names:
       no: Nyttårsaften
       pl: Sylwester
       pt: Véspera de Ano Novo
-      sv: Nyårsafton
+      sv: nyårsafton
       th: วันสิ้นปี
       vi: Đêm giao thừa
 
@@ -556,7 +556,7 @@ names:
       nl: Witte Donderdag
       no: Skjærtorsdag
       pl: Wielki Czwartek
-      sv: Skärtorsdagen
+      sv: skärtorsdagen
       vi: Thứ năm Tuần Thánh
   easter -2: # Good Friday
     name:
@@ -615,7 +615,7 @@ names:
       nl: Dag voor Pasen
       no: Påskeaften
       pl: Wielka Sobota
-      sv: Påskafton
+      sv: påskafton
       vi: Thứ bảy Tuần Thánh
       zh: 耶穌受難節翌日
   easter: # Easter
@@ -757,7 +757,7 @@ names:
       nl: Tweede pinksterdag
       no: Andre pinsedag
       ro: A doua zi de Rusalii
-      sv: Annandag pingst
+      sv: annandag pingst
   easter 60: # Corpus Christi
     name:
       en: Corpus Christi

--- a/test/fixtures/AX-2015.json
+++ b/test/fixtures/AX-2015.json
@@ -120,7 +120,7 @@
     "date": "2015-12-24 12:00:00",
     "start": "2015-12-24T10:00:00.000Z",
     "end": "2015-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Thu"
@@ -147,7 +147,7 @@
     "date": "2015-12-31 12:00:00",
     "start": "2015-12-31T10:00:00.000Z",
     "end": "2015-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Thu"

--- a/test/fixtures/AX-2016.json
+++ b/test/fixtures/AX-2016.json
@@ -120,7 +120,7 @@
     "date": "2016-12-24 12:00:00",
     "start": "2016-12-24T10:00:00.000Z",
     "end": "2016-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2016-12-31 12:00:00",
     "start": "2016-12-31T10:00:00.000Z",
     "end": "2016-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2017.json
+++ b/test/fixtures/AX-2017.json
@@ -120,7 +120,7 @@
     "date": "2017-12-24 12:00:00",
     "start": "2017-12-24T10:00:00.000Z",
     "end": "2017-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Sun"
@@ -147,7 +147,7 @@
     "date": "2017-12-31 12:00:00",
     "start": "2017-12-31T10:00:00.000Z",
     "end": "2017-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Sun"

--- a/test/fixtures/AX-2018.json
+++ b/test/fixtures/AX-2018.json
@@ -120,7 +120,7 @@
     "date": "2018-12-24 12:00:00",
     "start": "2018-12-24T10:00:00.000Z",
     "end": "2018-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Mon"
@@ -147,7 +147,7 @@
     "date": "2018-12-31 12:00:00",
     "start": "2018-12-31T10:00:00.000Z",
     "end": "2018-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Mon"

--- a/test/fixtures/AX-2019.json
+++ b/test/fixtures/AX-2019.json
@@ -120,7 +120,7 @@
     "date": "2019-12-24 12:00:00",
     "start": "2019-12-24T10:00:00.000Z",
     "end": "2019-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Tue"
@@ -147,7 +147,7 @@
     "date": "2019-12-31 12:00:00",
     "start": "2019-12-31T10:00:00.000Z",
     "end": "2019-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Tue"

--- a/test/fixtures/AX-2020.json
+++ b/test/fixtures/AX-2020.json
@@ -120,7 +120,7 @@
     "date": "2020-12-24 12:00:00",
     "start": "2020-12-24T10:00:00.000Z",
     "end": "2020-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Thu"
@@ -147,7 +147,7 @@
     "date": "2020-12-31 12:00:00",
     "start": "2020-12-31T10:00:00.000Z",
     "end": "2020-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Thu"

--- a/test/fixtures/AX-2021.json
+++ b/test/fixtures/AX-2021.json
@@ -120,7 +120,7 @@
     "date": "2021-12-24 12:00:00",
     "start": "2021-12-24T10:00:00.000Z",
     "end": "2021-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Fri"
@@ -147,7 +147,7 @@
     "date": "2021-12-31 12:00:00",
     "start": "2021-12-31T10:00:00.000Z",
     "end": "2021-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Fri"

--- a/test/fixtures/AX-2022.json
+++ b/test/fixtures/AX-2022.json
@@ -120,7 +120,7 @@
     "date": "2022-12-24 12:00:00",
     "start": "2022-12-24T10:00:00.000Z",
     "end": "2022-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2022-12-31 12:00:00",
     "start": "2022-12-31T10:00:00.000Z",
     "end": "2022-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Sat"

--- a/test/fixtures/AX-2023.json
+++ b/test/fixtures/AX-2023.json
@@ -120,7 +120,7 @@
     "date": "2023-12-24 12:00:00",
     "start": "2023-12-24T10:00:00.000Z",
     "end": "2023-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Sun"
@@ -147,7 +147,7 @@
     "date": "2023-12-31 12:00:00",
     "start": "2023-12-31T10:00:00.000Z",
     "end": "2023-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Sun"

--- a/test/fixtures/AX-2024.json
+++ b/test/fixtures/AX-2024.json
@@ -120,7 +120,7 @@
     "date": "2024-12-24 12:00:00",
     "start": "2024-12-24T10:00:00.000Z",
     "end": "2024-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Tue"
@@ -147,7 +147,7 @@
     "date": "2024-12-31 12:00:00",
     "start": "2024-12-31T10:00:00.000Z",
     "end": "2024-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Tue"

--- a/test/fixtures/AX-2025.json
+++ b/test/fixtures/AX-2025.json
@@ -120,7 +120,7 @@
     "date": "2025-12-24 12:00:00",
     "start": "2025-12-24T10:00:00.000Z",
     "end": "2025-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Wed"
@@ -147,7 +147,7 @@
     "date": "2025-12-31 12:00:00",
     "start": "2025-12-31T10:00:00.000Z",
     "end": "2025-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Wed"

--- a/test/fixtures/AX-2026.json
+++ b/test/fixtures/AX-2026.json
@@ -120,7 +120,7 @@
     "date": "2026-12-24 12:00:00",
     "start": "2026-12-24T10:00:00.000Z",
     "end": "2026-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Thu"
@@ -147,7 +147,7 @@
     "date": "2026-12-31 12:00:00",
     "start": "2026-12-31T10:00:00.000Z",
     "end": "2026-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Thu"

--- a/test/fixtures/AX-2027.json
+++ b/test/fixtures/AX-2027.json
@@ -120,7 +120,7 @@
     "date": "2027-12-24 12:00:00",
     "start": "2027-12-24T10:00:00.000Z",
     "end": "2027-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Fri"
@@ -147,7 +147,7 @@
     "date": "2027-12-31 12:00:00",
     "start": "2027-12-31T10:00:00.000Z",
     "end": "2027-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Fri"

--- a/test/fixtures/AX-2028.json
+++ b/test/fixtures/AX-2028.json
@@ -120,7 +120,7 @@
     "date": "2028-12-24 12:00:00",
     "start": "2028-12-24T10:00:00.000Z",
     "end": "2028-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Sun"
@@ -147,7 +147,7 @@
     "date": "2028-12-31 12:00:00",
     "start": "2028-12-31T10:00:00.000Z",
     "end": "2028-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Sun"

--- a/test/fixtures/AX-2029.json
+++ b/test/fixtures/AX-2029.json
@@ -120,7 +120,7 @@
     "date": "2029-12-24 12:00:00",
     "start": "2029-12-24T10:00:00.000Z",
     "end": "2029-12-24T22:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24 12:00",
     "_weekday": "Mon"
@@ -147,7 +147,7 @@
     "date": "2029-12-31 12:00:00",
     "start": "2029-12-31T10:00:00.000Z",
     "end": "2029-12-31T22:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31 12:00",
     "_weekday": "Mon"

--- a/test/fixtures/SE-2015.json
+++ b/test/fixtures/SE-2015.json
@@ -12,7 +12,7 @@
     "date": "2015-01-05 12:00:00",
     "start": "2015-01-05T11:00:00.000Z",
     "end": "2015-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Mon"
@@ -30,7 +30,7 @@
     "date": "2015-01-13 00:00:00",
     "start": "2015-01-12T23:00:00.000Z",
     "end": "2015-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2015-04-02 00:00:00",
     "start": "2015-04-01T22:00:00.000Z",
     "end": "2015-04-02T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2015-04-04 00:00:00",
     "start": "2015-04-03T22:00:00.000Z",
     "end": "2015-04-04T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2015-04-30 12:00:00",
     "start": "2015-04-30T10:00:00.000Z",
     "end": "2015-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Thu"
@@ -120,7 +120,7 @@
     "date": "2015-05-23 00:00:00",
     "start": "2015-05-22T22:00:00.000Z",
     "end": "2015-05-23T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2015-05-25 00:00:00",
     "start": "2015-05-24T22:00:00.000Z",
     "end": "2015-05-25T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2015-06-19 00:00:00",
     "start": "2015-06-18T22:00:00.000Z",
     "end": "2015-06-19T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2015-06-20 00:00:00",
     "start": "2015-06-19T22:00:00.000Z",
     "end": "2015-06-20T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2015-10-30 12:00:00",
     "start": "2015-10-30T11:00:00.000Z",
     "end": "2015-10-30T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2015-12-24 00:00:00",
     "start": "2015-12-23T23:00:00.000Z",
     "end": "2015-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Thu"
@@ -264,7 +264,7 @@
     "date": "2015-12-31 00:00:00",
     "start": "2015-12-30T23:00:00.000Z",
     "end": "2015-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Thu"

--- a/test/fixtures/SE-2016.json
+++ b/test/fixtures/SE-2016.json
@@ -12,7 +12,7 @@
     "date": "2016-01-05 12:00:00",
     "start": "2016-01-05T11:00:00.000Z",
     "end": "2016-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Tue"
@@ -30,7 +30,7 @@
     "date": "2016-01-13 00:00:00",
     "start": "2016-01-12T23:00:00.000Z",
     "end": "2016-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2016-03-24 00:00:00",
     "start": "2016-03-23T23:00:00.000Z",
     "end": "2016-03-24T23:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2016-03-26 00:00:00",
     "start": "2016-03-25T23:00:00.000Z",
     "end": "2016-03-26T23:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2016-04-30 12:00:00",
     "start": "2016-04-30T10:00:00.000Z",
     "end": "2016-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2016-05-14 00:00:00",
     "start": "2016-05-13T22:00:00.000Z",
     "end": "2016-05-14T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2016-05-16 00:00:00",
     "start": "2016-05-15T22:00:00.000Z",
     "end": "2016-05-16T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2016-06-24 00:00:00",
     "start": "2016-06-23T22:00:00.000Z",
     "end": "2016-06-24T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2016-06-25 00:00:00",
     "start": "2016-06-24T22:00:00.000Z",
     "end": "2016-06-25T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2016-11-04 12:00:00",
     "start": "2016-11-04T11:00:00.000Z",
     "end": "2016-11-04T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2016-12-24 00:00:00",
     "start": "2016-12-23T23:00:00.000Z",
     "end": "2016-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Sat"
@@ -264,7 +264,7 @@
     "date": "2016-12-31 00:00:00",
     "start": "2016-12-30T23:00:00.000Z",
     "end": "2016-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2017.json
+++ b/test/fixtures/SE-2017.json
@@ -12,7 +12,7 @@
     "date": "2017-01-05 12:00:00",
     "start": "2017-01-05T11:00:00.000Z",
     "end": "2017-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Thu"
@@ -30,7 +30,7 @@
     "date": "2017-01-13 00:00:00",
     "start": "2017-01-12T23:00:00.000Z",
     "end": "2017-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2017-04-13 00:00:00",
     "start": "2017-04-12T22:00:00.000Z",
     "end": "2017-04-13T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2017-04-15 00:00:00",
     "start": "2017-04-14T22:00:00.000Z",
     "end": "2017-04-15T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2017-04-30 12:00:00",
     "start": "2017-04-30T10:00:00.000Z",
     "end": "2017-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2017-06-03 00:00:00",
     "start": "2017-06-02T22:00:00.000Z",
     "end": "2017-06-03T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2017-06-05 00:00:00",
     "start": "2017-06-04T22:00:00.000Z",
     "end": "2017-06-05T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2017-06-23 00:00:00",
     "start": "2017-06-22T22:00:00.000Z",
     "end": "2017-06-23T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2017-06-24 00:00:00",
     "start": "2017-06-23T22:00:00.000Z",
     "end": "2017-06-24T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2017-11-03 12:00:00",
     "start": "2017-11-03T11:00:00.000Z",
     "end": "2017-11-03T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2017-12-24 00:00:00",
     "start": "2017-12-23T23:00:00.000Z",
     "end": "2017-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Sun"
@@ -264,7 +264,7 @@
     "date": "2017-12-31 00:00:00",
     "start": "2017-12-30T23:00:00.000Z",
     "end": "2017-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Sun"

--- a/test/fixtures/SE-2018.json
+++ b/test/fixtures/SE-2018.json
@@ -12,7 +12,7 @@
     "date": "2018-01-05 12:00:00",
     "start": "2018-01-05T11:00:00.000Z",
     "end": "2018-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2018-01-13 00:00:00",
     "start": "2018-01-12T23:00:00.000Z",
     "end": "2018-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2018-03-29 00:00:00",
     "start": "2018-03-28T22:00:00.000Z",
     "end": "2018-03-29T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2018-03-31 00:00:00",
     "start": "2018-03-30T22:00:00.000Z",
     "end": "2018-03-31T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2018-04-30 12:00:00",
     "start": "2018-04-30T10:00:00.000Z",
     "end": "2018-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Mon"
@@ -120,7 +120,7 @@
     "date": "2018-05-19 00:00:00",
     "start": "2018-05-18T22:00:00.000Z",
     "end": "2018-05-19T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2018-05-21 00:00:00",
     "start": "2018-05-20T22:00:00.000Z",
     "end": "2018-05-21T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2018-06-22 00:00:00",
     "start": "2018-06-21T22:00:00.000Z",
     "end": "2018-06-22T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2018-06-23 00:00:00",
     "start": "2018-06-22T22:00:00.000Z",
     "end": "2018-06-23T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2018-11-02 12:00:00",
     "start": "2018-11-02T11:00:00.000Z",
     "end": "2018-11-02T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2018-12-24 00:00:00",
     "start": "2018-12-23T23:00:00.000Z",
     "end": "2018-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Mon"
@@ -264,7 +264,7 @@
     "date": "2018-12-31 00:00:00",
     "start": "2018-12-30T23:00:00.000Z",
     "end": "2018-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Mon"

--- a/test/fixtures/SE-2019.json
+++ b/test/fixtures/SE-2019.json
@@ -12,7 +12,7 @@
     "date": "2019-01-05 12:00:00",
     "start": "2019-01-05T11:00:00.000Z",
     "end": "2019-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Sat"
@@ -30,7 +30,7 @@
     "date": "2019-01-13 00:00:00",
     "start": "2019-01-12T23:00:00.000Z",
     "end": "2019-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Sun"
@@ -48,7 +48,7 @@
     "date": "2019-04-18 00:00:00",
     "start": "2019-04-17T22:00:00.000Z",
     "end": "2019-04-18T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2019-04-20 00:00:00",
     "start": "2019-04-19T22:00:00.000Z",
     "end": "2019-04-20T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2019-04-30 12:00:00",
     "start": "2019-04-30T10:00:00.000Z",
     "end": "2019-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Tue"
@@ -138,7 +138,7 @@
     "date": "2019-06-08 00:00:00",
     "start": "2019-06-07T22:00:00.000Z",
     "end": "2019-06-08T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -156,7 +156,7 @@
     "date": "2019-06-10 00:00:00",
     "start": "2019-06-09T22:00:00.000Z",
     "end": "2019-06-10T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2019-06-21 00:00:00",
     "start": "2019-06-20T22:00:00.000Z",
     "end": "2019-06-21T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2019-06-22 00:00:00",
     "start": "2019-06-21T22:00:00.000Z",
     "end": "2019-06-22T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2019-11-01 12:00:00",
     "start": "2019-11-01T11:00:00.000Z",
     "end": "2019-11-01T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2019-12-24 00:00:00",
     "start": "2019-12-23T23:00:00.000Z",
     "end": "2019-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Tue"
@@ -264,7 +264,7 @@
     "date": "2019-12-31 00:00:00",
     "start": "2019-12-30T23:00:00.000Z",
     "end": "2019-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Tue"

--- a/test/fixtures/SE-2020.json
+++ b/test/fixtures/SE-2020.json
@@ -12,7 +12,7 @@
     "date": "2020-01-05 12:00:00",
     "start": "2020-01-05T11:00:00.000Z",
     "end": "2020-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Sun"
@@ -30,7 +30,7 @@
     "date": "2020-01-13 00:00:00",
     "start": "2020-01-12T23:00:00.000Z",
     "end": "2020-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2020-04-09 00:00:00",
     "start": "2020-04-08T22:00:00.000Z",
     "end": "2020-04-09T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2020-04-11 00:00:00",
     "start": "2020-04-10T22:00:00.000Z",
     "end": "2020-04-11T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2020-04-30 12:00:00",
     "start": "2020-04-30T10:00:00.000Z",
     "end": "2020-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Thu"
@@ -120,7 +120,7 @@
     "date": "2020-05-30 00:00:00",
     "start": "2020-05-29T22:00:00.000Z",
     "end": "2020-05-30T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2020-06-01 00:00:00",
     "start": "2020-05-31T22:00:00.000Z",
     "end": "2020-06-01T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2020-06-19 00:00:00",
     "start": "2020-06-18T22:00:00.000Z",
     "end": "2020-06-19T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2020-06-20 00:00:00",
     "start": "2020-06-19T22:00:00.000Z",
     "end": "2020-06-20T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2020-10-30 12:00:00",
     "start": "2020-10-30T11:00:00.000Z",
     "end": "2020-10-30T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2020-12-24 00:00:00",
     "start": "2020-12-23T23:00:00.000Z",
     "end": "2020-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Thu"
@@ -264,7 +264,7 @@
     "date": "2020-12-31 00:00:00",
     "start": "2020-12-30T23:00:00.000Z",
     "end": "2020-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Thu"

--- a/test/fixtures/SE-2021.json
+++ b/test/fixtures/SE-2021.json
@@ -12,7 +12,7 @@
     "date": "2021-01-05 12:00:00",
     "start": "2021-01-05T11:00:00.000Z",
     "end": "2021-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Tue"
@@ -30,7 +30,7 @@
     "date": "2021-01-13 00:00:00",
     "start": "2021-01-12T23:00:00.000Z",
     "end": "2021-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2021-04-01 00:00:00",
     "start": "2021-03-31T22:00:00.000Z",
     "end": "2021-04-01T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2021-04-03 00:00:00",
     "start": "2021-04-02T22:00:00.000Z",
     "end": "2021-04-03T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2021-04-30 12:00:00",
     "start": "2021-04-30T10:00:00.000Z",
     "end": "2021-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Fri"
@@ -120,7 +120,7 @@
     "date": "2021-05-22 00:00:00",
     "start": "2021-05-21T22:00:00.000Z",
     "end": "2021-05-22T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2021-05-24 00:00:00",
     "start": "2021-05-23T22:00:00.000Z",
     "end": "2021-05-24T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2021-06-25 00:00:00",
     "start": "2021-06-24T22:00:00.000Z",
     "end": "2021-06-25T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2021-06-26 00:00:00",
     "start": "2021-06-25T22:00:00.000Z",
     "end": "2021-06-26T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2021-11-05 12:00:00",
     "start": "2021-11-05T11:00:00.000Z",
     "end": "2021-11-05T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2021-12-24 00:00:00",
     "start": "2021-12-23T23:00:00.000Z",
     "end": "2021-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Fri"
@@ -264,7 +264,7 @@
     "date": "2021-12-31 00:00:00",
     "start": "2021-12-30T23:00:00.000Z",
     "end": "2021-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Fri"

--- a/test/fixtures/SE-2022.json
+++ b/test/fixtures/SE-2022.json
@@ -12,7 +12,7 @@
     "date": "2022-01-05 12:00:00",
     "start": "2022-01-05T11:00:00.000Z",
     "end": "2022-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Wed"
@@ -30,7 +30,7 @@
     "date": "2022-01-13 00:00:00",
     "start": "2022-01-12T23:00:00.000Z",
     "end": "2022-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2022-04-14 00:00:00",
     "start": "2022-04-13T22:00:00.000Z",
     "end": "2022-04-14T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2022-04-16 00:00:00",
     "start": "2022-04-15T22:00:00.000Z",
     "end": "2022-04-16T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2022-04-30 12:00:00",
     "start": "2022-04-30T10:00:00.000Z",
     "end": "2022-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Sat"
@@ -129,7 +129,7 @@
     "date": "2022-06-04 00:00:00",
     "start": "2022-06-03T22:00:00.000Z",
     "end": "2022-06-04T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2022-06-06 00:00:00",
     "start": "2022-06-05T22:00:00.000Z",
     "end": "2022-06-06T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2022-06-24 00:00:00",
     "start": "2022-06-23T22:00:00.000Z",
     "end": "2022-06-24T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2022-06-25 00:00:00",
     "start": "2022-06-24T22:00:00.000Z",
     "end": "2022-06-25T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2022-11-04 12:00:00",
     "start": "2022-11-04T11:00:00.000Z",
     "end": "2022-11-04T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2022-12-24 00:00:00",
     "start": "2022-12-23T23:00:00.000Z",
     "end": "2022-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Sat"
@@ -264,7 +264,7 @@
     "date": "2022-12-31 00:00:00",
     "start": "2022-12-30T23:00:00.000Z",
     "end": "2022-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Sat"

--- a/test/fixtures/SE-2023.json
+++ b/test/fixtures/SE-2023.json
@@ -12,7 +12,7 @@
     "date": "2023-01-05 12:00:00",
     "start": "2023-01-05T11:00:00.000Z",
     "end": "2023-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Thu"
@@ -30,7 +30,7 @@
     "date": "2023-01-13 00:00:00",
     "start": "2023-01-12T23:00:00.000Z",
     "end": "2023-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Fri"
@@ -48,7 +48,7 @@
     "date": "2023-04-06 00:00:00",
     "start": "2023-04-05T22:00:00.000Z",
     "end": "2023-04-06T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2023-04-08 00:00:00",
     "start": "2023-04-07T22:00:00.000Z",
     "end": "2023-04-08T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2023-04-30 12:00:00",
     "start": "2023-04-30T10:00:00.000Z",
     "end": "2023-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Sun"
@@ -120,7 +120,7 @@
     "date": "2023-05-27 00:00:00",
     "start": "2023-05-26T22:00:00.000Z",
     "end": "2023-05-27T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2023-05-29 00:00:00",
     "start": "2023-05-28T22:00:00.000Z",
     "end": "2023-05-29T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2023-06-23 00:00:00",
     "start": "2023-06-22T22:00:00.000Z",
     "end": "2023-06-23T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2023-06-24 00:00:00",
     "start": "2023-06-23T22:00:00.000Z",
     "end": "2023-06-24T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2023-11-03 12:00:00",
     "start": "2023-11-03T11:00:00.000Z",
     "end": "2023-11-03T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2023-12-24 00:00:00",
     "start": "2023-12-23T23:00:00.000Z",
     "end": "2023-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Sun"
@@ -264,7 +264,7 @@
     "date": "2023-12-31 00:00:00",
     "start": "2023-12-30T23:00:00.000Z",
     "end": "2023-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Sun"

--- a/test/fixtures/SE-2024.json
+++ b/test/fixtures/SE-2024.json
@@ -12,7 +12,7 @@
     "date": "2024-01-05 12:00:00",
     "start": "2024-01-05T11:00:00.000Z",
     "end": "2024-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2024-01-13 00:00:00",
     "start": "2024-01-12T23:00:00.000Z",
     "end": "2024-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2024-03-28 00:00:00",
     "start": "2024-03-27T23:00:00.000Z",
     "end": "2024-03-28T23:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2024-03-30 00:00:00",
     "start": "2024-03-29T23:00:00.000Z",
     "end": "2024-03-30T23:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2024-04-30 12:00:00",
     "start": "2024-04-30T10:00:00.000Z",
     "end": "2024-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Tue"
@@ -120,7 +120,7 @@
     "date": "2024-05-18 00:00:00",
     "start": "2024-05-17T22:00:00.000Z",
     "end": "2024-05-18T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2024-05-20 00:00:00",
     "start": "2024-05-19T22:00:00.000Z",
     "end": "2024-05-20T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2024-06-21 00:00:00",
     "start": "2024-06-20T22:00:00.000Z",
     "end": "2024-06-21T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2024-06-22 00:00:00",
     "start": "2024-06-21T22:00:00.000Z",
     "end": "2024-06-22T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2024-11-01 12:00:00",
     "start": "2024-11-01T11:00:00.000Z",
     "end": "2024-11-01T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2024-12-24 00:00:00",
     "start": "2024-12-23T23:00:00.000Z",
     "end": "2024-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Tue"
@@ -264,7 +264,7 @@
     "date": "2024-12-31 00:00:00",
     "start": "2024-12-30T23:00:00.000Z",
     "end": "2024-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Tue"

--- a/test/fixtures/SE-2025.json
+++ b/test/fixtures/SE-2025.json
@@ -12,7 +12,7 @@
     "date": "2025-01-05 12:00:00",
     "start": "2025-01-05T11:00:00.000Z",
     "end": "2025-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Sun"
@@ -30,7 +30,7 @@
     "date": "2025-01-13 00:00:00",
     "start": "2025-01-12T23:00:00.000Z",
     "end": "2025-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Mon"
@@ -48,7 +48,7 @@
     "date": "2025-04-17 00:00:00",
     "start": "2025-04-16T22:00:00.000Z",
     "end": "2025-04-17T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2025-04-19 00:00:00",
     "start": "2025-04-18T22:00:00.000Z",
     "end": "2025-04-19T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2025-04-30 12:00:00",
     "start": "2025-04-30T10:00:00.000Z",
     "end": "2025-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Wed"
@@ -138,7 +138,7 @@
     "date": "2025-06-07 00:00:00",
     "start": "2025-06-06T22:00:00.000Z",
     "end": "2025-06-07T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -156,7 +156,7 @@
     "date": "2025-06-09 00:00:00",
     "start": "2025-06-08T22:00:00.000Z",
     "end": "2025-06-09T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2025-06-20 00:00:00",
     "start": "2025-06-19T22:00:00.000Z",
     "end": "2025-06-20T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2025-06-21 00:00:00",
     "start": "2025-06-20T22:00:00.000Z",
     "end": "2025-06-21T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2025-10-31 12:00:00",
     "start": "2025-10-31T11:00:00.000Z",
     "end": "2025-10-31T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2025-12-24 00:00:00",
     "start": "2025-12-23T23:00:00.000Z",
     "end": "2025-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Wed"
@@ -264,7 +264,7 @@
     "date": "2025-12-31 00:00:00",
     "start": "2025-12-30T23:00:00.000Z",
     "end": "2025-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Wed"

--- a/test/fixtures/SE-2026.json
+++ b/test/fixtures/SE-2026.json
@@ -12,7 +12,7 @@
     "date": "2026-01-05 12:00:00",
     "start": "2026-01-05T11:00:00.000Z",
     "end": "2026-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Mon"
@@ -30,7 +30,7 @@
     "date": "2026-01-13 00:00:00",
     "start": "2026-01-12T23:00:00.000Z",
     "end": "2026-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Tue"
@@ -48,7 +48,7 @@
     "date": "2026-04-02 00:00:00",
     "start": "2026-04-01T22:00:00.000Z",
     "end": "2026-04-02T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2026-04-04 00:00:00",
     "start": "2026-04-03T22:00:00.000Z",
     "end": "2026-04-04T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2026-04-30 12:00:00",
     "start": "2026-04-30T10:00:00.000Z",
     "end": "2026-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Thu"
@@ -120,7 +120,7 @@
     "date": "2026-05-23 00:00:00",
     "start": "2026-05-22T22:00:00.000Z",
     "end": "2026-05-23T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2026-05-25 00:00:00",
     "start": "2026-05-24T22:00:00.000Z",
     "end": "2026-05-25T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2026-06-19 00:00:00",
     "start": "2026-06-18T22:00:00.000Z",
     "end": "2026-06-19T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2026-06-20 00:00:00",
     "start": "2026-06-19T22:00:00.000Z",
     "end": "2026-06-20T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2026-10-30 12:00:00",
     "start": "2026-10-30T11:00:00.000Z",
     "end": "2026-10-30T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2026-12-24 00:00:00",
     "start": "2026-12-23T23:00:00.000Z",
     "end": "2026-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Thu"
@@ -264,7 +264,7 @@
     "date": "2026-12-31 00:00:00",
     "start": "2026-12-30T23:00:00.000Z",
     "end": "2026-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Thu"

--- a/test/fixtures/SE-2027.json
+++ b/test/fixtures/SE-2027.json
@@ -12,7 +12,7 @@
     "date": "2027-01-05 12:00:00",
     "start": "2027-01-05T11:00:00.000Z",
     "end": "2027-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Tue"
@@ -30,7 +30,7 @@
     "date": "2027-01-13 00:00:00",
     "start": "2027-01-12T23:00:00.000Z",
     "end": "2027-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Wed"
@@ -48,7 +48,7 @@
     "date": "2027-03-25 00:00:00",
     "start": "2027-03-24T23:00:00.000Z",
     "end": "2027-03-25T23:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2027-03-27 00:00:00",
     "start": "2027-03-26T23:00:00.000Z",
     "end": "2027-03-27T23:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2027-04-30 12:00:00",
     "start": "2027-04-30T10:00:00.000Z",
     "end": "2027-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Fri"
@@ -120,7 +120,7 @@
     "date": "2027-05-15 00:00:00",
     "start": "2027-05-14T22:00:00.000Z",
     "end": "2027-05-15T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2027-05-17 00:00:00",
     "start": "2027-05-16T22:00:00.000Z",
     "end": "2027-05-17T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2027-06-25 00:00:00",
     "start": "2027-06-24T22:00:00.000Z",
     "end": "2027-06-25T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2027-06-26 00:00:00",
     "start": "2027-06-25T22:00:00.000Z",
     "end": "2027-06-26T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2027-11-05 12:00:00",
     "start": "2027-11-05T11:00:00.000Z",
     "end": "2027-11-05T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2027-12-24 00:00:00",
     "start": "2027-12-23T23:00:00.000Z",
     "end": "2027-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Fri"
@@ -264,7 +264,7 @@
     "date": "2027-12-31 00:00:00",
     "start": "2027-12-30T23:00:00.000Z",
     "end": "2027-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Fri"

--- a/test/fixtures/SE-2028.json
+++ b/test/fixtures/SE-2028.json
@@ -12,7 +12,7 @@
     "date": "2028-01-05 12:00:00",
     "start": "2028-01-05T11:00:00.000Z",
     "end": "2028-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Wed"
@@ -30,7 +30,7 @@
     "date": "2028-01-13 00:00:00",
     "start": "2028-01-12T23:00:00.000Z",
     "end": "2028-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Thu"
@@ -48,7 +48,7 @@
     "date": "2028-04-13 00:00:00",
     "start": "2028-04-12T22:00:00.000Z",
     "end": "2028-04-13T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2028-04-15 00:00:00",
     "start": "2028-04-14T22:00:00.000Z",
     "end": "2028-04-15T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2028-04-30 12:00:00",
     "start": "2028-04-30T10:00:00.000Z",
     "end": "2028-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2028-06-03 00:00:00",
     "start": "2028-06-02T22:00:00.000Z",
     "end": "2028-06-03T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -147,7 +147,7 @@
     "date": "2028-06-05 00:00:00",
     "start": "2028-06-04T22:00:00.000Z",
     "end": "2028-06-05T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2028-06-23 00:00:00",
     "start": "2028-06-22T22:00:00.000Z",
     "end": "2028-06-23T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2028-06-24 00:00:00",
     "start": "2028-06-23T22:00:00.000Z",
     "end": "2028-06-24T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2028-11-03 12:00:00",
     "start": "2028-11-03T11:00:00.000Z",
     "end": "2028-11-03T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2028-12-24 00:00:00",
     "start": "2028-12-23T23:00:00.000Z",
     "end": "2028-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Sun"
@@ -264,7 +264,7 @@
     "date": "2028-12-31 00:00:00",
     "start": "2028-12-30T23:00:00.000Z",
     "end": "2028-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Sun"

--- a/test/fixtures/SE-2029.json
+++ b/test/fixtures/SE-2029.json
@@ -12,7 +12,7 @@
     "date": "2029-01-05 12:00:00",
     "start": "2029-01-05T11:00:00.000Z",
     "end": "2029-01-05T23:00:00.000Z",
-    "name": "Trettondagsafton",
+    "name": "trettondagsafton",
     "type": "optional",
     "rule": "01-05 12:00",
     "_weekday": "Fri"
@@ -30,7 +30,7 @@
     "date": "2029-01-13 00:00:00",
     "start": "2029-01-12T23:00:00.000Z",
     "end": "2029-01-13T23:00:00.000Z",
-    "name": "Tjugondag Knut",
+    "name": "tjugondag Knut",
     "type": "observance",
     "rule": "01-13",
     "_weekday": "Sat"
@@ -48,7 +48,7 @@
     "date": "2029-03-29 00:00:00",
     "start": "2029-03-28T22:00:00.000Z",
     "end": "2029-03-29T22:00:00.000Z",
-    "name": "Skärtorsdagen",
+    "name": "skärtorsdagen",
     "type": "observance",
     "rule": "easter -3",
     "_weekday": "Thu"
@@ -66,7 +66,7 @@
     "date": "2029-03-31 00:00:00",
     "start": "2029-03-30T22:00:00.000Z",
     "end": "2029-03-31T22:00:00.000Z",
-    "name": "Påskafton",
+    "name": "påskafton",
     "type": "observance",
     "rule": "easter -1",
     "_weekday": "Sat"
@@ -93,7 +93,7 @@
     "date": "2029-04-30 12:00:00",
     "start": "2029-04-30T10:00:00.000Z",
     "end": "2029-04-30T22:00:00.000Z",
-    "name": "Valborgsmässoafton",
+    "name": "valborgsmässoafton",
     "type": "optional",
     "rule": "04-30 12:00",
     "_weekday": "Mon"
@@ -120,7 +120,7 @@
     "date": "2029-05-19 00:00:00",
     "start": "2029-05-18T22:00:00.000Z",
     "end": "2029-05-19T22:00:00.000Z",
-    "name": "Pingstafton",
+    "name": "pingstafton",
     "type": "observance",
     "rule": "easter 48",
     "_weekday": "Sat"
@@ -138,7 +138,7 @@
     "date": "2029-05-21 00:00:00",
     "start": "2029-05-20T22:00:00.000Z",
     "end": "2029-05-21T22:00:00.000Z",
-    "name": "Annandag pingst",
+    "name": "annandag pingst",
     "type": "observance",
     "rule": "easter 50",
     "_weekday": "Mon"
@@ -165,7 +165,7 @@
     "date": "2029-06-22 00:00:00",
     "start": "2029-06-21T22:00:00.000Z",
     "end": "2029-06-22T22:00:00.000Z",
-    "name": "Midsommarafton",
+    "name": "midsommarafton",
     "type": "bank",
     "rule": "friday after 06-19",
     "_weekday": "Fri"
@@ -174,7 +174,7 @@
     "date": "2029-06-23 00:00:00",
     "start": "2029-06-22T22:00:00.000Z",
     "end": "2029-06-23T22:00:00.000Z",
-    "name": "Midsommardagen",
+    "name": "midsommardagen",
     "type": "public",
     "rule": "saturday after 06-20",
     "_weekday": "Sat"
@@ -183,7 +183,7 @@
     "date": "2029-11-02 12:00:00",
     "start": "2029-11-02T11:00:00.000Z",
     "end": "2029-11-02T23:00:00.000Z",
-    "name": "Allhelgonaafton",
+    "name": "allhelgonaafton",
     "type": "optional",
     "rule": "friday after 10-30 12:00",
     "_weekday": "Fri"
@@ -237,7 +237,7 @@
     "date": "2029-12-24 00:00:00",
     "start": "2029-12-23T23:00:00.000Z",
     "end": "2029-12-24T23:00:00.000Z",
-    "name": "Julafton",
+    "name": "julafton",
     "type": "bank",
     "rule": "12-24",
     "_weekday": "Mon"
@@ -264,7 +264,7 @@
     "date": "2029-12-31 00:00:00",
     "start": "2029-12-30T23:00:00.000Z",
     "end": "2029-12-31T23:00:00.000Z",
-    "name": "Nyårsafton",
+    "name": "nyårsafton",
     "type": "bank",
     "rule": "12-31",
     "_weekday": "Mon"


### PR DESCRIPTION
Most Swedish holiday names in this repo were capitalized, but the actual law text (lag 1989:253 om allmänna helgdagar, this file's `@source`) writes them lowercase throughout - e.g. "midsommardagen", "nyårsdagen", "annandag påsk" - except where a proper noun is involved (e.g. "Kristi himmelsfärdsdag"). Fixed both names.yaml and SE.yaml's country-specific overrides to match.