### PR TITLE
fix(AT): type Martinstag, Tag der Volksabstimmung and Rupert as observance

### DIFF
--- a/data/countries/AT.yaml
+++ b/data/countries/AT.yaml
@@ -68,6 +68,7 @@ holidays:
           11-11:
             name:
               de-at: Martinstag
+            type: observance
       "2":
         names:
           de: Kärnten
@@ -79,6 +80,7 @@ holidays:
           10-10:
             name:
               de-at: Tag der Volksabstimmung
+            type: observance
       "3":
         names:
           de: Niederösterreich
@@ -108,6 +110,7 @@ holidays:
           09-24:
             name:
               de-at: Rupert
+            type: observance
       "6":
         names:
           de: Steiermark

--- a/test/fixtures/AT-1-2015.json
+++ b/test/fixtures/AT-1-2015.json
@@ -139,7 +139,7 @@
     "start": "2015-11-10T23:00:00.000Z",
     "end": "2015-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-1-2016.json
+++ b/test/fixtures/AT-1-2016.json
@@ -139,7 +139,7 @@
     "start": "2016-11-10T23:00:00.000Z",
     "end": "2016-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-1-2017.json
+++ b/test/fixtures/AT-1-2017.json
@@ -139,7 +139,7 @@
     "start": "2017-11-10T23:00:00.000Z",
     "end": "2017-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-1-2018.json
+++ b/test/fixtures/AT-1-2018.json
@@ -139,7 +139,7 @@
     "start": "2018-11-10T23:00:00.000Z",
     "end": "2018-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-1-2019.json
+++ b/test/fixtures/AT-1-2019.json
@@ -130,7 +130,7 @@
     "start": "2019-11-10T23:00:00.000Z",
     "end": "2019-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-1-2020.json
+++ b/test/fixtures/AT-1-2020.json
@@ -130,7 +130,7 @@
     "start": "2020-11-10T23:00:00.000Z",
     "end": "2020-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-1-2021.json
+++ b/test/fixtures/AT-1-2021.json
@@ -130,7 +130,7 @@
     "start": "2021-11-10T23:00:00.000Z",
     "end": "2021-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-1-2022.json
+++ b/test/fixtures/AT-1-2022.json
@@ -130,7 +130,7 @@
     "start": "2022-11-10T23:00:00.000Z",
     "end": "2022-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-1-2023.json
+++ b/test/fixtures/AT-1-2023.json
@@ -130,7 +130,7 @@
     "start": "2023-11-10T23:00:00.000Z",
     "end": "2023-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-1-2024.json
+++ b/test/fixtures/AT-1-2024.json
@@ -130,7 +130,7 @@
     "start": "2024-11-10T23:00:00.000Z",
     "end": "2024-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-1-2025.json
+++ b/test/fixtures/AT-1-2025.json
@@ -130,7 +130,7 @@
     "start": "2025-11-10T23:00:00.000Z",
     "end": "2025-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-1-2026.json
+++ b/test/fixtures/AT-1-2026.json
@@ -130,7 +130,7 @@
     "start": "2026-11-10T23:00:00.000Z",
     "end": "2026-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-1-2027.json
+++ b/test/fixtures/AT-1-2027.json
@@ -130,7 +130,7 @@
     "start": "2027-11-10T23:00:00.000Z",
     "end": "2027-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-1-2028.json
+++ b/test/fixtures/AT-1-2028.json
@@ -130,7 +130,7 @@
     "start": "2028-11-10T23:00:00.000Z",
     "end": "2028-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-1-2029.json
+++ b/test/fixtures/AT-1-2029.json
@@ -130,7 +130,7 @@
     "start": "2029-11-10T23:00:00.000Z",
     "end": "2029-11-11T23:00:00.000Z",
     "name": "Martinstag",
-    "type": "public",
+    "type": "observance",
     "rule": "11-11",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-2-2015.json
+++ b/test/fixtures/AT-2-2015.json
@@ -130,7 +130,7 @@
     "start": "2015-10-09T22:00:00.000Z",
     "end": "2015-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-2-2016.json
+++ b/test/fixtures/AT-2-2016.json
@@ -130,7 +130,7 @@
     "start": "2016-10-09T22:00:00.000Z",
     "end": "2016-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-2-2017.json
+++ b/test/fixtures/AT-2-2017.json
@@ -130,7 +130,7 @@
     "start": "2017-10-09T22:00:00.000Z",
     "end": "2017-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-2-2018.json
+++ b/test/fixtures/AT-2-2018.json
@@ -130,7 +130,7 @@
     "start": "2018-10-09T22:00:00.000Z",
     "end": "2018-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-2-2019.json
+++ b/test/fixtures/AT-2-2019.json
@@ -121,7 +121,7 @@
     "start": "2019-10-09T22:00:00.000Z",
     "end": "2019-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-2-2020.json
+++ b/test/fixtures/AT-2-2020.json
@@ -121,7 +121,7 @@
     "start": "2020-10-09T22:00:00.000Z",
     "end": "2020-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-2-2021.json
+++ b/test/fixtures/AT-2-2021.json
@@ -121,7 +121,7 @@
     "start": "2021-10-09T22:00:00.000Z",
     "end": "2021-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-2-2022.json
+++ b/test/fixtures/AT-2-2022.json
@@ -121,7 +121,7 @@
     "start": "2022-10-09T22:00:00.000Z",
     "end": "2022-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-2-2023.json
+++ b/test/fixtures/AT-2-2023.json
@@ -121,7 +121,7 @@
     "start": "2023-10-09T22:00:00.000Z",
     "end": "2023-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-2-2024.json
+++ b/test/fixtures/AT-2-2024.json
@@ -121,7 +121,7 @@
     "start": "2024-10-09T22:00:00.000Z",
     "end": "2024-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-2-2025.json
+++ b/test/fixtures/AT-2-2025.json
@@ -121,7 +121,7 @@
     "start": "2025-10-09T22:00:00.000Z",
     "end": "2025-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-2-2026.json
+++ b/test/fixtures/AT-2-2026.json
@@ -121,7 +121,7 @@
     "start": "2026-10-09T22:00:00.000Z",
     "end": "2026-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-2-2027.json
+++ b/test/fixtures/AT-2-2027.json
@@ -121,7 +121,7 @@
     "start": "2027-10-09T22:00:00.000Z",
     "end": "2027-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-2-2028.json
+++ b/test/fixtures/AT-2-2028.json
@@ -121,7 +121,7 @@
     "start": "2028-10-09T22:00:00.000Z",
     "end": "2028-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-2-2029.json
+++ b/test/fixtures/AT-2-2029.json
@@ -121,7 +121,7 @@
     "start": "2029-10-09T22:00:00.000Z",
     "end": "2029-10-10T22:00:00.000Z",
     "name": "Tag der Volksabstimmung",
-    "type": "public",
+    "type": "observance",
     "rule": "10-10",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-5-2015.json
+++ b/test/fixtures/AT-5-2015.json
@@ -121,7 +121,7 @@
     "start": "2015-09-23T22:00:00.000Z",
     "end": "2015-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-5-2016.json
+++ b/test/fixtures/AT-5-2016.json
@@ -121,7 +121,7 @@
     "start": "2016-09-23T22:00:00.000Z",
     "end": "2016-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-5-2017.json
+++ b/test/fixtures/AT-5-2017.json
@@ -121,7 +121,7 @@
     "start": "2017-09-23T22:00:00.000Z",
     "end": "2017-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-5-2018.json
+++ b/test/fixtures/AT-5-2018.json
@@ -121,7 +121,7 @@
     "start": "2018-09-23T22:00:00.000Z",
     "end": "2018-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Mon"
   },

--- a/test/fixtures/AT-5-2019.json
+++ b/test/fixtures/AT-5-2019.json
@@ -112,7 +112,7 @@
     "start": "2019-09-23T22:00:00.000Z",
     "end": "2019-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-5-2020.json
+++ b/test/fixtures/AT-5-2020.json
@@ -112,7 +112,7 @@
     "start": "2020-09-23T22:00:00.000Z",
     "end": "2020-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-5-2021.json
+++ b/test/fixtures/AT-5-2021.json
@@ -112,7 +112,7 @@
     "start": "2021-09-23T22:00:00.000Z",
     "end": "2021-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-5-2022.json
+++ b/test/fixtures/AT-5-2022.json
@@ -112,7 +112,7 @@
     "start": "2022-09-23T22:00:00.000Z",
     "end": "2022-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Sat"
   },

--- a/test/fixtures/AT-5-2023.json
+++ b/test/fixtures/AT-5-2023.json
@@ -112,7 +112,7 @@
     "start": "2023-09-23T22:00:00.000Z",
     "end": "2023-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-5-2024.json
+++ b/test/fixtures/AT-5-2024.json
@@ -112,7 +112,7 @@
     "start": "2024-09-23T22:00:00.000Z",
     "end": "2024-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Tue"
   },

--- a/test/fixtures/AT-5-2025.json
+++ b/test/fixtures/AT-5-2025.json
@@ -112,7 +112,7 @@
     "start": "2025-09-23T22:00:00.000Z",
     "end": "2025-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Wed"
   },

--- a/test/fixtures/AT-5-2026.json
+++ b/test/fixtures/AT-5-2026.json
@@ -112,7 +112,7 @@
     "start": "2026-09-23T22:00:00.000Z",
     "end": "2026-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Thu"
   },

--- a/test/fixtures/AT-5-2027.json
+++ b/test/fixtures/AT-5-2027.json
@@ -112,7 +112,7 @@
     "start": "2027-09-23T22:00:00.000Z",
     "end": "2027-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Fri"
   },

--- a/test/fixtures/AT-5-2028.json
+++ b/test/fixtures/AT-5-2028.json
@@ -112,7 +112,7 @@
     "start": "2028-09-23T22:00:00.000Z",
     "end": "2028-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Sun"
   },

--- a/test/fixtures/AT-5-2029.json
+++ b/test/fixtures/AT-5-2029.json
@@ -112,7 +112,7 @@
     "start": "2029-09-23T22:00:00.000Z",
     "end": "2029-09-24T22:00:00.000Z",
     "name": "Rupert",
-    "type": "public",
+    "type": "observance",
     "rule": "09-24",
     "_weekday": "Mon"
   },


### PR DESCRIPTION
﻿## Summary
AT-1 (Martinstag), AT-2 (Tag der Volksabstimmung) and AT-5 (Rupert) were missing the type key in AT.yaml, so they defaulted to public and each state reported 14 public holidays instead of the 13 statutory ones under the Austrian Feiertagsgesetz. These days are Landesfeiertage with schools closed but ordinary working days, so they are now typed observance, mirroring Florian in Oberoesterreich (#606).

## Testing
Reproduced with Holidays for at-1, at-2 and at-5: all returned 14 public holidays including 11-11, 10-10 and 09-24. After the change all three return exactly the 13 statutory holidays. AT fixtures regenerated via mocha --writetests, no other country touched.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed
