### PR TITLE
fix(BE): add English names for all Belgian holidays

### DIFF
--- a/data/countries/BE.yaml
+++ b/data/countries/BE.yaml
@@ -119,8 +119,8 @@ holidays:
         days:
           07-11:
             name:
-              de: Festtag der Wallonischen Region
-              fr: Fête de la Région wallonne
+              de: Feiertag der Flämischen Gemeinschaft
+              fr: Fête de la Communauté flamande
               nl: Feestdag van de Vlaamse Gemeenschap
               en: Day of the Flemish Community
             type: observance

--- a/data/countries/BE.yaml
+++ b/data/countries/BE.yaml
@@ -35,6 +35,7 @@ holidays:
           fr: Lundi de Pâques
           nl: Paasmaandag
           de: Ostermontag
+          en: Easter Monday
       05-01:
         _name: 05-01
       2nd sunday in May:
@@ -45,6 +46,7 @@ holidays:
           nl: Hemelvaartsdag
           fr: Ascension
           de: Christi Himmelfahrt
+          en: Ascension Day
       easter 49:
         _name: easter 49
         type: observance
@@ -53,6 +55,7 @@ holidays:
           fr: Lundi de Pentecôte
           nl: Pinkstermaandag
           de: Pfingstmontag
+          en: Whit Monday
       07-21:
         _name: National Holiday
       08-15:
@@ -60,6 +63,7 @@ holidays:
           fr: Assomption
           nl: Tenhemelopneming
           de: Mariä Himmelfahrt
+          en: Assumption Day
       11-01:
         _name: 11-01
       11-02:
@@ -70,11 +74,13 @@ holidays:
           de: Waffenstillstand
           fr: Armistice
           nl: Wapenstilstand
+          en: Armistice Day
       11-15:
         name:
           nl: Koningsdag
           fr: Fête du Roi
           de: Festtag des Königs
+          en: King's Feast
         type: observance
       12-06:
         _name: 12-06
@@ -92,6 +98,7 @@ holidays:
             name:
               nl: Feest van de Iris
               fr: Fête de l'Iris
+              en: Iris Festival
             type: observance
       DE:
         name: Deutschsprachige Gemeinschaft
@@ -103,6 +110,7 @@ holidays:
               de: Tag der Deutschsprachigen Gemeinschaft
               fr: Jour de la Communauté Germanophone
               nl: Feestdag van de Duitstalige Gemeenschap
+              en: Day of the German-speaking Community
             type: observance
       VLG:
         name: Vlaamse Gemeenschap
@@ -114,6 +122,7 @@ holidays:
               de: Festtag der Wallonischen Region
               fr: Fête de la Région wallonne
               nl: Feestdag van de Vlaamse Gemeenschap
+              en: Day of the Flemish Community
             type: observance
           11-02:
             _name: 11-02
@@ -124,6 +133,7 @@ holidays:
               nl: Koningsdag
               fr: Fête du Roi
               de: Festtag des Königs
+              en: King's Feast
             type: observance
             note: day-off for employees of the flemish government
           12-26:
@@ -151,6 +161,7 @@ holidays:
               de: Tag der Französischsprachigen Gemeinschaft
               fr: La fête de la communauté française
               nl: Feestdag van de Franse Gemeenschap
+              en: French Community Holiday
             type: observance
         # regions:
         # WBR:


### PR DESCRIPTION
Belgium declares `langs: [fr, nl, de]` and several holidays only have local French, Dutch and German names. Asking for `languages: 'en'` gives a mixed list: shared names from `names.yaml` come back in English, the local ones fall back to French or Dutch.

This adds an `en` name to every Belgian holiday that lacked one, following https://en.wikipedia.org/wiki/Public_holidays_in_Belgium (already cited in the file):

| Rule | Region | en |
|---|---|---|
| `easter 1` | BE | Easter Monday |
| `easter 39` | BE | Ascension Day |
| `easter 50` | BE | Whit Monday |
| `08-15` | BE | Assumption Day |
| `11-11` | BE | Armistice Day |
| `11-15` | BE, VLG | King's Feast |
| `05-08` | BRU | Iris Festival |
| `11-15` | DE | Day of the German-speaking Community |
| `07-11` | VLG | Day of the Flemish Community |
| `09-27` | WAL | French Community Holiday |

Second commit, separable: the Flemish Community day (`VLG`, `07-11`) carried the French and German names of the Day of the Walloon Region. Corrected to *Fête de la Communauté flamande* / *Feiertag der Flämischen Gemeinschaft* per the same source.

## How to check

1. `npm run yaml`
2. `node test/sample.js be 2026 --lang en --short`, then the same for `be.bru`, `be.de`, `be.vlg` and `be.wal`. Every name comes back in English.
3. `npx mocha` passes (5634 tests). Default-language output is unchanged, so no fixtures changed.