### PR TITLE
fix(IE): update holidays and source references

### DIFF
--- a/data/countries/IE.yaml
+++ b/data/countries/IE.yaml
@@ -1,10 +1,7 @@
 holidays:
-  # @source http://www.citizensinformation.ie/en/employment/employment_rights_and_conditions/leave_and_holidays/public_holidays_in_ireland.html
-  # @source https://www.bpfi.ie/wp-content/uploads/2017/10/Bank20Holidays202017-20.pdf
-  #
-  # Note that the "Bank of Ireland" is not the official national bank playes a
-  # somewhat similar role (https://en.wikipedia.org/wiki/Bank_of_Ireland#Role_as_government_banker).
-  # @source https://personalbanking.bankofireland.com/app/uploads/2018/11/OMI021897-CHRISTMAS-2018-CAMPAIGN-Opening-Hours-A1-Generic_v3.v2-compressed.pdf
+  # @source https://www.citizensinformation.ie/en/employment/employment-rights-and-conditions/leave-and-holidays/public-holidays/
+  # @source https://www.irishstatutebook.ie/eli/1997/act/20/enacted/en/html
+  # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_the_Republic_of_Ireland
   IE:
     names:
       en: Ireland
@@ -16,8 +13,9 @@ holidays:
     days:
       01-01:
         _name: 01-01
-      # Official Rule: First Monday in February, or 1 February if the date falls on a Friday
       02-01 if Tuesday,Wednesday,Thursday,Saturday,Sunday then next Monday since 2023:
+        # Official Rule: First Monday in February, or 1 February if the date falls on a Friday
+        # @source https://www.irishstatutebook.ie/eli/2023/act/8/enacted/en/html
         name:
           en: St. Brigid’s Day
       03-17:
@@ -36,11 +34,12 @@ holidays:
         type: bank
       easter:
         _name: easter
+        type: observance
       easter 1:
         _name: easter 1
       1st monday in May:
         name:
-          en: May Day
+          en: First Monday in May
       1st monday in June:
         name:
           en: First Monday in June
@@ -49,18 +48,18 @@ holidays:
           en: First Monday in August
       1st Monday before 11-01:
         name:
-          en: October Bank Holiday
+          en: Last Monday in October
           type: bank
       12-25:
         _name: 12-25
       12-26:
         _name: 12-26
         name:
-          en: St. Stephen's Day
+          en: St. Stephen’s Day
       12-26 and if saturday then next monday if sunday then next monday:
         _name: 12-26
         name:
-          en: St. Stephen's Day
+          en: St. Stephen’s Day
         substitute: true
         type: bank
       3rd sunday in June:

--- a/test/fixtures/IE-2015.json
+++ b/test/fixtures/IE-2015.json
@@ -40,7 +40,7 @@
     "start": "2015-04-04T23:00:00.000Z",
     "end": "2015-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -57,7 +57,7 @@
     "date": "2015-05-04 00:00:00",
     "start": "2015-05-03T23:00:00.000Z",
     "end": "2015-05-04T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2015-10-26 00:00:00",
     "start": "2015-10-26T00:00:00.000Z",
     "end": "2015-10-27T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2015-12-26 00:00:00",
     "start": "2015-12-26T00:00:00.000Z",
     "end": "2015-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2015-12-28 00:00:00",
     "start": "2015-12-28T00:00:00.000Z",
     "end": "2015-12-29T00:00:00.000Z",
-    "name": "St. Stephen's Day (substitute day)",
+    "name": "St. Stephen’s Day (substitute day)",
     "type": "bank",
     "substitute": true,
     "rule": "12-26 and if saturday then next monday if sunday then next monday",

--- a/test/fixtures/IE-2016.json
+++ b/test/fixtures/IE-2016.json
@@ -40,7 +40,7 @@
     "start": "2016-03-27T00:00:00.000Z",
     "end": "2016-03-27T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -57,7 +57,7 @@
     "date": "2016-05-02 00:00:00",
     "start": "2016-05-01T23:00:00.000Z",
     "end": "2016-05-02T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2016-10-31 00:00:00",
     "start": "2016-10-31T00:00:00.000Z",
     "end": "2016-11-01T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2016-12-26 00:00:00",
     "start": "2016-12-26T00:00:00.000Z",
     "end": "2016-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"

--- a/test/fixtures/IE-2017.json
+++ b/test/fixtures/IE-2017.json
@@ -40,7 +40,7 @@
     "start": "2017-04-15T23:00:00.000Z",
     "end": "2017-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -57,7 +57,7 @@
     "date": "2017-05-01 00:00:00",
     "start": "2017-04-30T23:00:00.000Z",
     "end": "2017-05-01T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2017-10-30 00:00:00",
     "start": "2017-10-30T00:00:00.000Z",
     "end": "2017-10-31T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2017-12-26 00:00:00",
     "start": "2017-12-26T00:00:00.000Z",
     "end": "2017-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/IE-2018.json
+++ b/test/fixtures/IE-2018.json
@@ -50,7 +50,7 @@
     "start": "2018-03-31T23:00:00.000Z",
     "end": "2018-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -67,7 +67,7 @@
     "date": "2018-05-07 00:00:00",
     "start": "2018-05-06T23:00:00.000Z",
     "end": "2018-05-07T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -103,7 +103,7 @@
     "date": "2018-10-29 00:00:00",
     "start": "2018-10-29T00:00:00.000Z",
     "end": "2018-10-30T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -121,7 +121,7 @@
     "date": "2018-12-26 00:00:00",
     "start": "2018-12-26T00:00:00.000Z",
     "end": "2018-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"

--- a/test/fixtures/IE-2019.json
+++ b/test/fixtures/IE-2019.json
@@ -50,7 +50,7 @@
     "start": "2019-04-20T23:00:00.000Z",
     "end": "2019-04-21T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -67,7 +67,7 @@
     "date": "2019-05-06 00:00:00",
     "start": "2019-05-05T23:00:00.000Z",
     "end": "2019-05-06T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -103,7 +103,7 @@
     "date": "2019-10-28 00:00:00",
     "start": "2019-10-28T00:00:00.000Z",
     "end": "2019-10-29T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -121,7 +121,7 @@
     "date": "2019-12-26 00:00:00",
     "start": "2019-12-26T00:00:00.000Z",
     "end": "2019-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"

--- a/test/fixtures/IE-2020.json
+++ b/test/fixtures/IE-2020.json
@@ -40,7 +40,7 @@
     "start": "2020-04-11T23:00:00.000Z",
     "end": "2020-04-12T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -57,7 +57,7 @@
     "date": "2020-05-04 00:00:00",
     "start": "2020-05-03T23:00:00.000Z",
     "end": "2020-05-04T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2020-10-26 00:00:00",
     "start": "2020-10-26T00:00:00.000Z",
     "end": "2020-10-27T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2020-12-26 00:00:00",
     "start": "2020-12-26T00:00:00.000Z",
     "end": "2020-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"
@@ -120,7 +120,7 @@
     "date": "2020-12-28 00:00:00",
     "start": "2020-12-28T00:00:00.000Z",
     "end": "2020-12-29T00:00:00.000Z",
-    "name": "St. Stephen's Day (substitute day)",
+    "name": "St. Stephen’s Day (substitute day)",
     "type": "bank",
     "substitute": true,
     "rule": "12-26 and if saturday then next monday if sunday then next monday",

--- a/test/fixtures/IE-2021.json
+++ b/test/fixtures/IE-2021.json
@@ -40,7 +40,7 @@
     "start": "2021-04-03T23:00:00.000Z",
     "end": "2021-04-04T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -57,7 +57,7 @@
     "date": "2021-05-03 00:00:00",
     "start": "2021-05-02T23:00:00.000Z",
     "end": "2021-05-03T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2021-10-25 00:00:00",
     "start": "2021-10-24T23:00:00.000Z",
     "end": "2021-10-25T23:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2021-12-26 00:00:00",
     "start": "2021-12-26T00:00:00.000Z",
     "end": "2021-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"
@@ -120,7 +120,7 @@
     "date": "2021-12-27 00:00:00",
     "start": "2021-12-27T00:00:00.000Z",
     "end": "2021-12-28T00:00:00.000Z",
-    "name": "St. Stephen's Day (substitute day)",
+    "name": "St. Stephen’s Day (substitute day)",
     "type": "bank",
     "substitute": true,
     "rule": "12-26 and if saturday then next monday if sunday then next monday",

--- a/test/fixtures/IE-2022.json
+++ b/test/fixtures/IE-2022.json
@@ -40,7 +40,7 @@
     "start": "2022-04-16T23:00:00.000Z",
     "end": "2022-04-17T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -57,7 +57,7 @@
     "date": "2022-05-02 00:00:00",
     "start": "2022-05-01T23:00:00.000Z",
     "end": "2022-05-02T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -93,7 +93,7 @@
     "date": "2022-10-31 00:00:00",
     "start": "2022-10-31T00:00:00.000Z",
     "end": "2022-11-01T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -111,7 +111,7 @@
     "date": "2022-12-26 00:00:00",
     "start": "2022-12-26T00:00:00.000Z",
     "end": "2022-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Mon"

--- a/test/fixtures/IE-2023.json
+++ b/test/fixtures/IE-2023.json
@@ -49,7 +49,7 @@
     "start": "2023-04-08T23:00:00.000Z",
     "end": "2023-04-09T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -66,7 +66,7 @@
     "date": "2023-05-01 00:00:00",
     "start": "2023-04-30T23:00:00.000Z",
     "end": "2023-05-01T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2023-10-30 00:00:00",
     "start": "2023-10-30T00:00:00.000Z",
     "end": "2023-10-31T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -120,7 +120,7 @@
     "date": "2023-12-26 00:00:00",
     "start": "2023-12-26T00:00:00.000Z",
     "end": "2023-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/IE-2024.json
+++ b/test/fixtures/IE-2024.json
@@ -59,7 +59,7 @@
     "start": "2024-03-31T00:00:00.000Z",
     "end": "2024-03-31T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -76,7 +76,7 @@
     "date": "2024-05-06 00:00:00",
     "start": "2024-05-05T23:00:00.000Z",
     "end": "2024-05-06T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2024-10-28 00:00:00",
     "start": "2024-10-28T00:00:00.000Z",
     "end": "2024-10-29T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -130,7 +130,7 @@
     "date": "2024-12-26 00:00:00",
     "start": "2024-12-26T00:00:00.000Z",
     "end": "2024-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Thu"

--- a/test/fixtures/IE-2025.json
+++ b/test/fixtures/IE-2025.json
@@ -49,7 +49,7 @@
     "start": "2025-04-19T23:00:00.000Z",
     "end": "2025-04-20T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -66,7 +66,7 @@
     "date": "2025-05-05 00:00:00",
     "start": "2025-05-04T23:00:00.000Z",
     "end": "2025-05-05T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2025-10-27 00:00:00",
     "start": "2025-10-27T00:00:00.000Z",
     "end": "2025-10-28T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -120,7 +120,7 @@
     "date": "2025-12-26 00:00:00",
     "start": "2025-12-26T00:00:00.000Z",
     "end": "2025-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Fri"

--- a/test/fixtures/IE-2026.json
+++ b/test/fixtures/IE-2026.json
@@ -49,7 +49,7 @@
     "start": "2026-04-04T23:00:00.000Z",
     "end": "2026-04-05T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -66,7 +66,7 @@
     "date": "2026-05-04 00:00:00",
     "start": "2026-05-03T23:00:00.000Z",
     "end": "2026-05-04T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2026-10-26 00:00:00",
     "start": "2026-10-26T00:00:00.000Z",
     "end": "2026-10-27T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -120,7 +120,7 @@
     "date": "2026-12-26 00:00:00",
     "start": "2026-12-26T00:00:00.000Z",
     "end": "2026-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sat"
@@ -129,7 +129,7 @@
     "date": "2026-12-28 00:00:00",
     "start": "2026-12-28T00:00:00.000Z",
     "end": "2026-12-29T00:00:00.000Z",
-    "name": "St. Stephen's Day (substitute day)",
+    "name": "St. Stephen’s Day (substitute day)",
     "type": "bank",
     "substitute": true,
     "rule": "12-26 and if saturday then next monday if sunday then next monday",

--- a/test/fixtures/IE-2027.json
+++ b/test/fixtures/IE-2027.json
@@ -49,7 +49,7 @@
     "start": "2027-03-28T00:00:00.000Z",
     "end": "2027-03-28T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -66,7 +66,7 @@
     "date": "2027-05-03 00:00:00",
     "start": "2027-05-02T23:00:00.000Z",
     "end": "2027-05-03T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2027-10-25 00:00:00",
     "start": "2027-10-24T23:00:00.000Z",
     "end": "2027-10-25T23:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -120,7 +120,7 @@
     "date": "2027-12-26 00:00:00",
     "start": "2027-12-26T00:00:00.000Z",
     "end": "2027-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Sun"
@@ -129,7 +129,7 @@
     "date": "2027-12-27 00:00:00",
     "start": "2027-12-27T00:00:00.000Z",
     "end": "2027-12-28T00:00:00.000Z",
-    "name": "St. Stephen's Day (substitute day)",
+    "name": "St. Stephen’s Day (substitute day)",
     "type": "bank",
     "substitute": true,
     "rule": "12-26 and if saturday then next monday if sunday then next monday",

--- a/test/fixtures/IE-2028.json
+++ b/test/fixtures/IE-2028.json
@@ -49,7 +49,7 @@
     "start": "2028-04-15T23:00:00.000Z",
     "end": "2028-04-16T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -66,7 +66,7 @@
     "date": "2028-05-01 00:00:00",
     "start": "2028-04-30T23:00:00.000Z",
     "end": "2028-05-01T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -102,7 +102,7 @@
     "date": "2028-10-30 00:00:00",
     "start": "2028-10-30T00:00:00.000Z",
     "end": "2028-10-31T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -120,7 +120,7 @@
     "date": "2028-12-26 00:00:00",
     "start": "2028-12-26T00:00:00.000Z",
     "end": "2028-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Tue"

--- a/test/fixtures/IE-2029.json
+++ b/test/fixtures/IE-2029.json
@@ -59,7 +59,7 @@
     "start": "2029-03-31T23:00:00.000Z",
     "end": "2029-04-01T23:00:00.000Z",
     "name": "Easter Sunday",
-    "type": "public",
+    "type": "observance",
     "rule": "easter",
     "_weekday": "Sun"
   },
@@ -76,7 +76,7 @@
     "date": "2029-05-07 00:00:00",
     "start": "2029-05-06T23:00:00.000Z",
     "end": "2029-05-07T23:00:00.000Z",
-    "name": "May Day",
+    "name": "First Monday in May",
     "type": "public",
     "rule": "1st monday in May",
     "_weekday": "Mon"
@@ -112,7 +112,7 @@
     "date": "2029-10-29 00:00:00",
     "start": "2029-10-29T00:00:00.000Z",
     "end": "2029-10-30T00:00:00.000Z",
-    "name": "October Bank Holiday",
+    "name": "Last Monday in October",
     "type": "public",
     "rule": "1st Monday before 11-01",
     "_weekday": "Mon"
@@ -130,7 +130,7 @@
     "date": "2029-12-26 00:00:00",
     "start": "2029-12-26T00:00:00.000Z",
     "end": "2029-12-27T00:00:00.000Z",
-    "name": "St. Stephen's Day",
+    "name": "St. Stephen’s Day",
     "type": "public",
     "rule": "12-26",
     "_weekday": "Wed"


### PR DESCRIPTION
- Remove unreachable source URLs
- Add official statutory sources
- Better document the 2023 St Brigid’s Day change
- Classify Easter Sunday as an observance
- Align holiday names and apostrophes