### PR TITLE
fix(DE): Make region augsburg have catholic holidays

### DIFF
--- a/data/countries/DE.yaml
+++ b/data/countries/DE.yaml
@@ -185,6 +185,15 @@ holidays:
         regions:
           A:
             name: Stadt Augsburg
+            # @source: https://www.stmi.bayern.de/staat-und-verfassung/feiertage/
+            # @source: https://www.statistik.bayern.de/statistik/gebiet_bevoelkerung/zensus/
+            # @source: https://www.br.de/nachrichten/bayern/mariae-himmelfahrt-wo-heuer-feiertag-ist-und-wo-nicht,VSGOlgV
+            _days:
+              - DEhttps://www.stmi.bayern.de/staat-und-verfassung/feiertage/
+              - states
+              - BY
+              - regions
+              - KATH
             days:
               08-08:
                 name:

--- a/data/countries/DE.yaml
+++ b/data/countries/DE.yaml
@@ -189,7 +189,7 @@ holidays:
             # @source: https://www.statistik.bayern.de/statistik/gebiet_bevoelkerung/zensus/
             # @source: https://www.br.de/nachrichten/bayern/mariae-himmelfahrt-wo-heuer-feiertag-ist-und-wo-nicht,VSGOlgV
             _days:
-              - DEhttps://www.stmi.bayern.de/staat-und-verfassung/feiertage/
+              - DE
               - states
               - BY
               - regions

--- a/test/fixtures/DE-BY-A-2015.json
+++ b/test/fixtures/DE-BY-A-2015.json
@@ -175,7 +175,7 @@
     "start": "2015-08-14T22:00:00.000Z",
     "end": "2015-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
   },

--- a/test/fixtures/DE-BY-A-2016.json
+++ b/test/fixtures/DE-BY-A-2016.json
@@ -175,7 +175,7 @@
     "start": "2016-08-14T22:00:00.000Z",
     "end": "2016-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
   },

--- a/test/fixtures/DE-BY-A-2017.json
+++ b/test/fixtures/DE-BY-A-2017.json
@@ -175,7 +175,7 @@
     "start": "2017-08-14T22:00:00.000Z",
     "end": "2017-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
   },

--- a/test/fixtures/DE-BY-A-2018.json
+++ b/test/fixtures/DE-BY-A-2018.json
@@ -175,7 +175,7 @@
     "start": "2018-08-14T22:00:00.000Z",
     "end": "2018-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
   },

--- a/test/fixtures/DE-BY-A-2019.json
+++ b/test/fixtures/DE-BY-A-2019.json
@@ -175,7 +175,7 @@
     "start": "2019-08-14T22:00:00.000Z",
     "end": "2019-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
   },

--- a/test/fixtures/DE-BY-A-2020.json
+++ b/test/fixtures/DE-BY-A-2020.json
@@ -175,7 +175,7 @@
     "start": "2020-08-14T22:00:00.000Z",
     "end": "2020-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
   },

--- a/test/fixtures/DE-BY-A-2021.json
+++ b/test/fixtures/DE-BY-A-2021.json
@@ -175,7 +175,7 @@
     "start": "2021-08-14T22:00:00.000Z",
     "end": "2021-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-BY-A-2022.json
+++ b/test/fixtures/DE-BY-A-2022.json
@@ -175,7 +175,7 @@
     "start": "2022-08-14T22:00:00.000Z",
     "end": "2022-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Mon"
   },

--- a/test/fixtures/DE-BY-A-2023.json
+++ b/test/fixtures/DE-BY-A-2023.json
@@ -175,7 +175,7 @@
     "start": "2023-08-14T22:00:00.000Z",
     "end": "2023-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
   },

--- a/test/fixtures/DE-BY-A-2024.json
+++ b/test/fixtures/DE-BY-A-2024.json
@@ -175,7 +175,7 @@
     "start": "2024-08-14T22:00:00.000Z",
     "end": "2024-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Thu"
   },

--- a/test/fixtures/DE-BY-A-2025.json
+++ b/test/fixtures/DE-BY-A-2025.json
@@ -175,7 +175,7 @@
     "start": "2025-08-14T22:00:00.000Z",
     "end": "2025-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Fri"
   },

--- a/test/fixtures/DE-BY-A-2026.json
+++ b/test/fixtures/DE-BY-A-2026.json
@@ -175,7 +175,7 @@
     "start": "2026-08-14T22:00:00.000Z",
     "end": "2026-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Sat"
   },

--- a/test/fixtures/DE-BY-A-2027.json
+++ b/test/fixtures/DE-BY-A-2027.json
@@ -175,7 +175,7 @@
     "start": "2027-08-14T22:00:00.000Z",
     "end": "2027-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Sun"
   },

--- a/test/fixtures/DE-BY-A-2028.json
+++ b/test/fixtures/DE-BY-A-2028.json
@@ -175,7 +175,7 @@
     "start": "2028-08-14T22:00:00.000Z",
     "end": "2028-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Tue"
   },

--- a/test/fixtures/DE-BY-A-2029.json
+++ b/test/fixtures/DE-BY-A-2029.json
@@ -175,7 +175,7 @@
     "start": "2029-08-14T22:00:00.000Z",
     "end": "2029-08-15T22:00:00.000Z",
     "name": "Mariä Himmelfahrt",
-    "type": "observance",
+    "type": "public",
     "rule": "08-15",
     "_weekday": "Wed"
   },


### PR DESCRIPTION
In Bavaria, there are 2 types of regions: KATH and EVANG. Additionally, there is Augsburg which has the Firedensfest as addional holiday on 08.08. However, Augsburg is also KATH and should have those holidays aswell.
This PR adds the KATH holidays to the region of Augsburg.

Below are some sources from the official state of bavaria as well as an easy to read newspaper article.

https://www.stmi.bayern.de/staat-und-verfassung/feiertage/
https://www.statistik.bayern.de/statistik/gebiet_bevoelkerung/zensus/
https://www.br.de/nachrichten/bayern/mariae-himmelfahrt-wo-heuer-feiertag-ist-und-wo-nicht,VSGOlgV