### PR TITLE
fix(RO): align Romanian holiday labels

### DIFF
--- a/data/countries/RO.yaml
+++ b/data/countries/RO.yaml
@@ -1,4 +1,5 @@
 holidays:
+  # @attrib https://ro.wikipedia.org/wiki/S%C4%83rb%C4%83tori_publice_%C3%AEn_Rom%C3%A2nia
   # @attrib https://de.wikipedia.org/wiki/Feiertage_in_Rum%C3%A4nien
   # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Romania
   # @source http://www.dreptonline.ro/legislatie/codul_muncii.php
@@ -22,7 +23,7 @@ holidays:
           en: Epiphany
       01-07:
         name:
-          ro: Sfântul Ion
+          ro: Sfântul Ioan Botezătorul
           en: Saint John the Baptist
       01-24:
         name:

--- a/data/names.yaml
+++ b/data/names.yaml
@@ -685,7 +685,7 @@ names:
       no: Andre påskedag
       pap: Di dos Dia Pasco di Resureccion
       pl: Drugi dzień Wielkanocy
-      ro: A doua zi de Pasti
+      ro: A doua zi de Paști
       sk: Veľkonočný pondelok
       sl: Velikonočni ponedeljek
       sr: Католички Васкрсни понедељак

--- a/test/fixtures/MD-2015.json
+++ b/test/fixtures/MD-2015.json
@@ -39,7 +39,7 @@
     "date": "2015-04-13 00:00:00",
     "start": "2015-04-12T21:00:00.000Z",
     "end": "2015-04-13T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2016.json
+++ b/test/fixtures/MD-2016.json
@@ -48,7 +48,7 @@
     "date": "2016-05-02 00:00:00",
     "start": "2016-05-01T21:00:00.000Z",
     "end": "2016-05-02T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2017.json
+++ b/test/fixtures/MD-2017.json
@@ -39,7 +39,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T21:00:00.000Z",
     "end": "2017-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2018.json
+++ b/test/fixtures/MD-2018.json
@@ -39,7 +39,7 @@
     "date": "2018-04-09 00:00:00",
     "start": "2018-04-08T21:00:00.000Z",
     "end": "2018-04-09T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2019.json
+++ b/test/fixtures/MD-2019.json
@@ -39,7 +39,7 @@
     "date": "2019-04-29 00:00:00",
     "start": "2019-04-28T21:00:00.000Z",
     "end": "2019-04-29T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2020.json
+++ b/test/fixtures/MD-2020.json
@@ -39,7 +39,7 @@
     "date": "2020-04-20 00:00:00",
     "start": "2020-04-19T21:00:00.000Z",
     "end": "2020-04-20T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2021.json
+++ b/test/fixtures/MD-2021.json
@@ -48,7 +48,7 @@
     "date": "2021-05-03 00:00:00",
     "start": "2021-05-02T21:00:00.000Z",
     "end": "2021-05-03T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2022.json
+++ b/test/fixtures/MD-2022.json
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T21:00:00.000Z",
     "end": "2022-04-25T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2023.json
+++ b/test/fixtures/MD-2023.json
@@ -39,7 +39,7 @@
     "date": "2023-04-17 00:00:00",
     "start": "2023-04-16T21:00:00.000Z",
     "end": "2023-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2024.json
+++ b/test/fixtures/MD-2024.json
@@ -48,7 +48,7 @@
     "date": "2024-05-06 00:00:00",
     "start": "2024-05-05T21:00:00.000Z",
     "end": "2024-05-06T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2025.json
+++ b/test/fixtures/MD-2025.json
@@ -39,7 +39,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T21:00:00.000Z",
     "end": "2025-04-21T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2026.json
+++ b/test/fixtures/MD-2026.json
@@ -39,7 +39,7 @@
     "date": "2026-04-13 00:00:00",
     "start": "2026-04-12T21:00:00.000Z",
     "end": "2026-04-13T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2027.json
+++ b/test/fixtures/MD-2027.json
@@ -48,7 +48,7 @@
     "date": "2027-05-03 00:00:00",
     "start": "2027-05-02T21:00:00.000Z",
     "end": "2027-05-03T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2028.json
+++ b/test/fixtures/MD-2028.json
@@ -39,7 +39,7 @@
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T21:00:00.000Z",
     "end": "2028-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-2029.json
+++ b/test/fixtures/MD-2029.json
@@ -39,7 +39,7 @@
     "date": "2029-04-09 00:00:00",
     "start": "2029-04-08T21:00:00.000Z",
     "end": "2029-04-09T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2015.json
+++ b/test/fixtures/MD-CA-2015.json
@@ -39,7 +39,7 @@
     "date": "2015-04-13 00:00:00",
     "start": "2015-04-12T21:00:00.000Z",
     "end": "2015-04-13T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2016.json
+++ b/test/fixtures/MD-CA-2016.json
@@ -48,7 +48,7 @@
     "date": "2016-05-02 00:00:00",
     "start": "2016-05-01T21:00:00.000Z",
     "end": "2016-05-02T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2017.json
+++ b/test/fixtures/MD-CA-2017.json
@@ -39,7 +39,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T21:00:00.000Z",
     "end": "2017-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2018.json
+++ b/test/fixtures/MD-CA-2018.json
@@ -39,7 +39,7 @@
     "date": "2018-04-09 00:00:00",
     "start": "2018-04-08T21:00:00.000Z",
     "end": "2018-04-09T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2019.json
+++ b/test/fixtures/MD-CA-2019.json
@@ -39,7 +39,7 @@
     "date": "2019-04-29 00:00:00",
     "start": "2019-04-28T21:00:00.000Z",
     "end": "2019-04-29T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2020.json
+++ b/test/fixtures/MD-CA-2020.json
@@ -39,7 +39,7 @@
     "date": "2020-04-20 00:00:00",
     "start": "2020-04-19T21:00:00.000Z",
     "end": "2020-04-20T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2021.json
+++ b/test/fixtures/MD-CA-2021.json
@@ -48,7 +48,7 @@
     "date": "2021-05-03 00:00:00",
     "start": "2021-05-02T21:00:00.000Z",
     "end": "2021-05-03T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2022.json
+++ b/test/fixtures/MD-CA-2022.json
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T21:00:00.000Z",
     "end": "2022-04-25T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2023.json
+++ b/test/fixtures/MD-CA-2023.json
@@ -39,7 +39,7 @@
     "date": "2023-04-17 00:00:00",
     "start": "2023-04-16T21:00:00.000Z",
     "end": "2023-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2024.json
+++ b/test/fixtures/MD-CA-2024.json
@@ -48,7 +48,7 @@
     "date": "2024-05-06 00:00:00",
     "start": "2024-05-05T21:00:00.000Z",
     "end": "2024-05-06T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2025.json
+++ b/test/fixtures/MD-CA-2025.json
@@ -39,7 +39,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T21:00:00.000Z",
     "end": "2025-04-21T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2026.json
+++ b/test/fixtures/MD-CA-2026.json
@@ -39,7 +39,7 @@
     "date": "2026-04-13 00:00:00",
     "start": "2026-04-12T21:00:00.000Z",
     "end": "2026-04-13T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2027.json
+++ b/test/fixtures/MD-CA-2027.json
@@ -48,7 +48,7 @@
     "date": "2027-05-03 00:00:00",
     "start": "2027-05-02T21:00:00.000Z",
     "end": "2027-05-03T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2028.json
+++ b/test/fixtures/MD-CA-2028.json
@@ -39,7 +39,7 @@
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T21:00:00.000Z",
     "end": "2028-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CA-2029.json
+++ b/test/fixtures/MD-CA-2029.json
@@ -39,7 +39,7 @@
     "date": "2029-04-09 00:00:00",
     "start": "2029-04-08T21:00:00.000Z",
     "end": "2029-04-09T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2015.json
+++ b/test/fixtures/MD-CU-2015.json
@@ -39,7 +39,7 @@
     "date": "2015-04-13 00:00:00",
     "start": "2015-04-12T21:00:00.000Z",
     "end": "2015-04-13T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2016.json
+++ b/test/fixtures/MD-CU-2016.json
@@ -48,7 +48,7 @@
     "date": "2016-05-02 00:00:00",
     "start": "2016-05-01T21:00:00.000Z",
     "end": "2016-05-02T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2017.json
+++ b/test/fixtures/MD-CU-2017.json
@@ -39,7 +39,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T21:00:00.000Z",
     "end": "2017-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2018.json
+++ b/test/fixtures/MD-CU-2018.json
@@ -39,7 +39,7 @@
     "date": "2018-04-09 00:00:00",
     "start": "2018-04-08T21:00:00.000Z",
     "end": "2018-04-09T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2019.json
+++ b/test/fixtures/MD-CU-2019.json
@@ -39,7 +39,7 @@
     "date": "2019-04-29 00:00:00",
     "start": "2019-04-28T21:00:00.000Z",
     "end": "2019-04-29T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2020.json
+++ b/test/fixtures/MD-CU-2020.json
@@ -39,7 +39,7 @@
     "date": "2020-04-20 00:00:00",
     "start": "2020-04-19T21:00:00.000Z",
     "end": "2020-04-20T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2021.json
+++ b/test/fixtures/MD-CU-2021.json
@@ -48,7 +48,7 @@
     "date": "2021-05-03 00:00:00",
     "start": "2021-05-02T21:00:00.000Z",
     "end": "2021-05-03T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2022.json
+++ b/test/fixtures/MD-CU-2022.json
@@ -39,7 +39,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T21:00:00.000Z",
     "end": "2022-04-25T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2023.json
+++ b/test/fixtures/MD-CU-2023.json
@@ -39,7 +39,7 @@
     "date": "2023-04-17 00:00:00",
     "start": "2023-04-16T21:00:00.000Z",
     "end": "2023-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2024.json
+++ b/test/fixtures/MD-CU-2024.json
@@ -48,7 +48,7 @@
     "date": "2024-05-06 00:00:00",
     "start": "2024-05-05T21:00:00.000Z",
     "end": "2024-05-06T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2025.json
+++ b/test/fixtures/MD-CU-2025.json
@@ -39,7 +39,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T21:00:00.000Z",
     "end": "2025-04-21T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2026.json
+++ b/test/fixtures/MD-CU-2026.json
@@ -39,7 +39,7 @@
     "date": "2026-04-13 00:00:00",
     "start": "2026-04-12T21:00:00.000Z",
     "end": "2026-04-13T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2027.json
+++ b/test/fixtures/MD-CU-2027.json
@@ -48,7 +48,7 @@
     "date": "2027-05-03 00:00:00",
     "start": "2027-05-02T21:00:00.000Z",
     "end": "2027-05-03T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2028.json
+++ b/test/fixtures/MD-CU-2028.json
@@ -39,7 +39,7 @@
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T21:00:00.000Z",
     "end": "2028-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/MD-CU-2029.json
+++ b/test/fixtures/MD-CU-2029.json
@@ -39,7 +39,7 @@
     "date": "2029-04-09 00:00:00",
     "start": "2029-04-08T21:00:00.000Z",
     "end": "2029-04-09T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2015.json
+++ b/test/fixtures/RO-2015.json
@@ -21,7 +21,7 @@
     "date": "2015-01-07 00:00:00",
     "start": "2015-01-06T22:00:00.000Z",
     "end": "2015-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Wed"
@@ -66,7 +66,7 @@
     "date": "2015-04-13 00:00:00",
     "start": "2015-04-12T21:00:00.000Z",
     "end": "2015-04-13T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2016.json
+++ b/test/fixtures/RO-2016.json
@@ -21,7 +21,7 @@
     "date": "2016-01-07 00:00:00",
     "start": "2016-01-06T22:00:00.000Z",
     "end": "2016-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2016-05-02 00:00:00",
     "start": "2016-05-01T21:00:00.000Z",
     "end": "2016-05-02T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2017.json
+++ b/test/fixtures/RO-2017.json
@@ -21,7 +21,7 @@
     "date": "2017-01-07 00:00:00",
     "start": "2017-01-06T22:00:00.000Z",
     "end": "2017-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Sat"
@@ -66,7 +66,7 @@
     "date": "2017-04-17 00:00:00",
     "start": "2017-04-16T21:00:00.000Z",
     "end": "2017-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2018.json
+++ b/test/fixtures/RO-2018.json
@@ -21,7 +21,7 @@
     "date": "2018-01-07 00:00:00",
     "start": "2018-01-06T22:00:00.000Z",
     "end": "2018-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Sun"
@@ -66,7 +66,7 @@
     "date": "2018-04-09 00:00:00",
     "start": "2018-04-08T21:00:00.000Z",
     "end": "2018-04-09T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2019.json
+++ b/test/fixtures/RO-2019.json
@@ -21,7 +21,7 @@
     "date": "2019-01-07 00:00:00",
     "start": "2019-01-06T22:00:00.000Z",
     "end": "2019-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Mon"
@@ -66,7 +66,7 @@
     "date": "2019-04-29 00:00:00",
     "start": "2019-04-28T21:00:00.000Z",
     "end": "2019-04-29T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2020.json
+++ b/test/fixtures/RO-2020.json
@@ -21,7 +21,7 @@
     "date": "2020-01-07 00:00:00",
     "start": "2020-01-06T22:00:00.000Z",
     "end": "2020-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Tue"
@@ -66,7 +66,7 @@
     "date": "2020-04-20 00:00:00",
     "start": "2020-04-19T21:00:00.000Z",
     "end": "2020-04-20T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2021.json
+++ b/test/fixtures/RO-2021.json
@@ -21,7 +21,7 @@
     "date": "2021-01-07 00:00:00",
     "start": "2021-01-06T22:00:00.000Z",
     "end": "2021-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2021-05-03 00:00:00",
     "start": "2021-05-02T21:00:00.000Z",
     "end": "2021-05-03T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2022.json
+++ b/test/fixtures/RO-2022.json
@@ -21,7 +21,7 @@
     "date": "2022-01-07 00:00:00",
     "start": "2022-01-06T22:00:00.000Z",
     "end": "2022-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Fri"
@@ -66,7 +66,7 @@
     "date": "2022-04-25 00:00:00",
     "start": "2022-04-24T21:00:00.000Z",
     "end": "2022-04-25T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2023.json
+++ b/test/fixtures/RO-2023.json
@@ -21,7 +21,7 @@
     "date": "2023-01-07 00:00:00",
     "start": "2023-01-06T22:00:00.000Z",
     "end": "2023-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Sat"
@@ -66,7 +66,7 @@
     "date": "2023-04-17 00:00:00",
     "start": "2023-04-16T21:00:00.000Z",
     "end": "2023-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2024.json
+++ b/test/fixtures/RO-2024.json
@@ -21,7 +21,7 @@
     "date": "2024-01-07 00:00:00",
     "start": "2024-01-06T22:00:00.000Z",
     "end": "2024-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Sun"
@@ -75,7 +75,7 @@
     "date": "2024-05-06 00:00:00",
     "start": "2024-05-05T21:00:00.000Z",
     "end": "2024-05-06T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2025.json
+++ b/test/fixtures/RO-2025.json
@@ -21,7 +21,7 @@
     "date": "2025-01-07 00:00:00",
     "start": "2025-01-06T22:00:00.000Z",
     "end": "2025-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Tue"
@@ -66,7 +66,7 @@
     "date": "2025-04-21 00:00:00",
     "start": "2025-04-20T21:00:00.000Z",
     "end": "2025-04-21T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2026.json
+++ b/test/fixtures/RO-2026.json
@@ -21,7 +21,7 @@
     "date": "2026-01-07 00:00:00",
     "start": "2026-01-06T22:00:00.000Z",
     "end": "2026-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Wed"
@@ -66,7 +66,7 @@
     "date": "2026-04-13 00:00:00",
     "start": "2026-04-12T21:00:00.000Z",
     "end": "2026-04-13T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2027.json
+++ b/test/fixtures/RO-2027.json
@@ -21,7 +21,7 @@
     "date": "2027-01-07 00:00:00",
     "start": "2027-01-06T22:00:00.000Z",
     "end": "2027-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Thu"
@@ -75,7 +75,7 @@
     "date": "2027-05-03 00:00:00",
     "start": "2027-05-02T21:00:00.000Z",
     "end": "2027-05-03T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2028.json
+++ b/test/fixtures/RO-2028.json
@@ -21,7 +21,7 @@
     "date": "2028-01-07 00:00:00",
     "start": "2028-01-06T22:00:00.000Z",
     "end": "2028-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Fri"
@@ -66,7 +66,7 @@
     "date": "2028-04-17 00:00:00",
     "start": "2028-04-16T21:00:00.000Z",
     "end": "2028-04-17T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"

--- a/test/fixtures/RO-2029.json
+++ b/test/fixtures/RO-2029.json
@@ -21,7 +21,7 @@
     "date": "2029-01-07 00:00:00",
     "start": "2029-01-06T22:00:00.000Z",
     "end": "2029-01-07T22:00:00.000Z",
-    "name": "Sfântul Ion",
+    "name": "Sfântul Ioan Botezătorul",
     "type": "public",
     "rule": "01-07",
     "_weekday": "Sun"
@@ -66,7 +66,7 @@
     "date": "2029-04-09 00:00:00",
     "start": "2029-04-08T21:00:00.000Z",
     "end": "2029-04-09T21:00:00.000Z",
-    "name": "A doua zi de Pasti",
+    "name": "A doua zi de Paști",
     "type": "public",
     "rule": "orthodox 1",
     "_weekday": "Mon"


### PR DESCRIPTION
This PR improves two Romanian holiday labels:

- “Sfântul Ion” --> “Sfântul Ioan Botezătorul”
- “A doua zi de Pasti” --> “A doua zi de Paști”

The first change makes the feast name more precise (aligns with https://en.wikipedia.org/wiki/Public_holidays_in_Romania). The second adds the Romanian diacritic omitted in the currently referenced legal source. This is a localization improvement.