### PR TITLE
fix(AL): correct Albanian holiday substitutes

### DIFF
--- a/data/countries/AL.yaml
+++ b/data/countries/AL.yaml
@@ -1,4 +1,5 @@
 holidays:
+  # @source https://www.bankofalbania.org/Shtypi/Kalendari_i_festave_zyrtare_2026/
   # @attrib https://en.wikipedia.org/wiki/Public_holidays_in_Albania
   AL:
     names:
@@ -11,10 +12,10 @@ holidays:
     zones:
       - Europe/Tirane
     days:
-      01-01 and if sunday then next tuesday:
+      01-01 and if saturday then next monday if sunday then next tuesday:
         _name: 01-01
         substitute: true
-      01-02 and if sunday then next monday:
+      01-02 and if saturday then next monday if sunday then next tuesday:
         name:
           sq: Festa e Vitit të Ri
           en: New Year Holiday
@@ -32,12 +33,12 @@ holidays:
       03-08:
         _name: Mothers Day
         type: observance
-      03-14 and if sunday then next monday:
+      03-14 and if saturday,sunday then next monday:
         name:
           sq: Dita e Verës
           en: Summer Day
         substitute: true
-      03-22 and if sunday then next monday:
+      03-22 and if saturday,sunday then next monday:
         name:
           sq: Dita e Sulltan Nevruzit
           en: Sultan Nevruz's Day
@@ -61,7 +62,7 @@ holidays:
         name:
           sq: Pashkët Ortodokse
           en: Orthodox Easter
-      05-01 and if sunday then next monday:
+      05-01 and if saturday,sunday then next monday:
         _name: 05-01
         substitute: true
       06-01:
@@ -69,7 +70,7 @@ holidays:
           sq: Dita Ndërkombëtare e Fëmijëve
           en: Children's Day
         type: observance
-      10-19 and if sunday then next monday:
+      10-19 and if saturday,sunday then next monday:
         name:
           sq: Dita e Nënë Terezës
           en: Mother Teresa Day
@@ -81,13 +82,13 @@ holidays:
           sq: Dita e Alfabetit
           en: Alphabet Day
         type: observance
-      11-28 and if sunday then next monday:
+      11-28 and if saturday,sunday then next monday:
         _name: Independence Day
         substitute: true
-      11-29 and if sunday then next monday:
+      11-29 and if saturday,sunday then next monday:
         _name: Liberation Day
         substitute: true
-      12-08 and if sunday then next monday:
+      12-08 and if saturday,sunday then next monday:
         name:
           sq: Dita Kombëtare e Rinisë
           en: Youth Day
@@ -97,7 +98,7 @@ holidays:
       12-24:
         _name: 12-24
         type: bank
-      12-25 and if sunday then next monday:
+      12-25 and if saturday,sunday then next monday:
         _name: 12-25
         substitute: true
       1 Shawwal:

--- a/test/fixtures/AL-2015.json
+++ b/test/fixtures/AL-2015.json
@@ -5,7 +5,7 @@
     "end": "2015-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Thu"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2015-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Fri"
   },
   {
@@ -50,8 +50,18 @@
     "end": "2015-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2015-03-16 00:00:00",
+    "start": "2015-03-15T23:00:00.000Z",
+    "end": "2015-03-16T23:00:00.000Z",
+    "name": "Dita e Verës (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "03-14 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2015-03-22 00:00:00",
@@ -59,7 +69,7 @@
     "end": "2015-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -69,7 +79,7 @@
     "name": "Dita e Sulltan Nevruzit (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -123,7 +133,7 @@
     "end": "2015-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -159,7 +169,7 @@
     "end": "2015-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -177,7 +187,7 @@
     "end": "2015-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Sat"
   },
   {
@@ -186,7 +196,7 @@
     "end": "2015-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -196,7 +206,17 @@
     "name": "Dita e Çlirimit (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2015-11-30 00:00:00",
+    "start": "2015-11-29T23:00:00.000Z",
+    "end": "2015-11-30T23:00:00.000Z",
+    "name": "Dita e Pavarësisë (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -205,7 +225,7 @@
     "end": "2015-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -223,7 +243,7 @@
     "end": "2015-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/AL-2016.json
+++ b/test/fixtures/AL-2016.json
@@ -5,7 +5,7 @@
     "end": "2016-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Fri"
   },
   {
@@ -14,8 +14,18 @@
     "end": "2016-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2016-01-04 00:00:00",
+    "start": "2016-01-03T23:00:00.000Z",
+    "end": "2016-01-04T23:00:00.000Z",
+    "name": "Festa e Vitit të Ri (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Mon"
   },
   {
     "date": "2016-03-02 00:00:00",
@@ -50,7 +60,7 @@
     "end": "2016-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -59,7 +69,7 @@
     "end": "2016-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -95,7 +105,7 @@
     "end": "2016-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -114,7 +124,7 @@
     "name": "Dita Ndërkombëtare e Punonjësve (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -159,7 +169,7 @@
     "end": "2016-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -177,7 +187,7 @@
     "end": "2016-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -186,7 +196,7 @@
     "end": "2016-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -195,7 +205,7 @@
     "end": "2016-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -213,7 +223,7 @@
     "end": "2016-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -223,7 +233,7 @@
     "name": "Krishtlindja (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/AL-2017.json
+++ b/test/fixtures/AL-2017.json
@@ -5,7 +5,7 @@
     "end": "2017-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Sun"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2017-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Mon"
   },
   {
@@ -24,7 +24,7 @@
     "name": "Viti i Ri (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {
@@ -60,7 +60,7 @@
     "end": "2017-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -69,7 +69,7 @@
     "end": "2017-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -123,7 +123,7 @@
     "end": "2017-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -159,7 +159,7 @@
     "end": "2017-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -177,7 +177,7 @@
     "end": "2017-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -186,7 +186,7 @@
     "end": "2017-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -195,7 +195,7 @@
     "end": "2017-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -213,7 +213,7 @@
     "end": "2017-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/AL-2018.json
+++ b/test/fixtures/AL-2018.json
@@ -5,7 +5,7 @@
     "end": "2018-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Mon"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2018-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {
@@ -50,7 +50,7 @@
     "end": "2018-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2018-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2018-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -149,7 +149,7 @@
     "end": "2018-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -167,7 +167,7 @@
     "end": "2018-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -176,7 +176,7 @@
     "end": "2018-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -185,8 +185,18 @@
     "end": "2018-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2018-12-10 00:00:00",
+    "start": "2018-12-09T23:00:00.000Z",
+    "end": "2018-12-10T23:00:00.000Z",
+    "name": "Dita Kombëtare e Rinisë (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "12-08 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2018-12-24 00:00:00",
@@ -203,7 +213,7 @@
     "end": "2018-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   }
 ]

--- a/test/fixtures/AL-2019.json
+++ b/test/fixtures/AL-2019.json
@@ -5,7 +5,7 @@
     "end": "2019-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2019-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Wed"
   },
   {
@@ -50,7 +50,7 @@
     "end": "2019-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2019-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -113,7 +113,7 @@
     "end": "2019-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -149,8 +149,18 @@
     "end": "2019-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2019-10-21 00:00:00",
+    "start": "2019-10-20T22:00:00.000Z",
+    "end": "2019-10-21T22:00:00.000Z",
+    "name": "Dita e Nënë Terezës (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "10-19 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2019-11-22 00:00:00",
@@ -167,7 +177,7 @@
     "end": "2019-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -176,7 +186,7 @@
     "end": "2019-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -185,7 +195,7 @@
     "end": "2019-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -195,7 +205,7 @@
     "name": "Dita Kombëtare e Rinisë (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -213,7 +223,7 @@
     "end": "2019-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/AL-2020.json
+++ b/test/fixtures/AL-2020.json
@@ -5,7 +5,7 @@
     "end": "2020-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Wed"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2020-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Thu"
   },
   {
@@ -50,8 +50,18 @@
     "end": "2020-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2020-03-16 00:00:00",
+    "start": "2020-03-15T23:00:00.000Z",
+    "end": "2020-03-16T23:00:00.000Z",
+    "name": "Dita e Verës (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "03-14 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2020-03-22 00:00:00",
@@ -59,7 +69,7 @@
     "end": "2020-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -69,7 +79,7 @@
     "name": "Dita e Sulltan Nevruzit (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -123,7 +133,7 @@
     "end": "2020-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -159,7 +169,7 @@
     "end": "2020-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -177,7 +187,7 @@
     "end": "2020-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Sat"
   },
   {
@@ -186,7 +196,7 @@
     "end": "2020-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -196,7 +206,17 @@
     "name": "Dita e Çlirimit (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2020-11-30 00:00:00",
+    "start": "2020-11-29T23:00:00.000Z",
+    "end": "2020-11-30T23:00:00.000Z",
+    "name": "Dita e Pavarësisë (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -205,7 +225,7 @@
     "end": "2020-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -223,7 +243,7 @@
     "end": "2020-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/AL-2021.json
+++ b/test/fixtures/AL-2021.json
@@ -5,7 +5,7 @@
     "end": "2021-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Fri"
   },
   {
@@ -14,8 +14,18 @@
     "end": "2021-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2021-01-04 00:00:00",
+    "start": "2021-01-03T23:00:00.000Z",
+    "end": "2021-01-04T23:00:00.000Z",
+    "name": "Festa e Vitit të Ri (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Mon"
   },
   {
     "date": "2021-03-02 00:00:00",
@@ -50,7 +60,7 @@
     "end": "2021-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -60,7 +70,7 @@
     "name": "Dita e Verës (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -69,7 +79,7 @@
     "end": "2021-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -105,7 +115,7 @@
     "end": "2021-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Sat"
   },
   {
@@ -116,6 +126,16 @@
     "type": "public",
     "rule": "orthodox",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2021-05-03 00:00:00",
+    "start": "2021-05-02T22:00:00.000Z",
+    "end": "2021-05-03T22:00:00.000Z",
+    "name": "Dita Ndërkombëtare e Punonjësve (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "05-01 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2021-05-03 00:00:00",
@@ -159,7 +179,7 @@
     "end": "2021-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -177,7 +197,7 @@
     "end": "2021-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -186,7 +206,7 @@
     "end": "2021-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -196,7 +216,7 @@
     "name": "Dita e Pavarësisë (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -205,7 +225,7 @@
     "end": "2021-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -223,7 +243,17 @@
     "end": "2021-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2021-12-27 00:00:00",
+    "start": "2021-12-26T23:00:00.000Z",
+    "end": "2021-12-27T23:00:00.000Z",
+    "name": "Krishtlindja (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "12-25 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/AL-2022.json
+++ b/test/fixtures/AL-2022.json
@@ -5,7 +5,7 @@
     "end": "2022-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Sat"
   },
   {
@@ -14,18 +14,28 @@
     "end": "2022-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Sun"
   },
   {
     "date": "2022-01-03 00:00:00",
     "start": "2022-01-02T23:00:00.000Z",
     "end": "2022-01-03T23:00:00.000Z",
+    "name": "Viti i Ri (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2022-01-04 00:00:00",
+    "start": "2022-01-03T23:00:00.000Z",
+    "end": "2022-01-04T23:00:00.000Z",
     "name": "Festa e Vitit të Ri (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "01-02 and if sunday then next monday",
-    "_weekday": "Mon"
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Tue"
   },
   {
     "date": "2022-03-02 00:00:00",
@@ -60,7 +70,7 @@
     "end": "2022-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -69,7 +79,7 @@
     "end": "2022-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -123,7 +133,7 @@
     "end": "2022-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -142,7 +152,7 @@
     "name": "Dita Ndërkombëtare e Punonjësve (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -169,7 +179,7 @@
     "end": "2022-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -187,7 +197,7 @@
     "end": "2022-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -196,7 +206,7 @@
     "end": "2022-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -205,7 +215,7 @@
     "end": "2022-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -223,7 +233,7 @@
     "end": "2022-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -233,7 +243,7 @@
     "name": "Krishtlindja (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/AL-2023.json
+++ b/test/fixtures/AL-2023.json
@@ -5,7 +5,7 @@
     "end": "2023-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Sun"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2023-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Mon"
   },
   {
@@ -24,7 +24,7 @@
     "name": "Viti i Ri (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {
@@ -60,7 +60,7 @@
     "end": "2023-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -69,7 +69,7 @@
     "end": "2023-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -132,7 +132,7 @@
     "end": "2023-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -159,7 +159,7 @@
     "end": "2023-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -177,7 +177,7 @@
     "end": "2023-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -186,7 +186,7 @@
     "end": "2023-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -195,7 +195,7 @@
     "end": "2023-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -213,7 +213,7 @@
     "end": "2023-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/AL-2024.json
+++ b/test/fixtures/AL-2024.json
@@ -5,7 +5,7 @@
     "end": "2024-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Mon"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2024-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {
@@ -50,7 +50,7 @@
     "end": "2024-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2024-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -104,7 +104,7 @@
     "end": "2024-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -149,8 +149,18 @@
     "end": "2024-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2024-10-21 00:00:00",
+    "start": "2024-10-20T22:00:00.000Z",
+    "end": "2024-10-21T22:00:00.000Z",
+    "name": "Dita e Nënë Terezës (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "10-19 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2024-11-22 00:00:00",
@@ -167,7 +177,7 @@
     "end": "2024-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -176,7 +186,7 @@
     "end": "2024-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -185,7 +195,7 @@
     "end": "2024-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -195,7 +205,7 @@
     "name": "Dita Kombëtare e Rinisë (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -213,7 +223,7 @@
     "end": "2024-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   }
 ]

--- a/test/fixtures/AL-2025.json
+++ b/test/fixtures/AL-2025.json
@@ -5,7 +5,7 @@
     "end": "2025-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Wed"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2025-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Thu"
   },
   {
@@ -50,7 +50,7 @@
     "end": "2025-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -59,8 +59,18 @@
     "end": "2025-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2025-03-24 00:00:00",
+    "start": "2025-03-23T23:00:00.000Z",
+    "end": "2025-03-24T23:00:00.000Z",
+    "name": "Dita e Sulltan Nevruzit (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "03-22 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2025-03-30 00:00:00 -0600",
@@ -122,7 +132,7 @@
     "end": "2025-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -149,7 +159,7 @@
     "end": "2025-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -159,7 +169,7 @@
     "name": "Dita e Nënë Terezës (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -177,7 +187,7 @@
     "end": "2025-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -186,8 +196,18 @@
     "end": "2025-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2025-12-01 00:00:00",
+    "start": "2025-11-30T23:00:00.000Z",
+    "end": "2025-12-01T23:00:00.000Z",
+    "name": "Dita e Çlirimit (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "11-29 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2025-12-08 00:00:00",
@@ -195,7 +215,7 @@
     "end": "2025-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -213,7 +233,7 @@
     "end": "2025-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   }
 ]

--- a/test/fixtures/AL-2026.json
+++ b/test/fixtures/AL-2026.json
@@ -5,7 +5,7 @@
     "end": "2026-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Thu"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2026-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Fri"
   },
   {
@@ -50,8 +50,18 @@
     "end": "2026-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2026-03-16 00:00:00",
+    "start": "2026-03-15T23:00:00.000Z",
+    "end": "2026-03-16T23:00:00.000Z",
+    "name": "Dita e Verës (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "03-14 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2026-03-20 00:00:00 -0600",
@@ -68,7 +78,7 @@
     "end": "2026-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -78,7 +88,7 @@
     "name": "Dita e Sulltan Nevruzit (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -132,7 +142,7 @@
     "end": "2026-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -159,7 +169,7 @@
     "end": "2026-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -177,7 +187,7 @@
     "end": "2026-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Sat"
   },
   {
@@ -186,7 +196,7 @@
     "end": "2026-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -196,7 +206,17 @@
     "name": "Dita e Çlirimit (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2026-11-30 00:00:00",
+    "start": "2026-11-29T23:00:00.000Z",
+    "end": "2026-11-30T23:00:00.000Z",
+    "name": "Dita e Pavarësisë (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -205,7 +225,7 @@
     "end": "2026-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -223,7 +243,7 @@
     "end": "2026-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   }
 ]

--- a/test/fixtures/AL-2027.json
+++ b/test/fixtures/AL-2027.json
@@ -5,7 +5,7 @@
     "end": "2027-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Fri"
   },
   {
@@ -14,8 +14,18 @@
     "end": "2027-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2027-01-04 00:00:00",
+    "start": "2027-01-03T23:00:00.000Z",
+    "end": "2027-01-04T23:00:00.000Z",
+    "name": "Festa e Vitit të Ri (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Mon"
   },
   {
     "date": "2027-03-02 00:00:00",
@@ -59,7 +69,7 @@
     "end": "2027-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -69,7 +79,7 @@
     "name": "Dita e Verës (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -78,7 +88,7 @@
     "end": "2027-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -114,7 +124,7 @@
     "end": "2027-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Sat"
   },
   {
@@ -125,6 +135,16 @@
     "type": "public",
     "rule": "orthodox",
     "_weekday": "Sun"
+  },
+  {
+    "date": "2027-05-03 00:00:00",
+    "start": "2027-05-02T22:00:00.000Z",
+    "end": "2027-05-03T22:00:00.000Z",
+    "name": "Dita Ndërkombëtare e Punonjësve (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "05-01 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2027-05-03 00:00:00",
@@ -159,7 +179,7 @@
     "end": "2027-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -177,7 +197,7 @@
     "end": "2027-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Sun"
   },
   {
@@ -186,7 +206,7 @@
     "end": "2027-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -196,7 +216,7 @@
     "name": "Dita e Pavarësisë (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -205,7 +225,7 @@
     "end": "2027-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -223,7 +243,17 @@
     "end": "2027-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2027-12-27 00:00:00",
+    "start": "2027-12-26T23:00:00.000Z",
+    "end": "2027-12-27T23:00:00.000Z",
+    "name": "Krishtlindja (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "12-25 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/AL-2028.json
+++ b/test/fixtures/AL-2028.json
@@ -5,7 +5,7 @@
     "end": "2028-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Sat"
   },
   {
@@ -14,18 +14,28 @@
     "end": "2028-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Sun"
   },
   {
     "date": "2028-01-03 00:00:00",
     "start": "2028-01-02T23:00:00.000Z",
     "end": "2028-01-03T23:00:00.000Z",
+    "name": "Viti i Ri (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Mon"
+  },
+  {
+    "date": "2028-01-04 00:00:00",
+    "start": "2028-01-03T23:00:00.000Z",
+    "end": "2028-01-04T23:00:00.000Z",
     "name": "Festa e Vitit të Ri (ditë zëvendësuese)",
     "type": "public",
     "substitute": true,
-    "rule": "01-02 and if sunday then next monday",
-    "_weekday": "Mon"
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
+    "_weekday": "Tue"
   },
   {
     "date": "2028-02-26 00:00:00 -0600",
@@ -69,7 +79,7 @@
     "end": "2028-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -78,7 +88,7 @@
     "end": "2028-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -132,7 +142,7 @@
     "end": "2028-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   },
   {
@@ -159,7 +169,7 @@
     "end": "2028-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -177,7 +187,7 @@
     "end": "2028-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -186,7 +196,7 @@
     "end": "2028-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -195,7 +205,7 @@
     "end": "2028-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -213,7 +223,7 @@
     "end": "2028-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Mon"
   }
 ]

--- a/test/fixtures/AL-2029.json
+++ b/test/fixtures/AL-2029.json
@@ -5,7 +5,7 @@
     "end": "2029-01-01T23:00:00.000Z",
     "name": "Viti i Ri",
     "type": "public",
-    "rule": "01-01 and if sunday then next tuesday",
+    "rule": "01-01 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Mon"
   },
   {
@@ -14,7 +14,7 @@
     "end": "2029-01-02T23:00:00.000Z",
     "name": "Festa e Vitit të Ri",
     "type": "public",
-    "rule": "01-02 and if sunday then next monday",
+    "rule": "01-02 and if saturday then next monday if sunday then next tuesday",
     "_weekday": "Tue"
   },
   {
@@ -59,7 +59,7 @@
     "end": "2029-03-14T23:00:00.000Z",
     "name": "Dita e Verës",
     "type": "public",
-    "rule": "03-14 and if sunday then next monday",
+    "rule": "03-14 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -68,7 +68,7 @@
     "end": "2029-03-22T23:00:00.000Z",
     "name": "Dita e Sulltan Nevruzit",
     "type": "public",
-    "rule": "03-22 and if sunday then next monday",
+    "rule": "03-22 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -131,7 +131,7 @@
     "end": "2029-05-01T22:00:00.000Z",
     "name": "Dita Ndërkombëtare e Punonjësve",
     "type": "public",
-    "rule": "05-01 and if sunday then next monday",
+    "rule": "05-01 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   },
   {
@@ -149,7 +149,7 @@
     "end": "2029-10-19T22:00:00.000Z",
     "name": "Dita e Nënë Terezës",
     "type": "public",
-    "rule": "10-19 and if sunday then next monday",
+    "rule": "10-19 and if saturday,sunday then next monday",
     "_weekday": "Fri"
   },
   {
@@ -167,7 +167,7 @@
     "end": "2029-11-28T23:00:00.000Z",
     "name": "Dita e Pavarësisë",
     "type": "public",
-    "rule": "11-28 and if sunday then next monday",
+    "rule": "11-28 and if saturday,sunday then next monday",
     "_weekday": "Wed"
   },
   {
@@ -176,7 +176,7 @@
     "end": "2029-11-29T23:00:00.000Z",
     "name": "Dita e Çlirimit",
     "type": "public",
-    "rule": "11-29 and if sunday then next monday",
+    "rule": "11-29 and if saturday,sunday then next monday",
     "_weekday": "Thu"
   },
   {
@@ -185,8 +185,18 @@
     "end": "2029-12-08T23:00:00.000Z",
     "name": "Dita Kombëtare e Rinisë",
     "type": "public",
-    "rule": "12-08 and if sunday then next monday",
+    "rule": "12-08 and if saturday,sunday then next monday",
     "_weekday": "Sat"
+  },
+  {
+    "date": "2029-12-10 00:00:00",
+    "start": "2029-12-09T23:00:00.000Z",
+    "end": "2029-12-10T23:00:00.000Z",
+    "name": "Dita Kombëtare e Rinisë (ditë zëvendësuese)",
+    "type": "public",
+    "substitute": true,
+    "rule": "12-08 and if saturday,sunday then next monday",
+    "_weekday": "Mon"
   },
   {
     "date": "2029-12-24 00:00:00",
@@ -203,7 +213,7 @@
     "end": "2029-12-25T23:00:00.000Z",
     "name": "Krishtlindja",
     "type": "public",
-    "rule": "12-25 and if sunday then next monday",
+    "rule": "12-25 and if saturday,sunday then next monday",
     "_weekday": "Tue"
   }
 ]


### PR DESCRIPTION
With this Albania’s holiday rules now also account for substitute days when a public holiday falls on a Saturday or Sunday. The official [Bank of Albania source](https://www.bankofalbania.org/Shtypi/Kalendari_i_festave_zyrtare_2026/) explicitly defines these postponement rules.